### PR TITLE
classifications form doesn't update state from new state-unrelated props

### DIFF
--- a/src/components/ClassificationsForm.tsx
+++ b/src/components/ClassificationsForm.tsx
@@ -150,11 +150,17 @@ export default class ClassificationsForm extends React.Component<Classifications
   }
 
   componentWillReceiveProps(newProps) {
-    if (newProps.book) {
+    if (this.bookChanged(newProps.book)) {
       this.setState({ audience: newProps.book.audience });
       this.setState({ fiction: newProps.book.fiction });
       this.setState({ genres: this.bookGenres(newProps.book) });
     }
+  }
+
+  bookChanged(newBook: BookData): boolean {
+    return newBook.audience !== this.props.book.audience ||
+           newBook.fiction !== this.props.book.fiction ||
+           newBook.categories.sort() !== this.props.book.categories.sort()
   }
 
   bookGenres(book: BookData) {

--- a/src/components/__tests__/ClassificationsForm-test.tsx
+++ b/src/components/__tests__/ClassificationsForm-test.tsx
@@ -250,17 +250,27 @@ describe("ClassificationsForm", () => {
       expect(editClassifications.mock.calls[0][0]).toEqual(formData);
     });
 
-    it("updates state upon receiving new props", () => {
+    it("updates state upon receiving new state-related props", () => {
       let newBookData = Object.assign({}, bookData, {
         audience: "Adult",
         fiction: false,
-        categories: ["Urban Fantasy"]
+        categories: ["Cooking"]
       });
       wrapper.setProps({ book: newBookData });
 
       expect(wrapper.state("audience")).toBe("Adult");
       expect(wrapper.state("fiction")).toBe(false);
-      expect(wrapper.state("genres")).toEqual(["Urban Fantasy"]);
+      expect(wrapper.state("genres")).toEqual(["Cooking"]);
+    });
+
+    it("doesn't update state upoen receiving new state-unrelated props", () => {
+      // state updated with new form inputs
+      wrapper.setState({ fiction: false, genres: ["Cooking"] });
+      // form submitted, disabling form
+      wrapper.setProps({ disabled: true });
+      // state should not change back to earlier book props
+      expect(wrapper.state("fiction")).toBe(false);
+      expect(wrapper.state("genres")).toEqual(["Cooking"]);
     });
   });
 })


### PR DESCRIPTION
This branch fixes a bug that caused the ClassificationForm to display old input values immediately after the submit button was pressed.