### PR TITLE
editor fetches new book data when next/pev hot keys pressed

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -82,6 +82,13 @@ export class Editor extends React.Component<EditorProps, any> {
       this.props.fetchBook(bookAdminUrl);
     }
   }
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.bookUrl && nextProps.bookUrl !== this.props.bookUrl) {
+      let bookAdminUrl = nextProps.bookUrl.replace("works", "admin/works");
+      this.props.fetchBook(bookAdminUrl);
+    }
+  }
 }
 
 function mapStateToProps(state, ownProps) {

--- a/src/components/__tests__/Editor-test.tsx
+++ b/src/components/__tests__/Editor-test.tsx
@@ -10,7 +10,7 @@ import EditForm from "../EditForm";
 import ErrorMessage from "../ErrorMessage";
 
 describe("Editor", () => {
-  it("loads admin book url", () => {
+  it("loads admin book url on mount", () => {
     let permalink = "works/1234";
     let fetchBook = jest.genMockFunction();
 
@@ -20,6 +20,26 @@ describe("Editor", () => {
 
     expect(fetchBook.mock.calls.length).toBe(1);
     expect(fetchBook.mock.calls[0][0]).toBe("admin/works/1234");
+  });
+
+  it("loads admin book url when given a new book url", () => {
+    let permalink = "works/1234";
+    let newPermalink = "works/5555";
+    let fetchBook = jest.genMockFunction();
+    let element = document.createElement("div");
+
+    ReactDOM.render(
+      <Editor bookUrl={permalink} fetchBook={fetchBook} csrfToken={"token"} />,
+      element
+    );
+
+    ReactDOM.render(
+      <Editor bookUrl={newPermalink} fetchBook={fetchBook} csrfToken={"token"} />,
+      element
+    );
+
+    expect(fetchBook.mock.calls.length).toBe(2);
+    expect(fetchBook.mock.calls[1][0]).toBe("admin/works/5555");
   });
 
   it("shows title", () => {

--- a/tests/browser/navigate.js
+++ b/tests/browser/navigate.js
@@ -112,6 +112,8 @@ module.exports = {
     var nextBookSelector = "li:first-child .lane ul.laneBooks li:nth-child(2) a.laneBookLink";
     var prevBookSelector = "li:last-child .lane ul.laneBooks li:last-child a.laneBookLink";
     var bookTitleSelector = "h1.bookDetailsTitle";
+    var editTabSelector = "ul.nav-tabs li:nth-child(2) a";
+    var titleInputSelector = "input[name='title']";
 
     browser
       .goHome()
@@ -138,12 +140,20 @@ module.exports = {
                     .keys(browser.Keys.RIGHT_ARROW)
                     .verify.urlEquals(nextBookUrl)
                     .verify.containsText(bookTitleSelector, nextBookTitle)
+                    .click(editTabSelector)
+                    .waitForElementPresent(titleInputSelector, 5000)
+                    .waitForElementNotPresent(".fa-spinner", 5000)
+                    .verify.value(titleInputSelector, nextBookTitle)
                     .keys(browser.Keys.LEFT_ARROW)
                     .verify.urlEquals(bookUrl)
                     .verify.containsText(bookTitleSelector, bookTitle)
                     .keys(browser.Keys.LEFT_ARROW)
                     .verify.urlEquals(prevBookUrl)
-                    .verify.containsText(bookTitleSelector, prevBookTitle);
+                    .verify.containsText(bookTitleSelector, prevBookTitle)
+                    .click(editTabSelector)
+                    .waitForElementPresent(titleInputSelector, 5000)
+                    .waitForElementNotPresent(".fa-spinner", 5000)
+                    .verify.value(titleInputSelector, prevBookTitle)
                 });
               });
             });


### PR DESCRIPTION
This branch fixes a bug where the edit tab didn't update with new book data when hot keys were used to navigate to the next or previous book in a collection.

Closes #27.