### PR TITLE
Interface for setting up google oauth for admin authentication

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "Web Front-end for Library Simplified Circulation Manager",
   "repository": {
     "type": "git",

--- a/src/__tests__/actions-test.ts
+++ b/src/__tests__/actions-test.ts
@@ -503,4 +503,50 @@ describe("actions", () => {
       expect(fetchMock.args[0][1].body).to.equal(formData);
     });
   });
+
+  describe("fetchAdminAuthServices", () => {
+    it("dispatches request, load, and success", async () => {
+      const dispatch = stub();
+      const adminAuthServicesData = "adminAuthServices";
+      fetcher.testData = {
+        ok: true,
+        status: 200,
+        json: () => new Promise<any>((resolve, reject) => {
+          resolve(adminAuthServicesData);
+        })
+      };
+      fetcher.resolve = true;
+
+      const data = await actions.fetchAdminAuthServices()(dispatch);
+      expect(dispatch.callCount).to.equal(3);
+      expect(dispatch.args[0][0].type).to.equal(ActionCreator.ADMIN_AUTH_SERVICES_REQUEST);
+      expect(dispatch.args[1][0].type).to.equal(ActionCreator.ADMIN_AUTH_SERVICES_SUCCESS);
+      expect(dispatch.args[2][0].type).to.equal(ActionCreator.ADMIN_AUTH_SERVICES_LOAD);
+      expect(data).to.deep.equal(adminAuthServicesData);
+    });
+  });
+
+  describe("editAdminAuthService", () => {
+    it("dispatches request and success", async () => {
+      const editAdminAuthServiceUrl = "/admin/admin_auth_services";
+      const dispatch = stub();
+      const formData = new (window as any).FormData();
+      formData.append("csrf_token", "token");
+      formData.append("name", "new name");
+
+      const fetchMock = stub().returns(new Promise<any>((update, reject) => {
+        update({ status: 200 });
+      }));
+      fetch = fetchMock;
+
+      await actions.editAdminAuthService(formData)(dispatch);
+      expect(dispatch.callCount).to.equal(2);
+      expect(dispatch.args[0][0].type).to.equal(ActionCreator.EDIT_ADMIN_AUTH_SERVICE_REQUEST);
+      expect(dispatch.args[1][0].type).to.equal(ActionCreator.EDIT_ADMIN_AUTH_SERVICE_SUCCESS);
+      expect(fetchMock.callCount).to.equal(1);
+      expect(fetchMock.args[0][0]).to.equal(editAdminAuthServiceUrl);
+      expect(fetchMock.args[0][1].method).to.equal("POST");
+      expect(fetchMock.args[0][1].body).to.equal(formData);
+    });
+  });
 });

--- a/src/__tests__/index-test.ts
+++ b/src/__tests__/index-test.ts
@@ -1,0 +1,34 @@
+import { expect } from "chai";
+import { spy } from "sinon";
+
+import * as React from "react";
+import * as ReactDOM from "react-dom";
+import { mount } from "enzyme";
+
+const CirculationWeb = require("../index");
+import Setup from "../components/Setup";
+import { Router } from "react-router";
+
+describe("CirculationWeb", () => {
+  it("renders Setup", () => {
+    const renderSpy = spy(ReactDOM, "render");
+    new CirculationWeb({ settingUp: true });
+    expect(renderSpy.callCount).to.equal(1);
+    const component = renderSpy.args[0][0];
+    const wrapper = mount(component);
+    const setup = wrapper.find(Setup);
+    expect(setup.length).to.equal(1);
+    renderSpy.restore();
+  });
+
+  it("renders Router", () => {
+    const renderSpy = spy(ReactDOM, "render");
+    new CirculationWeb({});
+    expect(renderSpy.callCount).to.equal(1);
+    const component = renderSpy.args[0][0];
+    const wrapper = mount(component);
+    const router = wrapper.find(Router);
+    expect(router.length).to.equal(1);
+    renderSpy.restore();
+  });
+});

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1,4 +1,9 @@
-import { BookData, ComplaintsData, GenreTree, ClassificationData, CirculationEventData, StatsData, LibrariesData, CollectionsData } from "./interfaces";
+import {
+  BookData, ComplaintsData, GenreTree, ClassificationData,
+  CirculationEventData, StatsData,
+  LibrariesData, CollectionsData,
+  AdminAuthServicesData
+} from "./interfaces";
 import DataFetcher from "opds-web-client/lib/DataFetcher";
 import { RequestError, RequestRejector } from "opds-web-client/lib/DataFetcher";
 import BaseActionCreator from "opds-web-client/lib/actions";
@@ -18,6 +23,8 @@ export default class ActionCreator extends BaseActionCreator {
   static readonly EDIT_LIBRARY = "EDIT_LIBRARY";
   static readonly COLLECTIONS = "COLLECTIONS";
   static readonly EDIT_COLLECTION = "EDIT_COLLECTION";
+  static readonly ADMIN_AUTH_SERVICES = "ADMIN_AUTH_SERVICES";
+  static readonly EDIT_ADMIN_AUTH_SERVICE = "EDIT_ADMIN_AUTH_SERVICE";
 
   static readonly EDIT_BOOK_REQUEST = "EDIT_BOOK_REQUEST";
   static readonly EDIT_BOOK_SUCCESS = "EDIT_BOOK_SUCCESS";
@@ -81,6 +88,15 @@ export default class ActionCreator extends BaseActionCreator {
   static readonly EDIT_COLLECTION_REQUEST = "EDIT_COLLECTION_REQUEST";
   static readonly EDIT_COLLECTION_SUCCESS = "EDIT_COLLECTION_SUCCESS";
   static readonly EDIT_COLLECTION_FAILURE = "EDIT_COLLECTION_FAILURE";
+
+  static readonly ADMIN_AUTH_SERVICES_REQUEST = "ADMIN_AUTH_SERVICES_REQUEST";
+  static readonly ADMIN_AUTH_SERVICES_SUCCESS = "ADMIN_AUTH_SERVICES_SUCCESS";
+  static readonly ADMIN_AUTH_SERVICES_FAILURE = "ADMIN_AUTH_SERVICES_FAILURE";
+  static readonly ADMIN_AUTH_SERVICES_LOAD = "ADMIN_AUTH_SERVICES_LOAD";
+
+  static readonly EDIT_ADMIN_AUTH_SERVICE_REQUEST = "EDIT_ADMIN_AUTH_SERVICE_REQUEST";
+  static readonly EDIT_ADMIN_AUTH_SERVICE_SUCCESS = "EDIT_ADMIN_AUTH_SERVICE_SUCCESS";
+  static readonly EDIT_ADMIN_AUTH_SERVICE_FAILURE = "EDIT_ADMIN_AUTH_SERVICE_FAILURE";
 
   constructor(fetcher?: DataFetcher) {
     fetcher = fetcher || new DataFetcher();
@@ -243,5 +259,15 @@ export default class ActionCreator extends BaseActionCreator {
   editCollection(data: FormData) {
     const url = "/admin/collections";
     return this.postForm(ActionCreator.EDIT_COLLECTION, url, data).bind(this);
+  }
+
+  fetchAdminAuthServices() {
+    const url = "/admin/admin_auth_services";
+    return this.fetchJSON<AdminAuthServicesData>(ActionCreator.ADMIN_AUTH_SERVICES, url).bind(this);
+  }
+
+  editAdminAuthService(data: FormData) {
+    const url = "/admin/admin_auth_services";
+    return this.postForm(ActionCreator.EDIT_ADMIN_AUTH_SERVICE, url, data).bind(this);
   }
 }

--- a/src/components/AdminAuthServiceEditForm.tsx
+++ b/src/components/AdminAuthServiceEditForm.tsx
@@ -15,7 +15,17 @@ export interface AdminAuthServiceEditFormState {
   domains: string[];
 }
 
+export interface AdminAuthServiceEditFormContext {
+  settingUp: boolean;
+}
+
 export default class AdminAuthServiceEditForm extends React.Component<AdminAuthServiceEditFormProps, AdminAuthServiceEditFormState> {
+  context: AdminAuthServiceEditFormContext;
+
+  static contextTypes: React.ValidationMap<AdminAuthServiceEditFormContext> = {
+    settingUp: React.PropTypes.bool.isRequired
+  };
+
   constructor(props) {
     super(props);
     let defaultProvider;
@@ -151,6 +161,13 @@ export default class AdminAuthServiceEditForm extends React.Component<AdminAuthS
     const data = new (window as any).FormData(this.refs["form"] as any);
     data.append("domains", JSON.stringify(this.state.domains));
     this.props.editItem(data).then(() => {
+      // If we're setting up admin auth for the first time, refresh the page
+      // to go to login.
+      if (this.context.settingUp) {
+        window.location.reload();
+        return;
+      }
+
       // If a new admin auth service was created, go to its edit page.
       if (!this.props.item && data.get("name")) {
         window.location.href = "/admin/web/config/adminAuth/edit/" + data.get("name");

--- a/src/components/AdminAuthServiceEditForm.tsx
+++ b/src/components/AdminAuthServiceEditForm.tsx
@@ -1,0 +1,168 @@
+import * as React from "react";
+import EditableInput from "./EditableInput";
+import { AdminAuthServiceData } from "../interfaces";
+
+export interface AdminAuthServiceEditFormProps {
+  adminAuthService?: AdminAuthServiceData;
+  csrfToken: string;
+  disabled: boolean;
+  providers: string[];
+  editAdminAuthService: (data: FormData) => Promise<any>;
+}
+
+export default class AdminAuthServiceEditForm extends React.Component<AdminAuthServiceEditFormProps, any> {
+  constructor(props) {
+    super(props);
+    let defaultProvider;
+    if (this.props.providers && this.props.providers.length) {
+      defaultProvider = this.props.providers[0];
+    }
+    this.state = {
+      provider: (this.props.adminAuthService && this.props.adminAuthService.provider) || defaultProvider,
+      domains: (this.props.adminAuthService && this.props.adminAuthService["domains"]) || []
+    };
+    this.handleProviderChange = this.handleProviderChange.bind(this);
+    this.addDomain = this.addDomain.bind(this);
+    this.removeDomain = this.removeDomain.bind(this);
+    this.save = this.save.bind(this);
+  }
+
+  render(): JSX.Element {
+    return (
+      <form ref="form" onSubmit={this.save} className="edit-form">
+        <input
+          type="hidden"
+          name="csrf_token"
+          value={this.props.csrfToken}
+          />
+        <EditableInput
+          elementType="input"
+          type="text"
+          disabled={this.props.disabled}
+          readOnly={!!(this.props.adminAuthService && this.props.adminAuthService.name)}
+          name="name"
+          label="Name"
+          value={this.props.adminAuthService && this.props.adminAuthService.name}
+          />
+        <EditableInput
+          elementType="select"
+          disabled={this.props.disabled}
+          readOnly={!!(this.props.adminAuthService && this.props.adminAuthService.provider)}
+          name="provider"
+          label="Provider"
+          value={this.state.provider}
+          ref="provider"
+          onChange={this.handleProviderChange}
+          >
+          { this.props.providers && this.props.providers.length > 0 && this.props.providers.map(provider =>
+              <option key={provider} value={provider}>{provider}</option>
+            )
+          }
+        </EditableInput>
+        <EditableInput
+          elementType="input"
+          type="text"
+          disabled={this.props.disabled}
+          name="url"
+          label="Authentication URI"
+          value={this.props.adminAuthService && this.props.adminAuthService["url"] || "https://accounts.google.com/o/oauth2/auth" }
+          />
+        <EditableInput
+          elementType="input"
+          type="text"
+          disabled={this.props.disabled}
+          name="username"
+          label="Client ID"
+          value={this.props.adminAuthService && this.props.adminAuthService["username"]}
+          />
+        <EditableInput
+          elementType="input"
+          type="text"
+          disabled={this.props.disabled}
+          name="password"
+          label="Client Secret"
+          value={this.props.adminAuthService && this.props.adminAuthService["password"]}
+          />
+        <div className="form-group">
+          <label>Allowed Domains</label>
+          { this.state.domains.map(domain =>
+              <div key={domain} className="admin-auth-service-domain">
+                <div>{domain}</div>
+                <i
+                  className="fa fa-times"
+                  aria-hidden="true"
+                  onClick={() => !this.props.disabled && this.removeDomain(domain)}
+                  ></i>
+                <a
+                  className="sr-only"
+                  onClick={() => !this.props.disabled && this.removeDomain(domain)}
+                  >remove</a>
+              </div>
+            )
+          }
+        </div>
+        <div className="form-group">
+          <input
+            type="text"
+            name="add-domain"
+            label="Add an allowed domain"
+            ref="addDomain"
+            />
+          <button
+            type="button"
+            className="btn btn-default add-domain"
+            disabled={this.props.disabled}
+            onClick={this.addDomain}
+            >Add Domain</button>
+        </div>
+        <button
+          type="submit"
+          className="btn btn-default"
+          disabled={this.props.disabled}
+          >Submit</button>
+      </form>
+    );
+  }
+
+  componentWillReceiveProps(newProps) {
+    if (newProps.adminAuthService && newProps.adminAuthService.provider) {
+      if (!this.props.adminAuthService || !this.props.adminAuthService.provider || (this.props.adminAuthService.provider !== newProps.adminAuthService.provider)) {
+        this.setState({ provider: newProps.adminAuthService.provider });
+      }
+    }
+    if (newProps.adminAuthService && newProps.adminAuthService["domains"]) {
+     if (!this.props.adminAuthService || !this.props.adminAuthService["domains"] || (this.props.adminAuthService["domains"] !== newProps.adminAuthService["domains"])) {
+       this.setState({ domains: newProps.adminAuthService["domains"] });
+     }
+    }
+  }
+
+  save(event) {
+    event.preventDefault();
+
+    const data = new (window as any).FormData(this.refs["form"] as any);
+    data.append("domains", JSON.stringify(this.state.domains));
+    this.props.editAdminAuthService(data).then(() => {
+      // If a new admin auth service was created, go to its edit page.
+      if (!this.props.adminAuthService && data.get("name")) {
+        window.location.href = "/admin/web/config/adminAuth/edit/" + data.get("name");
+      }
+    });
+  }
+
+  handleProviderChange() {
+    const provider = (this.refs["provider"] as any).getValue();
+    this.setState({ provider });
+  }
+
+  removeDomain(domain: string) {
+    this.setState({ domains: this.state.domains.filter(stateDomain => stateDomain !== domain) });
+  }
+
+  addDomain() {
+    const domain = (this.refs["addDomain"] as any).value;
+    if (this.state.domains.indexOf(domain) === -1) {
+      this.setState({ domains: this.state.domains.concat([domain]) });
+    }
+  }
+}

--- a/src/components/AdminAuthServices.tsx
+++ b/src/components/AdminAuthServices.tsx
@@ -1,0 +1,131 @@
+import * as React from "react";
+import { Store } from "redux";
+import { connect } from "react-redux";
+import ActionCreator from "../actions";
+import { FetchErrorData } from "opds-web-client/lib/interfaces";
+import { AdminAuthServiceData } from "../interfaces";
+import { State } from "../reducers/index";
+import LoadingIndicator from "opds-web-client/lib/components/LoadingIndicator";
+import ErrorMessage from "./ErrorMessage";
+import AdminAuthServiceEditForm from "./AdminAuthServiceEditForm";
+
+export interface AdminAuthServicesProps {
+  store?: Store<State>;
+  adminAuthServices?: AdminAuthServiceData[];
+  providers?: string[];
+  fetchError?: FetchErrorData;
+  fetchAdminAuthServices?: () => Promise<any>;
+  editAdminAuthService?: (data: FormData) => Promise<any>;
+  isFetching?: boolean;
+  csrfToken: string;
+  editOrCreate?: string;
+  identifier?: string;
+}
+
+export class AdminAuthServices extends React.Component<AdminAuthServicesProps, any> {
+  constructor(props) {
+    super(props);
+    this.editAdminAuthService = this.editAdminAuthService.bind(this);
+  }
+
+  render(): JSX.Element {
+    return (
+      <div>
+        { this.props.fetchError &&
+          <ErrorMessage error={this.props.fetchError} />
+        }
+        { this.props.isFetching &&
+          <LoadingIndicator />
+        }
+
+        { !this.props.isFetching && !this.props.editOrCreate && this.props.adminAuthServices && this.props.adminAuthServices.length > 0 &&
+          <div>
+            <h2>Edit Admin Authentication Services</h2>
+            <ul>
+              { this.props.adminAuthServices && this.props.adminAuthServices.map((adminAuthService, index) =>
+                  <li key={index}>
+                    <h3>{adminAuthService.name}</h3>
+                    <a href={"/admin/web/config/adminAuth/edit/" + adminAuthService.name}>Edit admin authentication service</a>
+                  </li>
+                )
+              }
+            </ul>
+          </div>
+        }
+
+        { !this.props.isFetching && !this.props.editOrCreate &&
+          <a href="/admin/web/config/adminAuth/create">Create a new admin authentication service</a>
+        }
+
+        { !this.props.isFetching && (this.props.editOrCreate === "create") &&
+          <div>
+            <h2>Create a new admin authentication service</h2>
+            <AdminAuthServiceEditForm
+              providers={this.props.providers}
+              csrfToken={this.props.csrfToken}
+              disabled={this.props.isFetching}
+              editAdminAuthService={this.editAdminAuthService}
+              />
+          </div>
+        }
+
+        { !this.props.isFetching && this.adminAuthServiceToEdit() &&
+          <div>
+            <h2>Edit admin authentication service</h2>
+            <AdminAuthServiceEditForm
+              adminAuthService={this.adminAuthServiceToEdit()}
+              providers={this.props.providers}
+              csrfToken={this.props.csrfToken}
+              disabled={this.props.isFetching}
+              editAdminAuthService={this.editAdminAuthService}
+              />
+          </div>
+        }
+      </div>
+    );
+  }
+
+  componentWillMount() {
+    if (this.props.fetchAdminAuthServices) {
+      this.props.fetchAdminAuthServices();
+    }
+  }
+
+  editAdminAuthService(data: FormData) {
+    return this.props.editAdminAuthService(data).then(this.props.fetchAdminAuthServices);
+  }
+
+  adminAuthServiceToEdit() {
+    if (this.props.editOrCreate === "edit" && this.props.adminAuthServices) {
+      for (const adminAuthService of this.props.adminAuthServices) {
+        if (adminAuthService.name === this.props.identifier) {
+          return adminAuthService;
+        }
+      }
+    }
+  }
+}
+
+function mapStateToProps(state, ownProps) {
+  return {
+    adminAuthServices: state.editor.adminAuthServices && state.editor.adminAuthServices.data && state.editor.adminAuthServices.data.admin_auth_services,
+    providers: state.editor.adminAuthServices && state.editor.adminAuthServices.data && state.editor.adminAuthServices.data.providers,
+    fetchError: state.editor.adminAuthServices.fetchError,
+    isFetching: state.editor.adminAuthServices.isFetching || state.editor.adminAuthServices.isEditing
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  let actions = new ActionCreator();
+  return {
+    fetchAdminAuthServices: () => dispatch(actions.fetchAdminAuthServices()),
+    editAdminAuthService: (data: FormData) => dispatch(actions.editAdminAuthService(data))
+  };
+}
+
+const ConnectedAdminAuthServices = connect<any, any, any>(
+  mapStateToProps,
+  mapDispatchToProps
+)(AdminAuthServices);
+
+export default ConnectedAdminAuthServices;

--- a/src/components/AdminAuthServices.tsx
+++ b/src/components/AdminAuthServices.tsx
@@ -1,115 +1,20 @@
-import * as React from "react";
-import { Store } from "redux";
+import EditableConfigList from "./EditableConfigList";
 import { connect } from "react-redux";
 import ActionCreator from "../actions";
-import { FetchErrorData } from "opds-web-client/lib/interfaces";
-import { AdminAuthServiceData } from "../interfaces";
-import { State } from "../reducers/index";
-import LoadingIndicator from "opds-web-client/lib/components/LoadingIndicator";
-import ErrorMessage from "./ErrorMessage";
+import { AdminAuthServicesData, AdminAuthServiceData } from "../interfaces";
 import AdminAuthServiceEditForm from "./AdminAuthServiceEditForm";
 
-export interface AdminAuthServicesProps {
-  store?: Store<State>;
-  adminAuthServices?: AdminAuthServiceData[];
-  providers?: string[];
-  fetchError?: FetchErrorData;
-  fetchAdminAuthServices?: () => Promise<any>;
-  editAdminAuthService?: (data: FormData) => Promise<any>;
-  isFetching?: boolean;
-  csrfToken: string;
-  editOrCreate?: string;
-  identifier?: string;
-}
-
-export class AdminAuthServices extends React.Component<AdminAuthServicesProps, any> {
-  constructor(props) {
-    super(props);
-    this.editAdminAuthService = this.editAdminAuthService.bind(this);
-  }
-
-  render(): JSX.Element {
-    return (
-      <div>
-        { this.props.fetchError &&
-          <ErrorMessage error={this.props.fetchError} />
-        }
-        { this.props.isFetching &&
-          <LoadingIndicator />
-        }
-
-        { !this.props.isFetching && !this.props.editOrCreate && this.props.adminAuthServices && this.props.adminAuthServices.length > 0 &&
-          <div>
-            <h2>Edit Admin Authentication Services</h2>
-            <ul>
-              { this.props.adminAuthServices && this.props.adminAuthServices.map((adminAuthService, index) =>
-                  <li key={index}>
-                    <h3>{adminAuthService.name}</h3>
-                    <a href={"/admin/web/config/adminAuth/edit/" + adminAuthService.name}>Edit admin authentication service</a>
-                  </li>
-                )
-              }
-            </ul>
-          </div>
-        }
-
-        { !this.props.isFetching && !this.props.editOrCreate &&
-          <a href="/admin/web/config/adminAuth/create">Create a new admin authentication service</a>
-        }
-
-        { !this.props.isFetching && (this.props.editOrCreate === "create") &&
-          <div>
-            <h2>Create a new admin authentication service</h2>
-            <AdminAuthServiceEditForm
-              providers={this.props.providers}
-              csrfToken={this.props.csrfToken}
-              disabled={this.props.isFetching}
-              editAdminAuthService={this.editAdminAuthService}
-              />
-          </div>
-        }
-
-        { !this.props.isFetching && this.adminAuthServiceToEdit() &&
-          <div>
-            <h2>Edit admin authentication service</h2>
-            <AdminAuthServiceEditForm
-              adminAuthService={this.adminAuthServiceToEdit()}
-              providers={this.props.providers}
-              csrfToken={this.props.csrfToken}
-              disabled={this.props.isFetching}
-              editAdminAuthService={this.editAdminAuthService}
-              />
-          </div>
-        }
-      </div>
-    );
-  }
-
-  componentWillMount() {
-    if (this.props.fetchAdminAuthServices) {
-      this.props.fetchAdminAuthServices();
-    }
-  }
-
-  editAdminAuthService(data: FormData) {
-    return this.props.editAdminAuthService(data).then(this.props.fetchAdminAuthServices);
-  }
-
-  adminAuthServiceToEdit() {
-    if (this.props.editOrCreate === "edit" && this.props.adminAuthServices) {
-      for (const adminAuthService of this.props.adminAuthServices) {
-        if (adminAuthService.name === this.props.identifier) {
-          return adminAuthService;
-        }
-      }
-    }
-  }
+export class AdminAuthServices extends EditableConfigList<AdminAuthServicesData, AdminAuthServiceData> {
+  EditForm = AdminAuthServiceEditForm;
+  listDataKey = "admin_auth_services";
+  itemTypeName = "admin authentication service";
+  urlBase = "/admin/web/config/adminAuth/";
+  identifierKey = "name";
 }
 
 function mapStateToProps(state, ownProps) {
   return {
-    adminAuthServices: state.editor.adminAuthServices && state.editor.adminAuthServices.data && state.editor.adminAuthServices.data.admin_auth_services,
-    providers: state.editor.adminAuthServices && state.editor.adminAuthServices.data && state.editor.adminAuthServices.data.providers,
+    data: state.editor.adminAuthServices && state.editor.adminAuthServices.data,
     fetchError: state.editor.adminAuthServices.fetchError,
     isFetching: state.editor.adminAuthServices.isFetching || state.editor.adminAuthServices.isEditing
   };
@@ -118,8 +23,8 @@ function mapStateToProps(state, ownProps) {
 function mapDispatchToProps(dispatch) {
   let actions = new ActionCreator();
   return {
-    fetchAdminAuthServices: () => dispatch(actions.fetchAdminAuthServices()),
-    editAdminAuthService: (data: FormData) => dispatch(actions.editAdminAuthService(data))
+    fetchData: () => dispatch(actions.fetchAdminAuthServices()),
+    editItem: (data: FormData) => dispatch(actions.editAdminAuthService(data))
   };
 }
 

--- a/src/components/CollectionEditForm.tsx
+++ b/src/components/CollectionEditForm.tsx
@@ -1,26 +1,25 @@
 import * as React from "react";
 import EditableInput from "./EditableInput";
-import { CollectionData, LibraryData, ProtocolData } from "../interfaces";
+import { CollectionsData, CollectionData } from "../interfaces";
 
 export interface CollectionEditFormProps {
-  collection?: CollectionData;
+  data: CollectionsData;
+  item?: CollectionData;
   csrfToken: string;
   disabled: boolean;
-  protocols: ProtocolData[];
-  allLibraries: LibraryData[];
-  editCollection: (data: FormData) => Promise<any>;
+  editItem: (data: FormData) => Promise<void>;
 }
 
 export default class CollectionEditForm extends React.Component<CollectionEditFormProps, any> {
   constructor(props) {
     super(props);
     let defaultProtocol;
-    if (this.props.protocols && this.props.protocols.length) {
-       defaultProtocol = this.props.protocols[0].name;
+    if (this.props.data.protocols && this.props.data.protocols.length) {
+       defaultProtocol = this.props.data.protocols[0].name;
     }
     this.state = {
-      protocol: (this.props.collection && this.props.collection.protocol) || defaultProtocol,
-      libraries: (this.props.collection && this.props.collection.libraries) || []
+      protocol: (this.props.item && this.props.item.protocol) || defaultProtocol,
+      libraries: (this.props.item && this.props.item.libraries) || []
     };
     this.handleProtocolChange = this.handleProtocolChange.bind(this);
     this.addLibrary = this.addLibrary.bind(this);
@@ -41,27 +40,27 @@ export default class CollectionEditForm extends React.Component<CollectionEditFo
           elementType="input"
           type="text"
           disabled={this.props.disabled}
-          readOnly={!!(this.props.collection && this.props.collection.name)}
+          readOnly={!!(this.props.item && this.props.item.name)}
           name="name"
           label="Name"
-          value={this.props.collection && this.props.collection.name}
+          value={this.props.item && this.props.item.name}
           />
         <EditableInput
           elementType="select"
           disabled={this.props.disabled}
-          readOnly={!!(this.props.collection && this.props.collection.protocol)}
+          readOnly={!!(this.props.item && this.props.item.protocol)}
           name="protocol"
           label="Protocol"
           value={this.state.protocol}
           ref="protocol"
           onChange={this.handleProtocolChange}
           >
-          { this.props.protocols && this.props.protocols.length > 0 && this.props.protocols.map(protocol =>
+          { this.props.data.protocols && this.props.data.protocols.length > 0 && this.props.data.protocols.map(protocol =>
               <option key={protocol.name} value={protocol.name}>{protocol.name}</option>
             )
           }
         </EditableInput>
-        { this.props.protocols && this.protocolFields() && this.protocolFields().map(field =>
+        { this.props.data.protocols && this.protocolFields() && this.protocolFields().map(field =>
             <EditableInput
               key={field.key}
               elementType="input"
@@ -69,7 +68,7 @@ export default class CollectionEditForm extends React.Component<CollectionEditFo
               disabled={this.props.disabled}
               name={field.key}
               label={field.label}
-              value={this.props.collection && this.props.collection[field.key]}
+              value={this.props.item && this.props.item[field.key]}
               />
           )
         }
@@ -123,14 +122,14 @@ export default class CollectionEditForm extends React.Component<CollectionEditFo
   }
 
   componentWillReceiveProps(newProps) {
-    if (newProps.collection && newProps.collection.protocol) {
-      if (!this.props.collection || !this.props.collection.protocol || (this.props.collection.protocol !== newProps.collection.protocol)) {
-        this.setState({ protocol: newProps.collection.protocol });
+    if (newProps.item && newProps.item.protocol) {
+      if (!this.props.item || !this.props.item.protocol || (this.props.item.protocol !== newProps.item.protocol)) {
+        this.setState({ protocol: newProps.item.protocol });
       }
     }
-    if (newProps.collection && newProps.collection.libraries) {
-      if (!this.props.collection || !this.props.collection.libraries || (this.props.collection.libraries !== newProps.collection.libraries)) {
-        this.setState({ libraries: newProps.collection.libraries });
+    if (newProps.item && newProps.item.libraries) {
+      if (!this.props.item || !this.props.item.libraries || (this.props.item.libraries !== newProps.item.libraries)) {
+        this.setState({ libraries: newProps.item.libraries });
       }
     }
   }
@@ -140,9 +139,9 @@ export default class CollectionEditForm extends React.Component<CollectionEditFo
 
     const data = new (window as any).FormData(this.refs["form"] as any);
     data.append("libraries", JSON.stringify(this.state.libraries));
-    this.props.editCollection(data).then(() => {
+    this.props.editItem(data).then(() => {
       // If a new collection was created, go to its edit page.
-      if (!this.props.collection && data.get("name")) {
+      if (!this.props.item && data.get("name")) {
         window.location.href = "/admin/web/config/collections/edit/" + data.get("name");
       }
     });
@@ -154,8 +153,8 @@ export default class CollectionEditForm extends React.Component<CollectionEditFo
   }
 
   protocolFields() {
-    if (this.state.protocol && this.props.protocols) {
-      for (const protocol of this.props.protocols) {
+    if (this.state.protocol && this.props.data.protocols) {
+      for (const protocol of this.props.data.protocols) {
         if (protocol.name === this.state.protocol) {
           return protocol.fields;
         }
@@ -165,7 +164,7 @@ export default class CollectionEditForm extends React.Component<CollectionEditFo
   }
 
   availableLibraries(): string[] {
-    const names = (this.props.allLibraries || []).map(library => library.short_name);
+    const names = (this.props.data.allLibraries || []).map(library => library.short_name);
     return names.filter(name => this.state.libraries.indexOf(name) === -1);
   }
 

--- a/src/components/CollectionEditForm.tsx
+++ b/src/components/CollectionEditForm.tsx
@@ -175,7 +175,7 @@ export default class CollectionEditForm extends React.Component<CollectionEditFo
 
   addLibrary() {
     const library = (this.refs["addLibrary"] as any).value;
-    if (this.state.libraries.indexOf(library !== -1)) {
+    if (this.state.libraries.indexOf(library) === -1) {
       this.setState({ libraries: this.state.libraries.concat([library]) });
     }
   }

--- a/src/components/Collections.tsx
+++ b/src/components/Collections.tsx
@@ -43,7 +43,7 @@ export class Collections extends React.Component<CollectionsProps, any> {
           <div>
             <h2>Edit collections</h2>
             <ul>
-              { this.props.collections && this.props.collections.map((collection, index) =>
+              { this.props.collections.map((collection, index) =>
                   <li key={index}>
                     <h3>{collection.name}</h3>
                     <a href={"/admin/web/config/collections/edit/" + collection.name}>Edit collection</a>

--- a/src/components/Collections.tsx
+++ b/src/components/Collections.tsx
@@ -1,119 +1,22 @@
-import * as React from "react";
-import { Store } from "redux";
+import EditableConfigList from "./EditableConfigList";
 import { connect } from "react-redux";
 import ActionCreator from "../actions";
-import { FetchErrorData } from "opds-web-client/lib/interfaces";
-import { CollectionData, LibraryData, ProtocolData } from "../interfaces";
-import { State } from "../reducers/index";
-import LoadingIndicator from "opds-web-client/lib/components/LoadingIndicator";
-import ErrorMessage from "./ErrorMessage";
+import { CollectionsData, CollectionData, LibraryData } from "../interfaces";
 import CollectionEditForm from "./CollectionEditForm";
 
-export interface CollectionsProps {
-  store?: Store<State>;
-  collections?: CollectionData[];
-  protocols?: ProtocolData[];
-  allLibraries?: LibraryData[];
-  fetchError?: FetchErrorData;
-  fetchCollections?: () => Promise<any>;
-  editCollection?: (data: FormData) => Promise<any>;
-  isFetching?: boolean;
-  csrfToken: string;
-  editOrCreate?: string;
-  identifier?: string;
-}
-
-export class Collections extends React.Component<CollectionsProps, any> {
-  constructor(props) {
-    super(props);
-    this.editCollection = this.editCollection.bind(this);
-  }
-
-  render(): JSX.Element {
-    return (
-      <div>
-        { this.props.fetchError &&
-          <ErrorMessage error={this.props.fetchError} />
-        }
-        { this.props.isFetching &&
-          <LoadingIndicator />
-        }
-
-        { !this.props.isFetching && !this.props.editOrCreate && this.props.collections && this.props.collections.length > 0 &&
-          <div>
-            <h2>Edit collections</h2>
-            <ul>
-              { this.props.collections.map((collection, index) =>
-                  <li key={index}>
-                    <h3>{collection.name}</h3>
-                    <a href={"/admin/web/config/collections/edit/" + collection.name}>Edit collection</a>
-                  </li>
-                )
-              }
-            </ul>
-          </div>
-        }
-
-        { !this.props.isFetching && !this.props.editOrCreate &&
-          <a href="/admin/web/config/collections/create">Create a new collection</a>
-        }
-
-        { !this.props.isFetching && (this.props.editOrCreate === "create") &&
-          <div>
-            <h2>Create a new collection</h2>
-            <CollectionEditForm
-              protocols={this.props.protocols}
-              allLibraries={this.props.allLibraries}
-              csrfToken={this.props.csrfToken}
-              disabled={this.props.isFetching}
-              editCollection={this.editCollection}
-              />
-          </div>
-        }
-
-        { !this.props.isFetching && this.collectionToEdit() &&
-          <div>
-            <h2>Edit collection</h2>
-            <CollectionEditForm
-              collection={this.collectionToEdit()}
-              protocols={this.props.protocols}
-              allLibraries={this.props.allLibraries}
-              csrfToken={this.props.csrfToken}
-              disabled={this.props.isFetching}
-              editCollection={this.editCollection}
-              />
-          </div>
-        }
-      </div>
-    );
-  }
-
-  componentWillMount() {
-    if (this.props.fetchCollections) {
-      this.props.fetchCollections();
-    }
-  }
-
-  editCollection(data: FormData) {
-    return this.props.editCollection(data).then(this.props.fetchCollections);
-  }
-
-  collectionToEdit() {
-    if (this.props.editOrCreate === "edit" && this.props.collections) {
-      for (const collection of this.props.collections) {
-        if (collection.name === this.props.identifier) {
-          return collection;
-        }
-      }
-    }
-  }
+export class Collections extends EditableConfigList<CollectionsData, CollectionData> {
+  EditForm =  CollectionEditForm;
+  listDataKey = "collections";
+  itemTypeName = "collection";
+  urlBase = "/admin/web/config/collections/";
+  identifierKey = "name";
 }
 
 function mapStateToProps(state, ownProps) {
+  const data = Object.assign({}, state.editor.collections && state.editor.collections.data || {});
+  data.allLibraries = state.editor.collections.libraries;
   return {
-    collections: state.editor.collections && state.editor.collections.data && state.editor.collections.data.collections,
-    protocols: state.editor.collections && state.editor.collections.data && state.editor.collections.data.protocols,
-    allLibraries: state.editor.libraries && state.editor.libraries.data && state.editor.libraries.data.libraries,
+    data: data,
     fetchError: state.editor.collections.fetchError,
     isFetching: state.editor.collections.isFetching || state.editor.collections.isEditing
   };
@@ -122,8 +25,8 @@ function mapStateToProps(state, ownProps) {
 function mapDispatchToProps(dispatch) {
   let actions = new ActionCreator();
   return {
-    fetchCollections: () => dispatch(actions.fetchCollections()),
-    editCollection: (data: FormData) => dispatch(actions.editCollection(data))
+    fetchData: () => dispatch(actions.fetchCollections()),
+    editItem: (data: FormData) => dispatch(actions.editCollection(data))
   };
 }
 

--- a/src/components/ConfigTabContainer.tsx
+++ b/src/components/ConfigTabContainer.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import Libraries from "./Libraries";
 import Collections from "./Collections";
+import AdminAuthServices from "./AdminAuthServices";
 import { TabContainer, TabContainerProps } from "./TabContainer";
 
 export interface ConfigTabContainerProps extends TabContainerProps {
@@ -26,6 +27,14 @@ export default class ConfigTabContainer extends TabContainer<ConfigTabContainerP
           editOrCreate={this.props.editOrCreate}
           identifier={this.props.identifier}
           />
+      ),
+      adminAuth: (
+        <AdminAuthServices
+          store={this.props.store}
+          csrfToken={this.props.csrfToken}
+          editOrCreate={this.props.editOrCreate}
+          identifier={this.props.identifier}
+          />
       )
     };
   }
@@ -34,6 +43,14 @@ export default class ConfigTabContainer extends TabContainer<ConfigTabContainerP
     let tab = event.target.dataset.tabkey;
     if (this.context.router) {
       this.context.router.push("/admin/web/config/" + tab);
+    }
+  }
+
+  tabDisplayName(name) {
+    if (name === "adminAuth") {
+      return "Admin Authentication";
+    } else {
+      return super.tabDisplayName(name);
     }
   }
 

--- a/src/components/ContextProvider.tsx
+++ b/src/components/ContextProvider.tsx
@@ -8,6 +8,7 @@ export interface ContextProviderProps extends React.Props<any> {
   csrfToken: string;
   homeUrl: string;
   showCircEventsDownload?: boolean;
+  settingUp?: boolean;
 }
 
 export default class ContextProvider extends React.Component<ContextProviderProps, any> {
@@ -49,7 +50,8 @@ export default class ContextProvider extends React.Component<ContextProviderProp
     pathFor: React.PropTypes.func.isRequired,
     csrfToken: React.PropTypes.string.isRequired,
     homeUrl: React.PropTypes.string.isRequired,
-    showCircEventsDownload: React.PropTypes.bool.isRequired
+    showCircEventsDownload: React.PropTypes.bool.isRequired,
+    settingUp: React.PropTypes.bool.isRequired
   };
 
   getChildContext() {
@@ -58,7 +60,8 @@ export default class ContextProvider extends React.Component<ContextProviderProp
       pathFor: this.pathFor,
       csrfToken: this.props.csrfToken,
       homeUrl: this.props.homeUrl,
-      showCircEventsDownload: this.props.showCircEventsDownload || false
+      showCircEventsDownload: this.props.showCircEventsDownload || false,
+      settingUp: this.props.settingUp || false
     };
   }
 

--- a/src/components/EditableConfigList.tsx
+++ b/src/components/EditableConfigList.tsx
@@ -1,0 +1,122 @@
+import * as React from "react";
+import { Store } from "redux";
+import { FetchErrorData } from "opds-web-client/lib/interfaces";
+import { State } from "../reducers/index";
+import LoadingIndicator from "opds-web-client/lib/components/LoadingIndicator";
+import ErrorMessage from "./ErrorMessage";
+
+export interface EditableConfigListProps<T> {
+  store?: Store<State>;
+  data?: T;
+  fetchError?: FetchErrorData;
+  fetchData?: () => Promise<T>;
+  editItem?: (data: FormData) => Promise<void>;
+  isFetching?: boolean;
+  csrfToken: string;
+  editOrCreate?: string;
+  identifier?: string;
+}
+
+export interface EditFormProps<T, U> {
+  item?: U;
+  data: T;
+  csrfToken: string;
+  disabled: boolean;
+  editItem: (data: FormData) => Promise<void>;
+}
+
+export abstract class EditableConfigList<T, U> extends React.Component<EditableConfigListProps<T>, void> {
+  abstract EditForm: new(props: EditFormProps<T, U>) => React.Component<EditFormProps<T, U>, any>;
+  abstract listDataKey: string;
+  abstract itemTypeName: string;
+  abstract urlBase: string;
+  abstract identifierKey: string;
+
+  constructor(props) {
+    super(props);
+    this.editItem = this.editItem.bind(this);
+  }
+
+  render(): JSX.Element {
+    let EditForm = this.EditForm;
+
+    return (
+      <div>
+        { this.props.fetchError &&
+          <ErrorMessage error={this.props.fetchError} />
+        }
+        { this.props.isFetching &&
+          <LoadingIndicator />
+        }
+
+        { !this.props.isFetching && !this.props.editOrCreate && this.props.data && this.props.data[this.listDataKey] && this.props.data[this.listDataKey].length > 0 &&
+          <div>
+            <h2>Edit {this.itemTypeName}s</h2>
+            <ul>
+              { this.props.data[this.listDataKey].map((item, index) =>
+                  <li key={index}>
+                    <h3>{item.name}</h3>
+                    <a href={this.urlBase + "edit/" + item[this.identifierKey]}>Edit {this.itemTypeName}</a>
+                  </li>
+                )
+              }
+            </ul>
+          </div>
+        }
+
+        { !this.props.isFetching && !this.props.editOrCreate &&
+          <a href={this.urlBase + "create"}>Create a new {this.itemTypeName}</a>
+        }
+
+        { !this.props.isFetching && (this.props.editOrCreate === "create") &&
+          <div>
+            <h2>Create a new {this.itemTypeName}</h2>
+            <EditForm
+              data={this.props.data}
+              csrfToken={this.props.csrfToken}
+              disabled={this.props.isFetching}
+              editItem={this.editItem}
+              />
+          </div>
+        }
+
+        { !this.props.isFetching && this.itemToEdit() &&
+          <div>
+            <h2>Edit {this.itemTypeName}</h2>
+            <EditForm
+              item={this.itemToEdit()}
+              data={this.props.data}
+              csrfToken={this.props.csrfToken}
+              disabled={this.props.isFetching}
+              editItem={this.editItem}
+              />
+          </div>
+        }
+      </div>
+    );
+  }
+
+  componentWillMount() {
+    if (this.props.fetchData) {
+      this.props.fetchData();
+    }
+  }
+
+  async editItem(data: FormData): Promise<void> {
+    await this.props.editItem(data);
+    this.props.fetchData();
+  }
+
+  itemToEdit(): U | null {
+    if (this.props.editOrCreate === "edit" && this.props.data && this.props.data[this.listDataKey]) {
+      for (const item of this.props.data[this.listDataKey]) {
+        if (item[this.identifierKey] === this.props.identifier) {
+          return item;
+        }
+      }
+    }
+    return null;
+  }
+}
+
+export default EditableConfigList;

--- a/src/components/EditableConfigList.tsx
+++ b/src/components/EditableConfigList.tsx
@@ -51,7 +51,7 @@ export abstract class EditableConfigList<T, U> extends React.Component<EditableC
 
         { !this.props.isFetching && !this.props.editOrCreate && this.props.data && this.props.data[this.listDataKey] && this.props.data[this.listDataKey].length > 0 &&
           <div>
-            <h2>Edit {this.itemTypeName}s</h2>
+            <h2>Edit {this.itemTypeName} configurations</h2>
             <ul>
               { this.props.data[this.listDataKey].map((item, index) =>
                   <li key={index}>

--- a/src/components/Libraries.tsx
+++ b/src/components/Libraries.tsx
@@ -41,7 +41,7 @@ export class Libraries extends React.Component<LibrariesProps, any> {
           <div>
             <h2>Edit libraries</h2>
             <ul>
-              { this.props.libraries && this.props.libraries.map((library, index) =>
+              { this.props.libraries.map((library, index) =>
                   <li key={index}>
                     <h3>{library.name || library.short_name}</h3>
                     <a href={"/admin/web/config/libraries/edit/" + library.uuid}>Edit library</a>

--- a/src/components/Libraries.tsx
+++ b/src/components/Libraries.tsx
@@ -1,111 +1,20 @@
-import * as React from "react";
-import { Store } from "redux";
+import EditableConfigList from "./EditableConfigList";
 import { connect } from "react-redux";
 import ActionCreator from "../actions";
-import { FetchErrorData } from "opds-web-client/lib/interfaces";
-import { LibraryData } from "../interfaces";
-import { State } from "../reducers/index";
-import LoadingIndicator from "opds-web-client/lib/components/LoadingIndicator";
-import ErrorMessage from "./ErrorMessage";
+import { LibrariesData, LibraryData } from "../interfaces";
 import LibraryEditForm from "./LibraryEditForm";
 
-export interface LibrariesProps {
-  store?: Store<State>;
-  libraries?: LibraryData[];
-  fetchError?: FetchErrorData;
-  fetchLibraries?: () => Promise<any>;
-  editLibrary?: (data: FormData) => Promise<any>;
-  isFetching?: boolean;
-  csrfToken: string;
-  editOrCreate?: string;
-  identifier?: string;
-}
-
-export class Libraries extends React.Component<LibrariesProps, any> {
-  constructor(props) {
-    super(props);
-    this.editLibrary = this.editLibrary.bind(this);
-  }
-
-  render(): JSX.Element {
-    return (
-      <div>
-        { this.props.fetchError &&
-          <ErrorMessage error={this.props.fetchError} />
-        }
-        { this.props.isFetching &&
-          <LoadingIndicator />
-        }
-
-        { !this.props.isFetching && !this.props.editOrCreate && this.props.libraries && this.props.libraries.length > 0 &&
-          <div>
-            <h2>Edit libraries</h2>
-            <ul>
-              { this.props.libraries.map((library, index) =>
-                  <li key={index}>
-                    <h3>{library.name || library.short_name}</h3>
-                    <a href={"/admin/web/config/libraries/edit/" + library.uuid}>Edit library</a>
-                  </li>
-                )
-              }
-            </ul>
-          </div>
-        }
-
-        { !this.props.isFetching && !this.props.editOrCreate &&
-          <a href="/admin/web/config/libraries/create">Create a new library</a>
-        }
-
-        { !this.props.isFetching && (this.props.editOrCreate === "create") &&
-          <div>
-            <h2>Create a new library</h2>
-            <LibraryEditForm
-              csrfToken={this.props.csrfToken}
-              disabled={this.props.isFetching}
-              editLibrary={this.editLibrary}
-              />
-          </div>
-        }
-
-        { !this.props.isFetching && this.libraryToEdit() &&
-          <div>
-            <h2>Edit library</h2>
-            <LibraryEditForm
-              library={this.libraryToEdit()}
-              csrfToken={this.props.csrfToken}
-              disabled={this.props.isFetching}
-              editLibrary={this.editLibrary}
-              />
-          </div>
-        }
-      </div>
-    );
-  }
-
-  componentWillMount() {
-    if (this.props.fetchLibraries) {
-      this.props.fetchLibraries();
-    }
-  }
-
-  editLibrary(data: FormData) {
-    return this.props.editLibrary(data).then(this.props.fetchLibraries);
-  }
-
-  libraryToEdit() {
-    if (this.props.editOrCreate === "edit" && this.props.libraries) {
-      for (const library of this.props.libraries) {
-        if (library.uuid === this.props.identifier) {
-          return library;
-        }
-      }
-    }
-  }
+export class Libraries extends EditableConfigList<LibrariesData, LibraryData> {
+  EditForm = LibraryEditForm;
+  listDataKey = "libraries";
+  itemTypeName = "library";
+  urlBase = "/admin/web/config/libraries/";
+  identifierKey = "uuid";
 }
 
 function mapStateToProps(state, ownProps) {
   return {
-    libraries: state.editor.libraries && state.editor.libraries.data && state.editor.libraries.data.libraries || [],
+    data: state.editor.libraries && state.editor.libraries.data,
     fetchError: state.editor.libraries.fetchError,
     isFetching: state.editor.libraries.isFetching || state.editor.libraries.isEditing
   };
@@ -114,8 +23,8 @@ function mapStateToProps(state, ownProps) {
 function mapDispatchToProps(dispatch) {
   let actions = new ActionCreator();
   return {
-    fetchLibraries: () => dispatch(actions.fetchLibraries()),
-    editLibrary: (data: FormData) => dispatch(actions.editLibrary(data))
+    fetchData: () => dispatch(actions.fetchLibraries()),
+    editItem: (data: FormData) => dispatch(actions.editLibrary(data))
   };
 }
 

--- a/src/components/LibraryEditForm.tsx
+++ b/src/components/LibraryEditForm.tsx
@@ -1,15 +1,20 @@
 import * as React from "react";
 import EditableInput from "./EditableInput";
-import { LibraryData } from "../interfaces";
+import { LibrariesData, LibraryData } from "../interfaces";
 
 export interface LibraryEditFormProps {
-  library?: LibraryData;
+  data: LibrariesData;
+  item?: LibraryData;
   csrfToken: string;
   disabled: boolean;
-  editLibrary: (data: FormData) => Promise<any>;
+  editItem: (data: FormData) => Promise<void>;
 }
 
-export default class LibraryEditForm extends React.Component<LibraryEditFormProps, any> {
+export interface LibraryEditFormState {
+  useRandomSecret: boolean;
+}
+
+export default class LibraryEditForm extends React.Component<LibraryEditFormProps, LibraryEditFormState> {
   constructor(props) {
     super(props);
     this.state = {
@@ -29,7 +34,7 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
         <input
           type="hidden"
           name="uuid"
-          value={this.props.library && this.props.library.uuid}
+          value={this.props.item && this.props.item.uuid}
           />
         <EditableInput
           elementType="input"
@@ -37,7 +42,7 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
           disabled={this.props.disabled}
           name="name"
           label="Name"
-          value={this.props.library && this.props.library.name}
+          value={this.props.item && this.props.item.name}
           />
         <EditableInput
           elementType="input"
@@ -45,7 +50,7 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
           disabled={this.props.disabled}
           name="short_name"
           label="Short name"
-          value={this.props.library && this.props.library.short_name}
+          value={this.props.item && this.props.item.short_name}
           />
         <EditableInput
           elementType="input"
@@ -53,9 +58,9 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
           disabled={this.props.disabled}
           name="library_registry_short_name"
           label="Short name (for library registry)"
-          value={this.props.library && this.props.library.library_registry_short_name}
+          value={this.props.item && this.props.item.library_registry_short_name}
           />
-        { (!this.props.library || !this.props.library.library_registry_shared_secret) &&
+        { (!this.props.item || !this.props.item.library_registry_shared_secret) &&
           <EditableInput
             elementType="input"
             type="checkbox"
@@ -73,7 +78,7 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
             disabled={this.props.disabled}
             name="library_registry_shared_secret"
             label="Shared secret (for library registry)"
-            value={this.props.library && this.props.library.library_registry_shared_secret}
+            value={this.props.item && this.props.item.library_registry_shared_secret}
             />
           }
         <button
@@ -90,7 +95,7 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
     event.preventDefault();
 
     const data = new (window as any).FormData(this.refs["form"] as any);
-    this.props.editLibrary(data);
+    this.props.editItem(data);
   }
 
   handleRandomSecretChange() {

--- a/src/components/Setup.tsx
+++ b/src/components/Setup.tsx
@@ -1,0 +1,28 @@
+import * as React from "react";
+import { Store } from "redux";
+import AdminAuthServices from "./AdminAuthServices";
+import { State } from "../reducers/index";
+
+export interface SetupContext {
+  editorStore: Store<State>;
+  csrfToken: string;
+}
+
+export default class Setup extends React.Component<void, void> {
+  context: SetupContext;
+
+  static contextTypes: React.ValidationMap<SetupContext> = {
+    editorStore: React.PropTypes.object.isRequired,
+    csrfToken: React.PropTypes.string.isRequired
+  };
+
+  render(): JSX.Element {
+    return (
+      <AdminAuthServices
+        store={this.context.editorStore}
+        csrfToken={this.context.csrfToken}
+        editOrCreate="create"
+        />
+    );
+  }
+}

--- a/src/components/__tests__/AdminAuthServiceEditForm-test.tsx
+++ b/src/components/__tests__/AdminAuthServiceEditForm-test.tsx
@@ -1,0 +1,221 @@
+import { expect } from "chai";
+import { stub } from "sinon";
+
+import * as React from "react";
+import { shallow, mount } from "enzyme";
+
+import AdminAuthServiceEditForm from "../AdminAuthServiceEditForm";
+import EditableInput from "../EditableInput";
+
+describe("AdminAuthServiceEditForm", () => {
+  let wrapper;
+  let editAdminAuthService;
+  let adminAuthServiceData = {
+    name: "name",
+    provider: "OAuth provider",
+    url: "url",
+    username: "user",
+    password: "pass",
+    domains: ["nypl.org"]
+  };
+  let providersData = ["OAuth provider", "some other provider"];
+
+  let editableInputByName = (name) => {
+    let inputs = wrapper.find(EditableInput);
+    if (inputs.length >= 1) {
+      return inputs.filterWhere(input => input.props().name === name);
+    }
+    return [];
+  };
+
+  describe("rendering", () => {
+    beforeEach(() => {
+      editAdminAuthService = stub();
+      wrapper = shallow(
+        <AdminAuthServiceEditForm
+          csrfToken="token"
+          disabled={false}
+          providers={providersData}
+          editAdminAuthService={editAdminAuthService}
+          />
+      );
+    });
+
+    it("renders hidden csrf token", () => {
+      let input = wrapper.find("input[name=\"csrf_token\"]");
+      expect(input.props().value).to.equal("token");
+    });
+
+    it("renders name", () => {
+      let input = editableInputByName("name");
+      expect(input.props().value).not.to.be.ok;
+      expect(input.props().readOnly).to.equal(false);
+
+      wrapper.setProps({ adminAuthService: adminAuthServiceData });
+      input = editableInputByName("name");
+      expect(input.props().value).to.equal("name");
+      expect(input.props().readOnly).to.equal(true);
+    });
+
+    it("renders provider", () => {
+      let input = editableInputByName("provider");
+      // starts with first provider in list
+      expect(input.props().value).to.equal("OAuth provider");
+      expect(input.props().readOnly).to.equal(false);
+      let children = input.find("option");
+      expect(children.length).to.equal(2);
+      expect(children.at(0).text()).to.contain("OAuth provider");
+      expect(children.at(1).text()).to.contain("some other provider");
+
+      wrapper = shallow(
+        <AdminAuthServiceEditForm
+          csrfToken="token"
+          disabled={false}
+          providers={providersData}
+          editAdminAuthService={editAdminAuthService}
+          adminAuthService={adminAuthServiceData}
+          />
+      );
+      input = editableInputByName("provider");
+      expect(input.props().value).to.equal("OAuth provider");
+      expect(input.props().readOnly).to.equal(true);
+    });
+
+    it("renders url", () => {
+      let input = editableInputByName("url");
+      // There's a default url.
+      expect(input.props().value).to.be.ok;
+      expect(input.props().value).to.equal("https://accounts.google.com/o/oauth2/auth");
+
+      wrapper.setProps({ adminAuthService: adminAuthServiceData });
+      input = editableInputByName("url");
+      expect(input.props().value).to.equal("url");
+    });
+
+    it("renders username", () => {
+      let input = editableInputByName("username");
+      expect(input.props().value).not.to.be.ok;
+
+      wrapper.setProps({ adminAuthService: adminAuthServiceData });
+      input = editableInputByName("username");
+      expect(input.props().value).to.equal("user");
+    });
+
+    it("renders password", () => {
+      let input = editableInputByName("password");
+      expect(input.props().value).not.to.be.ok;
+
+      wrapper.setProps({ adminAuthService: adminAuthServiceData });
+      input = editableInputByName("password");
+      expect(input.props().value).to.equal("pass");
+    });
+
+    it("renders allowed domains", () => {
+      let domain = wrapper.find(".admin-auth-service-domain");
+      expect(domain.length).to.equal(0);
+
+      wrapper = shallow(
+        <AdminAuthServiceEditForm
+          csrfToken="token"
+          disabled={false}
+          providers={providersData}
+          editAdminAuthService={editAdminAuthService}
+          adminAuthService={adminAuthServiceData}
+          />
+      );
+      domain = wrapper.find(".admin-auth-service-domain");
+      expect(domain.length).to.equal(1);
+      expect(domain.text()).to.contain("nypl.org");
+      expect(domain.text()).to.contain("remove");
+    });
+
+    it("renders domain add input", () => {
+      let input = wrapper.find("input[name='add-domain']");
+      expect(input.props().label).to.equal("Add an allowed domain");
+    });
+  });
+
+  describe("behavior", () => {
+    beforeEach(() => {
+      editAdminAuthService = stub().returns(new Promise<void>(resolve => resolve()));
+      wrapper = mount(
+        <AdminAuthServiceEditForm
+          csrfToken="token"
+          disabled={false}
+          providers={providersData}
+          editAdminAuthService={editAdminAuthService}
+          />
+      );
+    });
+
+    it("adds a domain", () => {
+      let domain = wrapper.find(".admin-auth-service-domain");
+      expect(domain.length).to.equal(0);
+
+      let input = wrapper.find("input[name='add-domain']") as any;
+      let inputElement = input.get(0);
+      inputElement.value = "gmail.com";
+
+      let addButton = wrapper.find("button.add-domain");
+      addButton.simulate("click");
+
+      domain = wrapper.find(".admin-auth-service-domain");
+      expect(domain.length).to.equal(1);
+      expect(domain.text()).to.contain("gmail.com");
+      expect(domain.text()).to.contain("remove");
+    });
+
+    it("removes a library", () => {
+      wrapper = shallow(
+        <AdminAuthServiceEditForm
+          csrfToken="token"
+          disabled={false}
+          providers={providersData}
+          editAdminAuthService={editAdminAuthService}
+          adminAuthService={adminAuthServiceData}
+          />
+      );
+      let domain = wrapper.find(".admin-auth-service-domain");
+      expect(domain.length).to.equal(1);
+      expect(domain.text()).to.contain("nypl.org");
+
+      let removeButton = domain.find("i");
+      removeButton.simulate("click");
+
+      domain = wrapper.find(".admin-auth-service-domain");
+      expect(domain.length).to.equal(0);
+    });
+
+    it("submits data", () => {
+      wrapper.setProps({ adminAuthService: adminAuthServiceData });
+
+      let form = wrapper.find("form");
+      form.simulate("submit");
+
+      expect(editAdminAuthService.callCount).to.equal(1);
+      let formData = editAdminAuthService.args[0][0];
+      expect(formData.get("csrf_token")).to.equal("token");
+      expect(formData.get("name")).to.equal("name");
+      expect(formData.get("provider")).to.equal("OAuth provider");
+      expect(formData.get("url")).to.equal("url");
+      expect(formData.get("username")).to.equal("user");
+      expect(formData.get("password")).to.equal("pass");
+      expect(formData.get("domains")).to.equal(JSON.stringify(["nypl.org"]));
+    });
+
+    it("goes to admin auth service edit page after creating a new admin auth service", () => {
+      let input = wrapper.find("input[name='name']");
+      let inputElement = input.get(0);
+      inputElement.value = "newName";
+      input.simulate("change");
+
+      let form = wrapper.find("form");
+      form.simulate("submit");
+
+      expect(editAdminAuthService.callCount).to.equal(1);
+      let formData = editAdminAuthService.args[0][0];
+      expect(formData.get("csrf_token")).to.equal("token");
+      expect(formData.get("name")).to.equal("newName");
+    });
+  });
+});

--- a/src/components/__tests__/AdminAuthServiceEditForm-test.tsx
+++ b/src/components/__tests__/AdminAuthServiceEditForm-test.tsx
@@ -19,6 +19,10 @@ describe("AdminAuthServiceEditForm", () => {
     domains: ["nypl.org"]
   };
   let providersData = ["OAuth provider", "some other provider"];
+  let data = {
+    admin_auth_services: [adminAuthServiceData],
+    providers: providersData
+  };
 
   let editableInputByName = (name) => {
     let inputs = wrapper.find(EditableInput);
@@ -33,10 +37,10 @@ describe("AdminAuthServiceEditForm", () => {
       editAdminAuthService = stub();
       wrapper = shallow(
         <AdminAuthServiceEditForm
+          data={data}
           csrfToken="token"
           disabled={false}
-          providers={providersData}
-          editAdminAuthService={editAdminAuthService}
+          editItem={editAdminAuthService}
           />
       );
     });
@@ -51,7 +55,7 @@ describe("AdminAuthServiceEditForm", () => {
       expect(input.props().value).not.to.be.ok;
       expect(input.props().readOnly).to.equal(false);
 
-      wrapper.setProps({ adminAuthService: adminAuthServiceData });
+      wrapper.setProps({ item: adminAuthServiceData });
       input = editableInputByName("name");
       expect(input.props().value).to.equal("name");
       expect(input.props().readOnly).to.equal(true);
@@ -69,11 +73,11 @@ describe("AdminAuthServiceEditForm", () => {
 
       wrapper = shallow(
         <AdminAuthServiceEditForm
+          data={data}
           csrfToken="token"
           disabled={false}
-          providers={providersData}
-          editAdminAuthService={editAdminAuthService}
-          adminAuthService={adminAuthServiceData}
+          editItem={editAdminAuthService}
+          item={adminAuthServiceData}
           />
       );
       input = editableInputByName("provider");
@@ -87,7 +91,7 @@ describe("AdminAuthServiceEditForm", () => {
       expect(input.props().value).to.be.ok;
       expect(input.props().value).to.equal("https://accounts.google.com/o/oauth2/auth");
 
-      wrapper.setProps({ adminAuthService: adminAuthServiceData });
+      wrapper.setProps({ item: adminAuthServiceData });
       input = editableInputByName("url");
       expect(input.props().value).to.equal("url");
     });
@@ -96,7 +100,7 @@ describe("AdminAuthServiceEditForm", () => {
       let input = editableInputByName("username");
       expect(input.props().value).not.to.be.ok;
 
-      wrapper.setProps({ adminAuthService: adminAuthServiceData });
+      wrapper.setProps({ item: adminAuthServiceData });
       input = editableInputByName("username");
       expect(input.props().value).to.equal("user");
     });
@@ -105,7 +109,7 @@ describe("AdminAuthServiceEditForm", () => {
       let input = editableInputByName("password");
       expect(input.props().value).not.to.be.ok;
 
-      wrapper.setProps({ adminAuthService: adminAuthServiceData });
+      wrapper.setProps({ item: adminAuthServiceData });
       input = editableInputByName("password");
       expect(input.props().value).to.equal("pass");
     });
@@ -116,11 +120,11 @@ describe("AdminAuthServiceEditForm", () => {
 
       wrapper = shallow(
         <AdminAuthServiceEditForm
+          data={data}
           csrfToken="token"
           disabled={false}
-          providers={providersData}
-          editAdminAuthService={editAdminAuthService}
-          adminAuthService={adminAuthServiceData}
+          editItem={editAdminAuthService}
+          item={adminAuthServiceData}
           />
       );
       domain = wrapper.find(".admin-auth-service-domain");
@@ -140,10 +144,10 @@ describe("AdminAuthServiceEditForm", () => {
       editAdminAuthService = stub().returns(new Promise<void>(resolve => resolve()));
       wrapper = mount(
         <AdminAuthServiceEditForm
+          data={data}
           csrfToken="token"
           disabled={false}
-          providers={providersData}
-          editAdminAuthService={editAdminAuthService}
+          editItem={editAdminAuthService}
           />
       );
     });
@@ -168,11 +172,11 @@ describe("AdminAuthServiceEditForm", () => {
     it("removes a library", () => {
       wrapper = shallow(
         <AdminAuthServiceEditForm
+          data={data}
           csrfToken="token"
           disabled={false}
-          providers={providersData}
-          editAdminAuthService={editAdminAuthService}
-          adminAuthService={adminAuthServiceData}
+          editItem={editAdminAuthService}
+          item={adminAuthServiceData}
           />
       );
       let domain = wrapper.find(".admin-auth-service-domain");
@@ -187,7 +191,7 @@ describe("AdminAuthServiceEditForm", () => {
     });
 
     it("submits data", () => {
-      wrapper.setProps({ adminAuthService: adminAuthServiceData });
+      wrapper.setProps({ item: adminAuthServiceData });
 
       let form = wrapper.find("form");
       form.simulate("submit");

--- a/src/components/__tests__/AdminAuthServices-test.tsx
+++ b/src/components/__tests__/AdminAuthServices-test.tsx
@@ -1,0 +1,108 @@
+import { expect } from "chai";
+import { stub } from "sinon";
+
+import * as React from "react";
+import { shallow } from "enzyme";
+
+import { AdminAuthServices } from "../AdminAuthServices";
+import ErrorMessage from "../ErrorMessage";
+import LoadingIndicator from "opds-web-client/lib/components/LoadingIndicator";
+import AdminAuthServiceEditForm from "../AdminAuthServiceEditForm";
+
+describe("AdminAuthServices", () => {
+  let wrapper;
+  let fetchAdminAuthServices;
+  let editAdminAuthService;
+  let adminAuthServicesData = [{
+    name: "name",
+    provider: "OAuth provider",
+    url: "test.com",
+    username: "user",
+    password: "pass",
+    domains: []
+  }];
+
+  const pause = () => {
+    return new Promise<void>(resolve => setTimeout(resolve, 0));
+  };
+
+  beforeEach(() => {
+    fetchAdminAuthServices = stub();
+    editAdminAuthService = stub().returns(new Promise<void>(resolve => resolve()));
+
+    wrapper = shallow(
+      <AdminAuthServices
+        adminAuthServices={adminAuthServicesData}
+        fetchAdminAuthServices={fetchAdminAuthServices}
+        editAdminAuthService={editAdminAuthService}
+        csrfToken="token"
+        isFetching={false}
+        />
+    );
+  });
+
+  it("shows error message", () => {
+    let error = wrapper.find(ErrorMessage);
+    expect(error.length).to.equal(0);
+    let fetchError = { status: 400, response: "test error", url: "test url" };
+    wrapper.setProps({ fetchError });
+    error = wrapper.find(ErrorMessage);
+    expect(error.length).to.equal(1);
+  });
+
+  it("shows loading indicator", () => {
+    let loading = wrapper.find(LoadingIndicator);
+    expect(loading.length).to.equal(0);
+    wrapper.setProps({ isFetching: true });
+    loading = wrapper.find(LoadingIndicator);
+    expect(loading.length).to.equal(1);
+  });
+
+  it("shows admin auth service list", () => {
+    let adminAuthService = wrapper.find("li");
+    expect(adminAuthService.length).to.equal(1);
+    expect(adminAuthService.text()).to.contain("name");
+    let editLink = adminAuthService.find("a");
+    expect(editLink.props().href).to.equal("/admin/web/config/adminAuth/edit/name");
+  });
+
+  it("shows create link", () => {
+    let createLink = wrapper.find("div > a");
+    expect(createLink.length).to.equal(1);
+    expect(createLink.props().href).to.equal("/admin/web/config/adminAuth/create");
+  });
+
+  it("shows create form", () => {
+    let form = wrapper.find(AdminAuthServiceEditForm);
+    expect(form.length).to.equal(0);
+    wrapper.setProps({ editOrCreate: "create" });
+    form = wrapper.find(AdminAuthServiceEditForm);
+    expect(form.length).to.equal(1);
+    expect(form.props().adminAuthService).to.be.undefined;
+    expect(form.props().csrfToken).to.equal("token");
+    expect(form.props().disabled).to.equal(false);
+  });
+
+  it("shows edit form", () => {
+    wrapper.setProps({ editOrCreate: "edit", identifier: "name" });
+    let form = wrapper.find(AdminAuthServiceEditForm);
+    expect(form.length).to.equal(1);
+    expect(form.props().adminAuthService).to.equal(adminAuthServicesData[0]);
+    expect(form.props().csrfToken).to.equal("token");
+    expect(form.props().disabled).to.equal(false);
+  });
+
+  it("fetches admin auth services on mount and passes edit function to form", async () => {
+    expect(fetchAdminAuthServices.callCount).to.equal(1);
+
+    wrapper.setProps({ editOrCreate: "create" });
+    let form = wrapper.find(AdminAuthServiceEditForm);
+
+    expect(editAdminAuthService.callCount).to.equal(0);
+    form.props().editAdminAuthService();
+    expect(editAdminAuthService.callCount).to.equal(1);
+
+    await pause();
+    expect(fetchAdminAuthServices.callCount).to.equal(2);
+  });
+});

--- a/src/components/__tests__/AdminAuthServices-test.tsx
+++ b/src/components/__tests__/AdminAuthServices-test.tsx
@@ -11,30 +11,33 @@ import AdminAuthServiceEditForm from "../AdminAuthServiceEditForm";
 
 describe("AdminAuthServices", () => {
   let wrapper;
-  let fetchAdminAuthServices;
-  let editAdminAuthService;
-  let adminAuthServicesData = [{
-    name: "name",
-    provider: "OAuth provider",
-    url: "test.com",
-    username: "user",
-    password: "pass",
-    domains: []
-  }];
+  let fetchData;
+  let editItem;
+  let data = {
+    admin_auth_services: [{
+      name: "name",
+      provider: "OAuth provider",
+      url: "test.com",
+      username: "user",
+      password: "pass",
+      domains: []
+    }],
+    providers: ["OAuth provider"]
+  };
 
   const pause = () => {
     return new Promise<void>(resolve => setTimeout(resolve, 0));
   };
 
   beforeEach(() => {
-    fetchAdminAuthServices = stub();
-    editAdminAuthService = stub().returns(new Promise<void>(resolve => resolve()));
+    fetchData = stub();
+    editItem = stub().returns(new Promise<void>(resolve => resolve()));
 
     wrapper = shallow(
       <AdminAuthServices
-        adminAuthServices={adminAuthServicesData}
-        fetchAdminAuthServices={fetchAdminAuthServices}
-        editAdminAuthService={editAdminAuthService}
+        data={data}
+        fetchData={fetchData}
+        editItem={editItem}
         csrfToken="token"
         isFetching={false}
         />
@@ -78,7 +81,8 @@ describe("AdminAuthServices", () => {
     wrapper.setProps({ editOrCreate: "create" });
     form = wrapper.find(AdminAuthServiceEditForm);
     expect(form.length).to.equal(1);
-    expect(form.props().adminAuthService).to.be.undefined;
+    expect(form.props().data).to.deep.equal(data);
+    expect(form.props().item).to.be.undefined;
     expect(form.props().csrfToken).to.equal("token");
     expect(form.props().disabled).to.equal(false);
   });
@@ -87,22 +91,23 @@ describe("AdminAuthServices", () => {
     wrapper.setProps({ editOrCreate: "edit", identifier: "name" });
     let form = wrapper.find(AdminAuthServiceEditForm);
     expect(form.length).to.equal(1);
-    expect(form.props().adminAuthService).to.equal(adminAuthServicesData[0]);
+    expect(form.props().data).to.deep.equal(data);
+    expect(form.props().item).to.equal(data.admin_auth_services[0]);
     expect(form.props().csrfToken).to.equal("token");
     expect(form.props().disabled).to.equal(false);
   });
 
   it("fetches admin auth services on mount and passes edit function to form", async () => {
-    expect(fetchAdminAuthServices.callCount).to.equal(1);
+    expect(fetchData.callCount).to.equal(1);
 
     wrapper.setProps({ editOrCreate: "create" });
     let form = wrapper.find(AdminAuthServiceEditForm);
 
-    expect(editAdminAuthService.callCount).to.equal(0);
-    form.props().editAdminAuthService();
-    expect(editAdminAuthService.callCount).to.equal(1);
+    expect(editItem.callCount).to.equal(0);
+    form.props().editItem();
+    expect(editItem.callCount).to.equal(1);
 
     await pause();
-    expect(fetchAdminAuthServices.callCount).to.equal(2);
+    expect(fetchData.callCount).to.equal(2);
   });
 });

--- a/src/components/__tests__/CollectionEditForm-test.tsx
+++ b/src/components/__tests__/CollectionEditForm-test.tsx
@@ -36,6 +36,11 @@ describe("CollectionEditForm", () => {
     { "short_name": "nypl" },
     { "short_name": "bpl" }
   ];
+  let collectionsData = {
+    collections: [collectionData],
+    protocols: protocolsData,
+    allLibraries: allLibraries
+  };
 
   let editableInputByName = (name) => {
     let inputs = wrapper.find(EditableInput);
@@ -52,9 +57,8 @@ describe("CollectionEditForm", () => {
         <CollectionEditForm
           csrfToken="token"
           disabled={false}
-          protocols={protocolsData}
-          allLibraries={allLibraries}
-          editCollection={editCollection}
+          data={collectionsData}
+          editItem={editCollection}
           />
       );
     });
@@ -69,7 +73,7 @@ describe("CollectionEditForm", () => {
       expect(input.props().value).not.to.be.ok;
       expect(input.props().readOnly).to.equal(false);
 
-      wrapper.setProps({ collection: collectionData });
+      wrapper.setProps({ item: collectionData });
       input = editableInputByName("name");
       expect(input.props().value).to.equal("name");
       expect(input.props().readOnly).to.equal(true);
@@ -89,10 +93,9 @@ describe("CollectionEditForm", () => {
         <CollectionEditForm
           csrfToken="token"
           disabled={false}
-          protocols={protocolsData}
-          allLibraries={allLibraries}
-          editCollection={editCollection}
-          collection={collectionData}
+          data={collectionsData}
+          editItem={editCollection}
+          item={collectionData}
           />
       );
       input = editableInputByName("protocol");
@@ -115,10 +118,9 @@ describe("CollectionEditForm", () => {
         <CollectionEditForm
           csrfToken="token"
           disabled={false}
-          protocols={protocolsData}
-          allLibraries={allLibraries}
-          editCollection={editCollection}
-          collection={collectionData}
+          data={collectionsData}
+          editItem={editCollection}
+          item={collectionData}
           />
       );
 
@@ -142,10 +144,9 @@ describe("CollectionEditForm", () => {
         <CollectionEditForm
           csrfToken="token"
           disabled={false}
-          protocols={protocolsData}
-          allLibraries={allLibraries}
-          editCollection={editCollection}
-          collection={collectionData}
+          data={collectionsData}
+          editItem={editCollection}
+          item={collectionData}
           />
       );
       library = wrapper.find(".collection-library");
@@ -167,10 +168,9 @@ describe("CollectionEditForm", () => {
         <CollectionEditForm
           csrfToken="token"
           disabled={false}
-          protocols={protocolsData}
-          allLibraries={allLibraries}
-          editCollection={editCollection}
-          collection={collectionData}
+          data={collectionsData}
+          editItem={editCollection}
+          item={collectionData}
           />
       );
       select = wrapper.find("select[name='add-library']");
@@ -189,9 +189,8 @@ describe("CollectionEditForm", () => {
         <CollectionEditForm
           csrfToken="token"
           disabled={false}
-          protocols={protocolsData}
-          allLibraries={allLibraries}
-          editCollection={editCollection}
+          data={collectionsData}
+          editItem={editCollection}
           />
       );
     });
@@ -249,10 +248,9 @@ describe("CollectionEditForm", () => {
         <CollectionEditForm
           csrfToken="token"
           disabled={false}
-          protocols={protocolsData}
-          allLibraries={allLibraries}
-          editCollection={editCollection}
-          collection={collectionData}
+          data={collectionsData}
+          editItem={editCollection}
+          item={collectionData}
           />
       );
       let library = wrapper.find(".collection-library");
@@ -267,7 +265,7 @@ describe("CollectionEditForm", () => {
     });
 
     it("submits data", () => {
-      wrapper.setProps({ collection: collectionData });
+      wrapper.setProps({ item: collectionData });
 
       let form = wrapper.find("form");
       form.simulate("submit");

--- a/src/components/__tests__/ConfigTabContainer-test.tsx
+++ b/src/components/__tests__/ConfigTabContainer-test.tsx
@@ -8,6 +8,7 @@ import buildStore from "../../store";
 import ConfigTabContainer from "../ConfigTabContainer";
 import Libraries from "../Libraries";
 import Collections from "../Collections";
+import AdminAuthServices from "../AdminAuthServices";
 import { mockRouterContext } from "./routing";
 
 
@@ -33,11 +34,12 @@ describe("ConfigTabContainer", () => {
     );
   });
 
-  it("shows libraries and collections tabs", () => {
+  it("shows tabs", () => {
     let links = wrapper.find("ul.nav-tabs").find("a");
     let linkTexts = links.map(link => link.text());
     expect(linkTexts).to.contain("Libraries");
     expect(linkTexts).to.contain("Collections");
+    expect(linkTexts).to.contain("Admin Authentication");
   });
 
   it("shows Libraries", () => {
@@ -52,6 +54,13 @@ describe("ConfigTabContainer", () => {
     expect(collections.props().csrfToken).to.equal("token");
     expect(collections.props().editOrCreate).to.equal("edit");
     expect(collections.props().identifier).to.equal("identifier");
+  });
+
+  it("shows AdminAuthServices", () => {
+    let adminAuthServices = wrapper.find("AdminAuthServices");
+    expect(adminAuthServices.props().csrfToken).to.equal("token");
+    expect(adminAuthServices.props().editOrCreate).to.equal("edit");
+    expect(adminAuthServices.props().identifier).to.equal("identifier");
   });
 
   it("uses router to navigate when tab is clicked", () => {

--- a/src/components/__tests__/EditableConfigList-test.tsx
+++ b/src/components/__tests__/EditableConfigList-test.tsx
@@ -4,26 +4,38 @@ import { stub } from "sinon";
 import * as React from "react";
 import { shallow } from "enzyme";
 
-import { Collections } from "../Collections";
+import { EditableConfigList, EditFormProps } from "../EditableConfigList";
 import ErrorMessage from "../ErrorMessage";
 import LoadingIndicator from "opds-web-client/lib/components/LoadingIndicator";
-import CollectionEditForm from "../CollectionEditForm";
 
-describe("Collections", () => {
+describe("EditableConfigList", () => {
+  interface Thing {
+    name: string;
+  }
+
+  interface Things {
+    things: Thing[];
+  }
+
+  class ThingEditForm extends React.Component<EditFormProps<Things, Thing>, void> {
+    render(): JSX.Element {
+      return <div>Test</div>;
+    }
+  }
+
+  class ThingEditableConfigList extends EditableConfigList<Things, Thing> {
+    EditForm = ThingEditForm;
+    listDataKey = "things";
+    itemTypeName = "thing";
+    urlBase = "/admin/things/";
+    identifierKey = "name";
+  }
+
   let wrapper;
   let fetchData;
   let editItem;
-  let collectionsData = [{
-    name: "name",
-    protocol: "OPDS Import",
-    url: "test.com",
-    libraries: [],
-  }];
-  let data = {
-    collections: collectionsData,
-    protocols: [{ name: "OPDS Import", fields: [] }],
-    allLibraries: []
-  };
+  let thingData = { name: "name" };
+  let thingsData = { things: [thingData] };
 
   const pause = () => {
     return new Promise<void>(resolve => setTimeout(resolve, 0));
@@ -34,8 +46,8 @@ describe("Collections", () => {
     editItem = stub().returns(new Promise<void>(resolve => resolve()));
 
     wrapper = shallow(
-      <Collections
-        data={data}
+      <ThingEditableConfigList
+        data={thingsData}
         fetchData={fetchData}
         editItem={editItem}
         csrfToken="token"
@@ -61,27 +73,27 @@ describe("Collections", () => {
     expect(loading.length).to.equal(1);
   });
 
-  it("shows collection list", () => {
-    let collection = wrapper.find("li");
-    expect(collection.length).to.equal(1);
-    expect(collection.text()).to.contain("name");
-    let editLink = collection.find("a");
-    expect(editLink.props().href).to.equal("/admin/web/config/collections/edit/name");
+  it("shows thing list", () => {
+    let thing = wrapper.find("li");
+    expect(thing.length).to.equal(1);
+    expect(thing.text()).to.contain("name");
+    let editLink = thing.find("a");
+    expect(editLink.props().href).to.equal("/admin/things/edit/name");
   });
 
   it("shows create link", () => {
     let createLink = wrapper.find("div > a");
     expect(createLink.length).to.equal(1);
-    expect(createLink.props().href).to.equal("/admin/web/config/collections/create");
+    expect(createLink.props().href).to.equal("/admin/things/create");
   });
 
   it("shows create form", () => {
-    let form = wrapper.find(CollectionEditForm);
+    let form = wrapper.find(ThingEditForm);
     expect(form.length).to.equal(0);
     wrapper.setProps({ editOrCreate: "create" });
-    form = wrapper.find(CollectionEditForm);
+    form = wrapper.find(ThingEditForm);
     expect(form.length).to.equal(1);
-    expect(form.props().data).to.deep.equal(data);
+    expect(form.props().data).to.deep.equal(thingsData);
     expect(form.props().item).to.be.undefined;
     expect(form.props().csrfToken).to.equal("token");
     expect(form.props().disabled).to.equal(false);
@@ -89,19 +101,19 @@ describe("Collections", () => {
 
   it("shows edit form", () => {
     wrapper.setProps({ editOrCreate: "edit", identifier: "name" });
-    let form = wrapper.find(CollectionEditForm);
+    let form = wrapper.find(ThingEditForm);
     expect(form.length).to.equal(1);
-    expect(form.props().data).to.deep.equal(data);
-    expect(form.props().item).to.equal(collectionsData[0]);
+    expect(form.props().data).to.deep.equal(thingsData);
+    expect(form.props().item).to.equal(thingData);
     expect(form.props().csrfToken).to.equal("token");
     expect(form.props().disabled).to.equal(false);
   });
 
-  it("fetches collections on mount and passes edit function to form", async () => {
+  it("fetches data on mount and passes edit function to form", async () => {
     expect(fetchData.callCount).to.equal(1);
 
     wrapper.setProps({ editOrCreate: "create" });
-    let form = wrapper.find(CollectionEditForm);
+    let form = wrapper.find(ThingEditForm);
 
     expect(editItem.callCount).to.equal(0);
     form.props().editItem();

--- a/src/components/__tests__/Libraries-test.tsx
+++ b/src/components/__tests__/Libraries-test.tsx
@@ -11,29 +11,31 @@ import LibraryEditForm from "../LibraryEditForm";
 
 describe("Libraries", () => {
   let wrapper;
-  let fetchLibraries;
-  let editLibrary;
-  let librariesData = [{
-    uuid: "uuid",
-    name: "name",
-    short_name: "short_name",
-    library_registry_short_name: "registry name",
-    library_registry_shared_secret: "secret"
-  }];
+  let fetchData;
+  let editItem;
+  let data = {
+    libraries: [{
+      uuid: "uuid",
+      name: "name",
+      short_name: "short_name",
+      library_registry_short_name: "registry name",
+      library_registry_shared_secret: "secret"
+    }]
+  };
 
   const pause = () => {
     return new Promise<void>(resolve => setTimeout(resolve, 0));
   };
 
   beforeEach(() => {
-    fetchLibraries = stub();
-    editLibrary = stub().returns(new Promise<void>(resolve => resolve()));
+    fetchData = stub();
+    editItem = stub().returns(new Promise<void>(resolve => resolve()));
 
     wrapper = shallow(
       <Libraries
-        libraries={librariesData}
-        fetchLibraries={fetchLibraries}
-        editLibrary={editLibrary}
+        data={data}
+        fetchData={fetchData}
+        editItem={editItem}
         csrfToken="token"
         isFetching={false}
         />
@@ -77,7 +79,8 @@ describe("Libraries", () => {
     wrapper.setProps({ editOrCreate: "create" });
     form = wrapper.find(LibraryEditForm);
     expect(form.length).to.equal(1);
-    expect(form.props().library).to.be.undefined;
+    expect(form.props().data).to.deep.equal(data);
+    expect(form.props().item).to.be.undefined;
     expect(form.props().csrfToken).to.equal("token");
     expect(form.props().disabled).to.equal(false);
   });
@@ -86,22 +89,23 @@ describe("Libraries", () => {
     wrapper.setProps({ editOrCreate: "edit", identifier: "uuid" });
     let form = wrapper.find(LibraryEditForm);
     expect(form.length).to.equal(1);
-    expect(form.props().library).to.equal(librariesData[0]);
+    expect(form.props().data).to.deep.equal(data);
+    expect(form.props().item).to.equal(data.libraries[0]);
     expect(form.props().csrfToken).to.equal("token");
     expect(form.props().disabled).to.equal(false);
   });
 
   it("fetches libraries on mount and passes edit function to form", async () => {
-    expect(fetchLibraries.callCount).to.equal(1);
+    expect(fetchData.callCount).to.equal(1);
 
     wrapper.setProps({ editOrCreate: "create" });
     let form = wrapper.find(LibraryEditForm);
 
-    expect(editLibrary.callCount).to.equal(0);
-    form.props().editLibrary();
-    expect(editLibrary.callCount).to.equal(1);
+    expect(editItem.callCount).to.equal(0);
+    form.props().editItem();
+    expect(editItem.callCount).to.equal(1);
 
     await pause();
-    expect(fetchLibraries.callCount).to.equal(2);
+    expect(fetchData.callCount).to.equal(2);
   });
 });

--- a/src/components/__tests__/LibraryEditForm-test.tsx
+++ b/src/components/__tests__/LibraryEditForm-test.tsx
@@ -30,9 +30,10 @@ describe("LibraryEditForm", () => {
       editLibrary = stub();
       wrapper = shallow(
         <LibraryEditForm
+          data={{ libraries: [libraryData] }}
           csrfToken="token"
           disabled={false}
-          editLibrary={editLibrary}
+          editItem={editLibrary}
           />
       );
     });
@@ -46,7 +47,7 @@ describe("LibraryEditForm", () => {
       let input = wrapper.find("input[name=\"uuid\"]");
       expect(input.props().value).not.to.be.ok;
 
-      wrapper.setProps({ library: libraryData });
+      wrapper.setProps({ item: libraryData });
       input = wrapper.find("input[name=\"uuid\"]");
       expect(input.props().value).to.equal("uuid");
     });
@@ -55,7 +56,7 @@ describe("LibraryEditForm", () => {
       let input = editableInputByName("name");
       expect(input.props().value).not.to.be.ok;
 
-      wrapper.setProps({ library: libraryData });
+      wrapper.setProps({ item: libraryData });
       input = editableInputByName("name");
       expect(input.props().value).to.equal("name");
     });
@@ -64,7 +65,7 @@ describe("LibraryEditForm", () => {
       let input = editableInputByName("short_name");
       expect(input.props().value).not.to.be.ok;
 
-      wrapper.setProps({ library: libraryData });
+      wrapper.setProps({ item: libraryData });
       input = editableInputByName("short_name");
       expect(input.props().value).to.equal("short_name");
     });
@@ -73,7 +74,7 @@ describe("LibraryEditForm", () => {
       let input = editableInputByName("library_registry_short_name");
       expect(input.props().value).not.to.be.ok;
 
-      wrapper.setProps({ library: libraryData });
+      wrapper.setProps({ item: libraryData });
       input = editableInputByName("library_registry_short_name");
       expect(input.props().value).to.equal("registry name");
     });
@@ -84,7 +85,7 @@ describe("LibraryEditForm", () => {
       expect(input.props().type).to.equal("checkbox");
 
       // it's still there if there's a library but no shared secret
-      wrapper.setProps({ library: libraryData });
+      wrapper.setProps({ item: libraryData });
       input = editableInputByName("random_library_registry_shared_secret");
       expect(input.props().label).to.contain("random");
       expect(input.props().type).to.equal("checkbox");
@@ -93,7 +94,7 @@ describe("LibraryEditForm", () => {
       libraryData = Object.assign({}, libraryData, {
         library_registry_shared_secret: "secret"
       });
-      wrapper.setProps({ library: libraryData });
+      wrapper.setProps({ item: libraryData });
       input = editableInputByName("random_library_registry_shared_secret");
       expect(input.length).to.equal(0);
     });
@@ -102,7 +103,7 @@ describe("LibraryEditForm", () => {
       let input = editableInputByName("library_registry_shared_secret");
       expect(input.props().value).not.to.be.ok;
 
-      wrapper.setProps({ library: libraryData });
+      wrapper.setProps({ item: libraryData });
       input = editableInputByName("library_registry_shared_secret");
       expect(input.props().value).to.equal("secret");
     });
@@ -113,9 +114,10 @@ describe("LibraryEditForm", () => {
       editLibrary = stub();
       wrapper = mount(
         <LibraryEditForm
+          data={{ libraries: [libraryData] }}
           csrfToken="token"
           disabled={false}
-          editLibrary={editLibrary}
+          editItem={editLibrary}
           />
       );
     });
@@ -135,7 +137,7 @@ describe("LibraryEditForm", () => {
     });
 
     it("submits data", () => {
-      wrapper.setProps({ library: libraryData });
+      wrapper.setProps({ item: libraryData });
 
       let form = wrapper.find("form");
       form.simulate("submit");

--- a/src/components/__tests__/Setup-test.tsx
+++ b/src/components/__tests__/Setup-test.tsx
@@ -1,0 +1,37 @@
+import { expect } from "chai";
+import { stub } from "sinon";
+
+import * as React from "react";
+import { shallow } from "enzyme";
+
+import buildStore from "../../store";
+import Setup from "../Setup";
+import AdminAuthServices from "../AdminAuthServices";
+
+describe("Setup", () => {
+  let wrapper;
+  let store;
+  let context;
+
+  beforeEach(() => {
+    store = buildStore();
+    context = {
+      editorStore: store,
+      csrfToken: "token"
+    };
+
+    wrapper = shallow(
+      <Setup />,
+      { context }
+    );
+  });
+
+  it("shows admin auth services create form", () => {
+    let adminAuthServices = wrapper.find(AdminAuthServices);
+    expect(adminAuthServices).to.be.ok;
+    expect(adminAuthServices.props().store).to.equal(store);
+    expect(adminAuthServices.props().csrfToken).to.equal("token");
+    expect(adminAuthServices.props().editOrCreate).to.equal("create");
+    expect(adminAuthServices.props().adminAuthService).to.be.undefined;
+  });
+});

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,6 +5,7 @@ import ContextProvider from "./components/ContextProvider";
 import CatalogHandler from "./components/CatalogHandler";
 import Dashboard from "./components/Dashboard";
 import Config from "./components/Config";
+import Setup from "./components/Setup";
 
 class CirculationWeb {
   constructor(config) {
@@ -14,16 +15,25 @@ class CirculationWeb {
 
     let editorPath = "/admin/web(/collection/:collectionUrl)(/book/:bookUrl)(/tab/:tab)";
 
-    ReactDOM.render(
-      <ContextProvider {...config}>
-        <Router history={browserHistory}>
-          <Route path={editorPath} component={CatalogHandler} />
-          <Route path="/admin/web/dashboard" component={Dashboard} />
-          <Route path="/admin/web/config(/:tab)(/:editOrCreate)(/:identifier)" component={Config} />
-        </Router>
-      </ContextProvider>,
-      document.getElementById("opds-catalog")
-    );
+    if (config.settingUp) {
+      ReactDOM.render(
+        <ContextProvider {...config}>
+          <Setup />
+        </ContextProvider>,
+        document.getElementById("opds-catalog")
+      );
+    } else {
+      ReactDOM.render(
+        <ContextProvider {...config}>
+          <Router history={browserHistory}>
+            <Route path={editorPath} component={CatalogHandler} />
+            <Route path="/admin/web/dashboard" component={Dashboard} />
+            <Route path="/admin/web/config(/:tab)(/:editOrCreate)(/:identifier)" component={Config} />
+          </Router>
+        </ContextProvider>,
+        document.getElementById("opds-catalog")
+      );
+    }
   }
 }
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -134,6 +134,7 @@ export interface ProtocolData {
 export interface CollectionsData {
   collections: CollectionData[];
   protocols: ProtocolData[];
+  allLibraries?: LibraryData[];
 }
 
 export interface PathFor {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -144,6 +144,7 @@ export interface PathFor {
 export interface AdminAuthServiceData {
   name: string;
   provider: string;
+  domains: string[];
   [key: string]: string | string[];
 }
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -139,3 +139,14 @@ export interface CollectionsData {
 export interface PathFor {
   (collectionUrl: string, bookUrl: string, tab?: string): string;
 }
+
+export interface AdminAuthServiceData {
+  name: string;
+  provider: string;
+  [key: string]: string | string[];
+}
+
+export interface AdminAuthServicesData {
+  admin_auth_services: AdminAuthServiceData[];
+  providers: string[];
+}

--- a/src/reducers/__tests__/adminAuthServices-test.ts
+++ b/src/reducers/__tests__/adminAuthServices-test.ts
@@ -1,0 +1,117 @@
+import { expect } from "chai";
+
+import reducer, { AdminAuthServicesState } from "../adminAuthServices";
+import { AdminAuthServicesData } from "../../interfaces";
+import ActionCreator from "../../actions";
+
+describe("admin auth services reducer", () => {
+  let adminAuthServicesData: AdminAuthServicesData = {
+    admin_auth_services: [{
+      name: "abcd",
+      provider: "OAuth provider",
+      domains: [],
+    }],
+    providers: [
+      "OAuth provider",
+      "some other provider"
+    ]
+  };
+
+  let initState: AdminAuthServicesState = {
+    data: null,
+    isFetching: false,
+    isEditing: false,
+    fetchError: null,
+    isLoaded: false
+  };
+
+  let errorState: AdminAuthServicesState = {
+    data: null,
+    isFetching: false,
+    isEditing: false,
+    fetchError: { status: 400, response: "test error", url: "test url" },
+    isLoaded: true
+  };
+
+  it("returns initial state for unrecognized action", () => {
+    expect(reducer(undefined, {})).to.deep.equal(initState);
+  });
+
+  it("handles ADMIN_AUTH_SERVICES_REQUEST", () => {
+    let action = { type: ActionCreator.ADMIN_AUTH_SERVICES_REQUEST, url: "test_url" };
+
+    // start with empty state
+    let newState = Object.assign({}, initState, {
+      isFetching: true
+    });
+    expect(reducer(initState, action)).to.deep.equal(newState);
+
+    // start with error state
+    newState = Object.assign({}, errorState, {
+      isFetching: true,
+      fetchError: null
+    });
+    expect(reducer(errorState, action)).to.deep.equal(newState);
+  });
+
+  it("handles ADMIN_AUTH_SERVICES_FAILURE", () => {
+    let action = { type: ActionCreator.ADMIN_AUTH_SERVICES_FAILURE, error: "test error" };
+    let oldState = Object.assign({}, initState, { isFetching: true });
+    let newState = Object.assign({}, oldState, {
+      fetchError: "test error",
+      isFetching: false,
+      isLoaded: true
+    });
+    expect(reducer(oldState, action)).to.deep.equal(newState);
+  });
+
+  it("handles ADMIN_AUTH_SERVICES_LOAD", () => {
+    let action = { type: ActionCreator.ADMIN_AUTH_SERVICES_LOAD, data: adminAuthServicesData };
+    let newState = Object.assign({}, initState, {
+      data: adminAuthServicesData,
+      isFetching: false,
+      isLoaded: true
+    });
+    expect(reducer(initState, action)).to.deep.equal(newState);
+  });
+
+  it("handles EDIT_ADMIN_AUTH_SERVICE_REQUEST", () => {
+    let action = { type: ActionCreator.EDIT_ADMIN_AUTH_SERVICE_REQUEST, url: "test url" };
+
+    // start with empty state
+    let newState = Object.assign({}, initState, {
+      isEditing: true
+    });
+    expect(reducer(initState, action)).to.deep.equal(newState);
+
+    // start with error state
+    newState = Object.assign({}, errorState, {
+      isEditing: true,
+      fetchError: null
+    });
+    expect(reducer(errorState, action)).to.deep.equal(newState);
+  });
+
+  it("handles EDIT_ADMIN_AUTH_SERVICE_FAILURE", () => {
+    let action = { type: ActionCreator.EDIT_ADMIN_AUTH_SERVICE_FAILURE, error: "test error" };
+    let oldState = Object.assign({}, initState, {
+      isEditing: true
+    });
+    let newState = Object.assign({}, oldState, {
+      fetchError: "test error",
+      isEditing: false
+    });
+    expect(reducer(oldState, action)).to.deep.equal(newState);
+  });
+
+  it("handles EDIT_ADMIN_AUTH_SERVICE_SUCCESS", () => {
+    let action = { type: ActionCreator.EDIT_ADMIN_AUTH_SERVICE_SUCCESS };
+    let oldState = Object.assign({}, initState, {
+      isEditing: true
+    });
+    let newState = Object.assign({}, oldState, {
+      isEditing: false
+    });
+    expect(reducer(oldState, action)).to.deep.equal(newState);
+  });
+});

--- a/src/reducers/adminAuthServices.ts
+++ b/src/reducers/adminAuthServices.ts
@@ -1,0 +1,64 @@
+import { RequestError } from "opds-web-client/lib/DataFetcher";
+import { AdminAuthServicesData } from "../interfaces";
+import ActionCreator from "../actions";
+
+export interface AdminAuthServicesState {
+  data: AdminAuthServicesData;
+  isFetching: boolean;
+  isEditing: boolean;
+  fetchError: RequestError;
+  isLoaded: boolean;
+}
+
+const initialState: AdminAuthServicesState = {
+  data: null,
+  isFetching: false,
+  isEditing: false,
+  fetchError: null,
+  isLoaded: false
+};
+
+export default(state: AdminAuthServicesState = initialState, action) => {
+  switch (action.type) {
+    case ActionCreator.ADMIN_AUTH_SERVICES_REQUEST:
+      return Object.assign({}, state, {
+        isFetching: true,
+        fetchError: null
+      });
+
+    case ActionCreator.ADMIN_AUTH_SERVICES_LOAD:
+      return Object.assign({}, state, {
+        data: action.data,
+        isFetching: false,
+        isLoaded: true
+      });
+
+    case ActionCreator.ADMIN_AUTH_SERVICES_FAILURE:
+      return Object.assign({}, state, {
+        fetchError: action.error,
+        isFetching: false,
+        isLoaded: true
+      });
+
+    case ActionCreator.EDIT_ADMIN_AUTH_SERVICE_REQUEST:
+      return Object.assign({}, state, {
+        isEditing: true,
+        fetchError: null
+      });
+
+    case ActionCreator.EDIT_ADMIN_AUTH_SERVICE_SUCCESS:
+      return Object.assign({}, state, {
+        isEditing: false,
+        fetchError: null
+      });
+
+    case ActionCreator.EDIT_ADMIN_AUTH_SERVICE_FAILURE:
+      return Object.assign({}, state, {
+        isEditing: false,
+        fetchError: action.error
+      });
+
+    default:
+      return state;
+  }
+};

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -6,6 +6,7 @@ import circulationEvents, { CirculationEventsState } from "./circulationEvents";
 import stats, { StatsState } from "./stats";
 import libraries, { LibrariesState } from "./libraries";
 import collections, { CollectionsState } from "./collections";
+import adminAuthServices, { AdminAuthServicesState } from "./adminAuthServices";
 
 export interface State {
   book: BookState;
@@ -15,6 +16,7 @@ export interface State {
   stats: StatsState;
   libraries: LibrariesState;
   collections: CollectionsState;
+  adminAuthServices: AdminAuthServicesState;
 }
 
 export default combineReducers<State>({
@@ -24,5 +26,6 @@ export default combineReducers<State>({
   circulationEvents,
   stats,
   libraries,
-  collections
+  collections,
+  adminAuthServices
 });

--- a/src/stylesheets/admin_auth_service_edit_form.scss
+++ b/src/stylesheets/admin_auth_service_edit_form.scss
@@ -1,0 +1,15 @@
+.add-domain {
+  margin-left: 10px;
+}
+
+.admin-auth-service-domain {
+  div {
+    display: inline-block;
+    margin-right: 10px;
+  }
+
+  i {
+    color: #AAA;
+    cursor: pointer;
+  }
+}

--- a/src/stylesheets/app.scss
+++ b/src/stylesheets/app.scss
@@ -1,6 +1,7 @@
 @import "../../node_modules/bootstrap/dist/css/bootstrap.css";
 @import "../../node_modules/font-awesome/css/font-awesome.min.css";
 @import "../../node_modules/opds-web-client/lib/stylesheets/app.scss";
+@import "admin_auth_service_edit_form";
 @import "book_details_container";
 @import "book_details_tab_container";
 @import "button_form";


### PR DESCRIPTION
This fixes #77 

I added a form to edit an existing admin auth config, as well as set up the app to go straight to that form when it's in initial setup mode. 

As part of this I refactored the code that's used to show a list of editable config items - now there's a parent class that's shared by libraries, collections, and admin auth services.