### PR TITLE
use shortened collection and book urls in page urls

### DIFF
--- a/nightwatch.json
+++ b/nightwatch.json
@@ -33,9 +33,6 @@
         "globals.js"
       ],
       "end_session_on_fail": false,
-      "globals": {
-        "homeUrl": "http://localhost:6500/admin/"
-      },
       "loggingPrefs": {
         "browser": "ALL"
       }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "prod": "rm -rf dist && NODE_ENV=production webpack -p --progress --display-modules --config webpack.prod.config"
   },
   "dependencies": {
-    "bootstrap": "~3.3.6",
+    "bootstrap": "^3.3.6",
     "font-awesome": "^4.6.3",
     "opds-feed-parser": "0.0.11",
     "opds-web-client": "^0.0.19",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "prod": "rm -rf dist && NODE_ENV=production webpack -p --progress --display-modules --config webpack.prod.config"
   },
   "dependencies": {
-    "bootstrap": "^3.3.6",
+    "bootstrap": "~3.3.6",
     "font-awesome": "^4.6.3",
     "opds-feed-parser": "0.0.11",
     "opds-web-client": "^0.0.19",

--- a/src/components/CatalogHandler.tsx
+++ b/src/components/CatalogHandler.tsx
@@ -9,12 +9,9 @@ import reducers from "../reducers/index";
 import BookDetailsContainer, { BookDetailsContainerContext } from "./BookDetailsContainer";
 import Header from "./Header";
 import { BookLink } from "../interfaces";
-import * as qs from "qs";
-import createRouter from "../createRouter";
 import computeBreadcrumbs from "../computeBreadcrumbs";
 
 export interface CatalogHandlerProps extends React.Props<CatalogHandler> {
-  csrfToken: string;
   params: {
     collectionUrl: string;
     bookUrl: string;

--- a/src/components/CatalogHandler.tsx
+++ b/src/components/CatalogHandler.tsx
@@ -43,11 +43,26 @@ export default class CatalogHandler extends React.Component<CatalogHandlerProps,
     };
   }
 
+  expandCollectionUrl(url: string): string {
+    return url ?
+      document.location.origin + "/" + url :
+      url;
+  }
+
+  expandBookUrl(url: string): string {
+    return url ?
+      document.location.origin + "/works/" + url :
+      url;
+  }
+
   render(): JSX.Element {
     let { collectionUrl, bookUrl } = this.props.params;
 
-    collectionUrl = collectionUrl || this.context.homeUrl || null;
-    bookUrl = bookUrl || null;
+    collectionUrl =
+      this.expandCollectionUrl(collectionUrl) ||
+      this.context.homeUrl ||
+      null;
+    bookUrl = this.expandBookUrl(bookUrl) || null;
 
     let pageTitleTemplate = (collectionTitle, bookTitle) => {
       let details = bookTitle || collectionTitle;

--- a/src/components/ContextProvider.tsx
+++ b/src/components/ContextProvider.tsx
@@ -31,11 +31,15 @@ export default class ContextProvider extends React.Component<ContextProviderProp
   }
 
   prepareCollectionUrl(url: string): string {
-    return encodeURIComponent(url.replace(document.location.origin + "/", ""));
+    return encodeURIComponent(
+      url.replace(document.location.origin + "/", "").replace(/\/$/, "").replace(/^\//, "")
+    );
   }
 
   prepareBookUrl(url: string): string {
-    return encodeURIComponent(url.replace(document.location.origin + "/works/", ""));
+    return encodeURIComponent(
+      url.replace(document.location.origin + "/works/", "").replace(/\/$/, "").replace(/^\//, "")
+    );
   }
 
   static childContextTypes: React.ValidationMap<any> = {

--- a/src/components/ContextProvider.tsx
+++ b/src/components/ContextProvider.tsx
@@ -17,11 +17,25 @@ export default class ContextProvider extends React.Component<ContextProviderProp
     this.store = buildStore();
     this.pathFor = (collectionUrl: string, bookUrl: string, tab?: string) => {
       let path = "/admin/web";
-      path += collectionUrl ? `/collection/${encodeURIComponent(collectionUrl)}` : "";
-      path += bookUrl ? `/book/${encodeURIComponent(bookUrl)}` : "";
+      path +=
+        collectionUrl ?
+        `/collection/${this.prepareCollectionUrl(collectionUrl)}` :
+        "";
+      path +=
+        bookUrl ?
+        `/book/${this.prepareBookUrl(bookUrl)}` :
+        "";
       path += tab ? `/tab/${tab}` : "";
       return path;
     };
+  }
+
+  prepareCollectionUrl(url: string): string {
+    return encodeURIComponent(url.replace(document.location.origin + "/", ""));
+  }
+
+  prepareBookUrl(url: string): string {
+    return encodeURIComponent(url.replace(document.location.origin + "/works/", ""));
   }
 
   static childContextTypes: React.ValidationMap<any> = {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,7 +2,6 @@ import * as React from "react";
 import * as ReactDOM from "react-dom";
 import CatalogLink from "opds-web-client/lib/components/CatalogLink";
 import { Link } from "react-router";
-import * as fs from "fs";
 import logo from "../images/nypl-logo-transparent";
 import { Navbar, Nav, NavItem } from "react-bootstrap";
 

--- a/src/components/__tests__/CatalogHandler-test.tsx
+++ b/src/components/__tests__/CatalogHandler-test.tsx
@@ -11,8 +11,10 @@ describe("CatalogHandler", () => {
   let params;
   let context;
   let child;
+  let host = "http://example.com";
 
   beforeEach(() => {
+    document.location.href = host + "/test";
     params = {
       collectionUrl: "collectionurl",
       bookUrl: "bookurl",
@@ -23,7 +25,6 @@ describe("CatalogHandler", () => {
     };
     wrapper = shallow(
       <CatalogHandler
-        csrfToken="token"
         params={params}
         />,
       { context }
@@ -32,8 +33,8 @@ describe("CatalogHandler", () => {
 
   it("renders OPDSCatalog", () => {
     let catalog = wrapper.find(OPDSCatalog);
-    expect(catalog.prop("collectionUrl")).toBe("/collectionurl");
-    expect(catalog.prop("bookUrl")).toBe("/works/bookurl");
+    expect(catalog.prop("collectionUrl")).toBe(host + "/collectionurl");
+    expect(catalog.prop("bookUrl")).toBe(host + "/works/bookurl");
     expect(catalog.prop("BookDetailsContainer").name).toEqual("BookDetailsContainer");
     expect(catalog.prop("Header").name).toEqual("Header");
     expect(catalog.prop("computeBreadcrumbs")).toBeTruthy();

--- a/src/components/__tests__/CatalogHandler-test.tsx
+++ b/src/components/__tests__/CatalogHandler-test.tsx
@@ -14,8 +14,8 @@ describe("CatalogHandler", () => {
 
   beforeEach(() => {
     params = {
-      collectionUrl: "collection url",
-      bookUrl: "book url",
+      collectionUrl: "collectionurl",
+      bookUrl: "bookurl",
       tab: "tab"
     };
     context = {
@@ -32,8 +32,8 @@ describe("CatalogHandler", () => {
 
   it("renders OPDSCatalog", () => {
     let catalog = wrapper.find(OPDSCatalog);
-    expect(catalog.prop("collectionUrl")).toBe("collection url");
-    expect(catalog.prop("bookUrl")).toBe("book url");
+    expect(catalog.prop("collectionUrl")).toBe("/collectionurl");
+    expect(catalog.prop("bookUrl")).toBe("/works/bookurl");
     expect(catalog.prop("BookDetailsContainer").name).toEqual("BookDetailsContainer");
     expect(catalog.prop("Header").name).toEqual("Header");
     expect(catalog.prop("computeBreadcrumbs")).toBeTruthy();

--- a/src/components/__tests__/ContextProvider-test.tsx
+++ b/src/components/__tests__/ContextProvider-test.tsx
@@ -39,29 +39,54 @@ describe("ContextProvider", () => {
     let bookUrl = "book/url";
     let tab = "tab";
 
+    it("prepares collection url", () => {
+      let host = "http://example.com";
+      document.location.href = host + "/test";
+      let url = host + "/groups/eng/Adult%20Fiction";
+      expect(wrapper.instance().prepareCollectionUrl(url)).toBe("groups%2Feng%2FAdult%2520Fiction");
+    });
+
+    it("prepares book url", () => {
+      let host = "http://example.com";
+      document.location.href = host + "/test";
+      let url = host + "/works/Axis%20360/Axis%20360%20ID/0016201449";
+      expect(wrapper.instance().prepareBookUrl(url)).toBe("Axis%2520360%2FAxis%2520360%2520ID%2F0016201449");
+    });
+
     it("returns a path with collection, book, and tab", () => {
-      let path = wrapper.instance().pathFor(collectionUrl, bookUrl, tab);
-      expect(path).toBe(`/admin/web/collection/${encodeURIComponent(collectionUrl)}/book/${encodeURIComponent(bookUrl)}/tab/${tab}`);
+      let instance = wrapper.instance();
+      let path = instance.pathFor(collectionUrl, bookUrl, tab);
+      expect(path).toBe(
+        `/admin/web/collection/${instance.prepareCollectionUrl(collectionUrl)}` +
+        `/book/${instance.prepareBookUrl(bookUrl)}/tab/${tab}`
+      );
     });
 
     it("returns a path with collection and book", () => {
-      let path = wrapper.instance().pathFor(collectionUrl, bookUrl, null);
-      expect(path).toBe(`/admin/web/collection/${encodeURIComponent(collectionUrl)}/book/${encodeURIComponent(bookUrl)}`);
+      let instance = wrapper.instance();
+      let path = instance.pathFor(collectionUrl, bookUrl, null);
+      expect(path).toBe(
+        `/admin/web/collection/${instance.prepareCollectionUrl(collectionUrl)}` +
+        `/book/${instance.prepareBookUrl(bookUrl)}`
+      );
     });
 
     it("returns a path with only collection", () => {
-      let path = wrapper.instance().pathFor(collectionUrl, null, null);
-      expect(path).toBe(`/admin/web/collection/${encodeURIComponent(collectionUrl)}`);
+      let instance = wrapper.instance();
+      let path = instance.pathFor(collectionUrl, null, null);
+      expect(path).toBe(`/admin/web/collection/${instance.prepareCollectionUrl(collectionUrl)}`);
     });
 
     it("returns a path with only book", () => {
-      let path = wrapper.instance().pathFor(null, bookUrl, null);
-      expect(path).toBe(`/admin/web/book/${encodeURIComponent(bookUrl)}`);
+      let instance = wrapper.instance();
+      let path = instance.pathFor(null, bookUrl, null);
+      expect(path).toBe(`/admin/web/book/${instance.prepareBookUrl(bookUrl)}`);
     });
 
     it("returns a path with book and tab", () => {
-      let path = wrapper.instance().pathFor(null, bookUrl, tab);
-      expect(path).toBe(`/admin/web/book/${encodeURIComponent(bookUrl)}/tab/${tab}`);
+      let instance = wrapper.instance();
+      let path = instance.pathFor(null, bookUrl, tab);
+      expect(path).toBe(`/admin/web/book/${instance.prepareBookUrl(bookUrl)}/tab/${tab}`);
     });
 
     it("returns a path with no collection, book, or tab", () => {

--- a/tests/browser/globals.js.sample
+++ b/tests/browser/globals.js.sample
@@ -1,5 +1,5 @@
 module.exports = {
-  homeUrl: "http://localhost:6500/admin/",
+  homeUrl: "http://localhost:6500/admin/web/",
   username: "fakeusername",
   password: "fakepassword"
 };

--- a/tests/browser/redirect.js
+++ b/tests/browser/redirect.js
@@ -1,0 +1,50 @@
+var http = require("http");
+
+module.exports = {
+  "attempt to view a book before signing in": function(browser) {
+    // before signing in, find a book url in the catalog feed
+    http.get({
+      host: "localhost",
+      port: 6500,
+      path: "/groups/"
+    }, function(response) {
+      var body = "";
+
+      response.on("data", function(chunk) {
+        body += chunk;
+      });
+
+      response.on("end", function() {
+        var bookTitle = body.match(/<entry [\s\S]+?<title>([^<]+)<\/title>/i)[1];
+        var link = body.match(/<link [^>]*rel="alternate[^>]+\/>/i)[0];
+        var bookUrl = link.match(/href="([^"]+)"/)[1];
+
+        // transform the book url into an admin book url
+        var adminBookUrl =
+          browser.globals.homeUrl + "book/" +
+          encodeURIComponent(
+            bookUrl.replace(browser.globals.entryBaseUrl, "")
+          );
+
+        browser
+          .url(adminBookUrl)
+          .waitForElementVisible("input#Email", 1000)
+          .assert.urlContains(encodeURIComponent("state=") + encodeURI(encodeURI(adminBookUrl)))
+          .setValue("input#Email", browser.globals.username)
+          .click("input#next")
+          .waitForElementVisible("input#Passwd", 1000)
+          .setValue("input#Passwd", browser.globals.password)
+          .click("input#signIn")
+          .waitForElementVisible("button#submit_approve_access:enabled", 10000)
+          .click("button#submit_approve_access")
+          .waitForElementVisible("nav", 1000)
+          .assert.urlContains(adminBookUrl)
+          .assert.containsText("h1.bookDetailsTitle", bookTitle);
+      });
+    });
+  },
+
+  after: function(browser) {
+    browser.end();
+  }
+};


### PR DESCRIPTION
Within the application's catalog routes, collection URLs such as `http://localhost:6500/groups/eng/Adult%20Fiction` are shortened to `groups/eng/Adult%20Fiction` and book URLs such as `http://localhost:6500/works/Axis%20360/Axis%20360%20ID/0016201449` are shortened to `Axis%20360/Axis%20360%20ID/0016201449`. Further shortening can be done once the circulation manager itself supports shorter lane URLs.

This branch also adds a browser redirect test.