### PR TITLE
Add refresh button to Editor

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -31,7 +31,7 @@ export class Editor extends React.Component<EditorProps, any> {
             }
             { this.props.bookData.refreshLink &&
               <ButtonForm
-                label={"Refresh"}
+                label={"Refresh Metadata"}
                 link={this.props.bookData.refreshLink.href}
                 csrfToken={this.props.csrfToken}
                 refresh={refresh} />

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -29,6 +29,13 @@ export class Editor extends React.Component<EditorProps, any> {
                 csrfToken={this.props.csrfToken}
                 refresh={refresh} />
             }
+            { this.props.bookData.refreshLink &&
+              <ButtonForm
+                label={"Refresh"}
+                link={this.props.bookData.refreshLink.href}
+                csrfToken={this.props.csrfToken}
+                refresh={refresh} />
+            }
           </div>)
         }
       </div>

--- a/src/components/__tests__/Editor-test.tsx
+++ b/src/components/__tests__/Editor-test.tsx
@@ -69,6 +69,6 @@ describe("Editor", () => {
 
     let buttonForm = TestUtils.findRenderedComponentWithType(editor, ButtonForm);
     expect(buttonForm.props.link).toEqual("href");
-    expect(buttonForm.props.label).toEqual("Refresh");
+    expect(buttonForm.props.label).toEqual("Refresh Metadata");
   });
 });

--- a/src/components/__tests__/Editor-test.tsx
+++ b/src/components/__tests__/Editor-test.tsx
@@ -57,4 +57,18 @@ describe("Editor", () => {
     expect(buttonForm.props.link).toEqual("href");
     expect(buttonForm.props.label).toEqual("Restore");
   });
+
+  it("shows button form for refresh link", () => {
+    let setBook = jest.genMockFunction();
+    let refreshLink = {
+      href: "href", rel: "http://librarysimplified/terms/rel/refresh"
+    };
+    let editor = TestUtils.renderIntoDocument(
+      <Editor bookData={{ title: "title", refreshLink: refreshLink }} book="url" csrfToken={"token"} setBook={setBook} />
+    );
+
+    let buttonForm = TestUtils.findRenderedComponentWithType(editor, ButtonForm);
+    expect(buttonForm.props.link).toEqual("href");
+    expect(buttonForm.props.label).toEqual("Refresh");
+  });
 });

--- a/src/editorAdapter.ts
+++ b/src/editorAdapter.ts
@@ -9,9 +9,14 @@ export default function adapter(data: OPDSEntry): BookData {
     return link.rel === "http://librarysimplified.org/terms/rel/restore";
   });
 
+  let refreshLink = data.links.find(link => {
+    return link.rel === "http://librarysimplified.org/terms/rel/refresh";
+  });
+
   return {
     title: data.title,
     hideLink: hideLink,
-    restoreLink: restoreLink
+    restoreLink: restoreLink,
+    refreshLink: refreshLink
   };
 }

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -7,6 +7,7 @@ interface BookData {
   title: string;
   hideLink?: LinkData;
   restoreLink?: LinkData;
+  refreshLink?: LinkData;
 }
 
 interface BookLink {


### PR DESCRIPTION
This works with NYPL-Simplified/circulation#105.

The refresh works - you can see it in the logs - but this should be a short-term interface given that the Metadata Wrangler takes some time to run and be absorbed into a work's metadata.