### PR TITLE
Moved individual admin creation to its own tab/form and removed name from admin auth services.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "Web Front-end for Library Simplified Circulation Manager",
   "repository": {
     "type": "git",

--- a/src/__tests__/actions-test.ts
+++ b/src/__tests__/actions-test.ts
@@ -549,4 +549,50 @@ describe("actions", () => {
       expect(fetchMock.args[0][1].body).to.equal(formData);
     });
   });
+
+  describe("fetchIndividualAdmins", () => {
+    it("dispatches request, load, and success", async () => {
+      const dispatch = stub();
+      const individualAdminsData = "individualAdmins";
+      fetcher.testData = {
+        ok: true,
+        status: 200,
+        json: () => new Promise<any>((resolve, reject) => {
+          resolve(individualAdminsData);
+        })
+      };
+      fetcher.resolve = true;
+
+      const data = await actions.fetchIndividualAdmins()(dispatch);
+      expect(dispatch.callCount).to.equal(3);
+      expect(dispatch.args[0][0].type).to.equal(ActionCreator.INDIVIDUAL_ADMINS_REQUEST);
+      expect(dispatch.args[1][0].type).to.equal(ActionCreator.INDIVIDUAL_ADMINS_SUCCESS);
+      expect(dispatch.args[2][0].type).to.equal(ActionCreator.INDIVIDUAL_ADMINS_LOAD);
+      expect(data).to.deep.equal(individualAdminsData);
+    });
+  });
+
+  describe("editIndividualAdmin", () => {
+    it("dispatches request and success", async () => {
+      const editIndividualAdminUrl = "/admin/individual_admins";
+      const dispatch = stub();
+      const formData = new (window as any).FormData();
+      formData.append("csrf_token", "token");
+      formData.append("email", "email");
+
+      const fetchMock = stub().returns(new Promise<any>((update, reject) => {
+        update({ status: 200 });
+      }));
+      fetch = fetchMock;
+
+      await actions.editIndividualAdmin(formData)(dispatch);
+      expect(dispatch.callCount).to.equal(2);
+      expect(dispatch.args[0][0].type).to.equal(ActionCreator.EDIT_INDIVIDUAL_ADMIN_REQUEST);
+      expect(dispatch.args[1][0].type).to.equal(ActionCreator.EDIT_INDIVIDUAL_ADMIN_SUCCESS);
+      expect(fetchMock.callCount).to.equal(1);
+      expect(fetchMock.args[0][0]).to.equal(editIndividualAdminUrl);
+      expect(fetchMock.args[0][1].method).to.equal("POST");
+      expect(fetchMock.args[0][1].body).to.equal(formData);
+    });
+  });
 });

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -2,7 +2,7 @@ import {
   BookData, ComplaintsData, GenreTree, ClassificationData,
   CirculationEventData, StatsData,
   LibrariesData, CollectionsData,
-  AdminAuthServicesData
+  AdminAuthServicesData, IndividualAdminsData
 } from "./interfaces";
 import DataFetcher from "opds-web-client/lib/DataFetcher";
 import { RequestError, RequestRejector } from "opds-web-client/lib/DataFetcher";
@@ -25,6 +25,8 @@ export default class ActionCreator extends BaseActionCreator {
   static readonly EDIT_COLLECTION = "EDIT_COLLECTION";
   static readonly ADMIN_AUTH_SERVICES = "ADMIN_AUTH_SERVICES";
   static readonly EDIT_ADMIN_AUTH_SERVICE = "EDIT_ADMIN_AUTH_SERVICE";
+  static readonly INDIVIDUAL_ADMINS = "INDIVIDUAL_ADMINS";
+  static readonly EDIT_INDIVIDUAL_ADMIN = "EDIT_INDIVIDUAL_ADMIN";
 
   static readonly EDIT_BOOK_REQUEST = "EDIT_BOOK_REQUEST";
   static readonly EDIT_BOOK_SUCCESS = "EDIT_BOOK_SUCCESS";
@@ -97,6 +99,15 @@ export default class ActionCreator extends BaseActionCreator {
   static readonly EDIT_ADMIN_AUTH_SERVICE_REQUEST = "EDIT_ADMIN_AUTH_SERVICE_REQUEST";
   static readonly EDIT_ADMIN_AUTH_SERVICE_SUCCESS = "EDIT_ADMIN_AUTH_SERVICE_SUCCESS";
   static readonly EDIT_ADMIN_AUTH_SERVICE_FAILURE = "EDIT_ADMIN_AUTH_SERVICE_FAILURE";
+
+  static readonly INDIVIDUAL_ADMINS_REQUEST = "INDIVIDUAL_ADMINS_REQUEST";
+  static readonly INDIVIDUAL_ADMINS_SUCCESS = "INDIVIDUAL_ADMINS_SUCCESS";
+  static readonly INDIVIDUAL_ADMINS_FAILURE = "INDIVIDUAL_ADMINS_FAILURE";
+  static readonly INDIVIDUAL_ADMINS_LOAD = "INDIVIDUAL_ADMINS_LOAD";
+
+  static readonly EDIT_INDIVIDUAL_ADMIN_REQUEST = "EDIT_INDIVIDUAL_ADMIN_REQUEST";
+  static readonly EDIT_INDIVIDUAL_ADMIN_SUCCESS = "EDIT_INDIVIDUAL_ADMIN_SUCCESS";
+  static readonly EDIT_INDIVIDUAL_ADMIN_FAILURE = "EDIT_INDIVIDUAL_ADMIN_FAILURE";
 
   constructor(fetcher?: DataFetcher) {
     fetcher = fetcher || new DataFetcher();
@@ -269,5 +280,15 @@ export default class ActionCreator extends BaseActionCreator {
   editAdminAuthService(data: FormData) {
     const url = "/admin/admin_auth_services";
     return this.postForm(ActionCreator.EDIT_ADMIN_AUTH_SERVICE, url, data).bind(this);
+  }
+
+  fetchIndividualAdmins() {
+    const url = "/admin/individual_admins";
+    return this.fetchJSON<IndividualAdminsData>(ActionCreator.INDIVIDUAL_ADMINS, url).bind(this);
+  }
+
+  editIndividualAdmin(data: FormData) {
+    const url = "/admin/individual_admins";
+    return this.postForm(ActionCreator.EDIT_INDIVIDUAL_ADMIN, url, data).bind(this);
   }
 }

--- a/src/components/AdminAuthServices.tsx
+++ b/src/components/AdminAuthServices.tsx
@@ -9,7 +9,8 @@ export class AdminAuthServices extends EditableConfigList<AdminAuthServicesData,
   listDataKey = "admin_auth_services";
   itemTypeName = "admin authentication service";
   urlBase = "/admin/web/config/adminAuth/";
-  identifierKey = "name";
+  identifierKey = "provider";
+  labelKey = "provider";
 }
 
 function mapStateToProps(state, ownProps) {

--- a/src/components/Collections.tsx
+++ b/src/components/Collections.tsx
@@ -10,6 +10,7 @@ export class Collections extends EditableConfigList<CollectionsData, CollectionD
   itemTypeName = "collection";
   urlBase = "/admin/web/config/collections/";
   identifierKey = "name";
+  labelKey = "name";
 }
 
 function mapStateToProps(state, ownProps) {

--- a/src/components/ConfigTabContainer.tsx
+++ b/src/components/ConfigTabContainer.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import Libraries from "./Libraries";
 import Collections from "./Collections";
 import AdminAuthServices from "./AdminAuthServices";
+import IndividualAdmins from "./IndividualAdmins";
 import { TabContainer, TabContainerProps } from "./TabContainer";
 
 export interface ConfigTabContainerProps extends TabContainerProps {
@@ -35,6 +36,14 @@ export default class ConfigTabContainer extends TabContainer<ConfigTabContainerP
           editOrCreate={this.props.editOrCreate}
           identifier={this.props.identifier}
           />
+      ),
+      individualAdmins: (
+        <IndividualAdmins
+          store={this.props.store}
+          csrfToken={this.props.csrfToken}
+          editOrCreate={this.props.editOrCreate}
+          identifier={this.props.identifier}
+          />
       )
     };
   }
@@ -49,6 +58,8 @@ export default class ConfigTabContainer extends TabContainer<ConfigTabContainerP
   tabDisplayName(name) {
     if (name === "adminAuth") {
       return "Admin Authentication";
+    } else if (name === "individualAdmins") {
+      return "Individual Admins";
     } else {
       return super.tabDisplayName(name);
     }

--- a/src/components/EditableConfigList.tsx
+++ b/src/components/EditableConfigList.tsx
@@ -31,6 +31,7 @@ export abstract class EditableConfigList<T, U> extends React.Component<EditableC
   abstract itemTypeName: string;
   abstract urlBase: string;
   abstract identifierKey: string;
+  abstract labelKey: string;
 
   constructor(props) {
     super(props);
@@ -39,7 +40,6 @@ export abstract class EditableConfigList<T, U> extends React.Component<EditableC
 
   render(): JSX.Element {
     let EditForm = this.EditForm;
-
     return (
       <div>
         { this.props.fetchError &&
@@ -55,7 +55,7 @@ export abstract class EditableConfigList<T, U> extends React.Component<EditableC
             <ul>
               { this.props.data[this.listDataKey].map((item, index) =>
                   <li key={index}>
-                    <h3>{item.name}</h3>
+                    <h3>{item[this.labelKey]}</h3>
                     <a href={this.urlBase + "edit/" + item[this.identifierKey]}>Edit {this.itemTypeName}</a>
                   </li>
                 )

--- a/src/components/IndividualAdminEditForm.tsx
+++ b/src/components/IndividualAdminEditForm.tsx
@@ -1,0 +1,79 @@
+import * as React from "react";
+import EditableInput from "./EditableInput";
+import { IndividualAdminsData, IndividualAdminData } from "../interfaces";
+
+export interface IndividualAdminEditFormProps {
+  data: IndividualAdminsData;
+  item?: IndividualAdminData;
+  csrfToken: string;
+  disabled: boolean;
+  editItem: (data: FormData) => Promise<void>;
+}
+
+export interface IndividualAdminEditFormContext {
+  settingUp: boolean;
+}
+
+export default class IndividualAdminEditForm extends React.Component<IndividualAdminEditFormProps, void> {
+  context: IndividualAdminEditFormContext;
+
+  static contextTypes: React.ValidationMap<IndividualAdminEditFormContext> = {
+    settingUp: React.PropTypes.bool.isRequired
+  };
+
+  constructor(props) {
+    super(props);
+    this.save = this.save.bind(this);
+  }
+
+  render(): JSX.Element {
+    return (
+      <form ref="form" onSubmit={this.save} className="edit-form">
+        <input
+          type="hidden"
+          name="csrf_token"
+          value={this.props.csrfToken}
+          />
+        <EditableInput
+          elementType="input"
+          type="text"
+          disabled={this.props.disabled}
+          readOnly={!!(this.props.item && this.props.item.email)}
+          name="email"
+          label="Email"
+          value={this.props.item && this.props.item.email}
+          />
+        <EditableInput
+          elementType="input"
+          type="text"
+          disabled={this.props.disabled}
+          name="password"
+          label="Password"
+          />
+        <button
+          type="submit"
+          className="btn btn-default"
+          disabled={this.props.disabled}
+          >Submit</button>
+      </form>
+    );
+  }
+
+  save(event) {
+    event.preventDefault();
+    const data = new (window as any).FormData(this.refs["form"] as any);
+    this.props.editItem(data).then(() => {
+      // If we're setting up an admin for the first time, refresh the page
+      // to go to login.
+      if (this.context.settingUp) {
+        window.location.reload();
+        return;
+      }
+
+      // If a new admin was created, go to its edit page.
+      if (!this.props.item && data.get("email")) {
+        window.location.href = "/admin/web/config/individualAdmins/edit/" + data.get("email");
+      }
+    });
+  }
+}

--- a/src/components/IndividualAdmins.tsx
+++ b/src/components/IndividualAdmins.tsx
@@ -1,0 +1,37 @@
+import EditableConfigList from "./EditableConfigList";
+import { connect } from "react-redux";
+import ActionCreator from "../actions";
+import { IndividualAdminsData, IndividualAdminData } from "../interfaces";
+import IndividualAdminEditForm from "./IndividualAdminEditForm";
+
+export class IndividualAdmins extends EditableConfigList<IndividualAdminsData, IndividualAdminData> {
+  EditForm = IndividualAdminEditForm;
+  listDataKey = "individualAdmins";
+  itemTypeName = "individual admin";
+  urlBase = "/admin/web/config/individualAdmins/";
+  identifierKey = "email";
+  labelKey = "email";
+}
+
+function mapStateToProps(state, ownProps) {
+  return {
+    data: state.editor.individualAdmins && state.editor.individualAdmins.data,
+    fetchError: state.editor.individualAdmins.fetchError,
+    isFetching: state.editor.individualAdmins.isFetching || state.editor.individualAdmins.isEditing
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  let actions = new ActionCreator();
+  return {
+    fetchData: () => dispatch(actions.fetchIndividualAdmins()),
+    editItem: (data: FormData) => dispatch(actions.editIndividualAdmin(data))
+  };
+}
+
+const ConnectedIndividualAdmins = connect<any, any, any>(
+  mapStateToProps,
+  mapDispatchToProps
+)(IndividualAdmins);
+
+export default ConnectedIndividualAdmins;

--- a/src/components/Libraries.tsx
+++ b/src/components/Libraries.tsx
@@ -10,6 +10,7 @@ export class Libraries extends EditableConfigList<LibrariesData, LibraryData> {
   itemTypeName = "library";
   urlBase = "/admin/web/config/libraries/";
   identifierKey = "uuid";
+  labelKey = "name";
 }
 
 function mapStateToProps(state, ownProps) {

--- a/src/components/Setup.tsx
+++ b/src/components/Setup.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { Store } from "redux";
 import AdminAuthServices from "./AdminAuthServices";
+import IndividualAdmins from "./IndividualAdmins";
 import { State } from "../reducers/index";
 
 export interface SetupContext {
@@ -18,11 +19,18 @@ export default class Setup extends React.Component<void, void> {
 
   render(): JSX.Element {
     return (
-      <AdminAuthServices
-        store={this.context.editorStore}
-        csrfToken={this.context.csrfToken}
-        editOrCreate="create"
-        />
+      <div>
+        <AdminAuthServices
+          store={this.context.editorStore}
+          csrfToken={this.context.csrfToken}
+          editOrCreate="create"
+          />
+        <IndividualAdmins
+          store={this.context.editorStore}
+          csrfToken={this.context.csrfToken}
+          editOrCreate="create"
+          />
+      </div>
     );
   }
 }

--- a/src/components/__tests__/AdminAuthServices-test.tsx
+++ b/src/components/__tests__/AdminAuthServices-test.tsx
@@ -15,7 +15,6 @@ describe("AdminAuthServices", () => {
   let editItem;
   let data = {
     admin_auth_services: [{
-      name: "name",
       provider: "OAuth provider",
       url: "test.com",
       username: "user",
@@ -64,9 +63,9 @@ describe("AdminAuthServices", () => {
   it("shows admin auth service list", () => {
     let adminAuthService = wrapper.find("li");
     expect(adminAuthService.length).to.equal(1);
-    expect(adminAuthService.text()).to.contain("name");
+    expect(adminAuthService.text()).to.contain("OAuth provider");
     let editLink = adminAuthService.find("a");
-    expect(editLink.props().href).to.equal("/admin/web/config/adminAuth/edit/name");
+    expect(editLink.props().href).to.equal("/admin/web/config/adminAuth/edit/OAuth provider");
   });
 
   it("shows create link", () => {
@@ -88,7 +87,7 @@ describe("AdminAuthServices", () => {
   });
 
   it("shows edit form", () => {
-    wrapper.setProps({ editOrCreate: "edit", identifier: "name" });
+    wrapper.setProps({ editOrCreate: "edit", identifier: "OAuth provider" });
     let form = wrapper.find(AdminAuthServiceEditForm);
     expect(form.length).to.equal(1);
     expect(form.props().data).to.deep.equal(data);

--- a/src/components/__tests__/ConfigTabContainer-test.tsx
+++ b/src/components/__tests__/ConfigTabContainer-test.tsx
@@ -9,6 +9,7 @@ import ConfigTabContainer from "../ConfigTabContainer";
 import Libraries from "../Libraries";
 import Collections from "../Collections";
 import AdminAuthServices from "../AdminAuthServices";
+import IndividualAdmins from "../IndividualAdmins";
 import { mockRouterContext } from "./routing";
 
 
@@ -40,27 +41,35 @@ describe("ConfigTabContainer", () => {
     expect(linkTexts).to.contain("Libraries");
     expect(linkTexts).to.contain("Collections");
     expect(linkTexts).to.contain("Admin Authentication");
+    expect(linkTexts).to.contain("Individual Admins");
   });
 
   it("shows Libraries", () => {
-    let libraries = wrapper.find("Libraries");
+    let libraries = wrapper.find(Libraries);
     expect(libraries.props().csrfToken).to.equal("token");
     expect(libraries.props().editOrCreate).to.equal("edit");
     expect(libraries.props().identifier).to.equal("identifier");
   });
 
   it("shows Collections", () => {
-    let collections = wrapper.find("Collections");
+    let collections = wrapper.find(Collections);
     expect(collections.props().csrfToken).to.equal("token");
     expect(collections.props().editOrCreate).to.equal("edit");
     expect(collections.props().identifier).to.equal("identifier");
   });
 
   it("shows AdminAuthServices", () => {
-    let adminAuthServices = wrapper.find("AdminAuthServices");
+    let adminAuthServices = wrapper.find(AdminAuthServices);
     expect(adminAuthServices.props().csrfToken).to.equal("token");
     expect(adminAuthServices.props().editOrCreate).to.equal("edit");
     expect(adminAuthServices.props().identifier).to.equal("identifier");
+  });
+
+  it("shows IndividualAdmins", () => {
+    let individualAdmins = wrapper.find(IndividualAdmins);
+    expect(individualAdmins.props().csrfToken).to.equal("token");
+    expect(individualAdmins.props().editOrCreate).to.equal("edit");
+    expect(individualAdmins.props().identifier).to.equal("identifier");
   });
 
   it("uses router to navigate when tab is clicked", () => {

--- a/src/components/__tests__/IndividualAdminEditForm-test.tsx
+++ b/src/components/__tests__/IndividualAdminEditForm-test.tsx
@@ -1,0 +1,94 @@
+import { expect } from "chai";
+import { stub } from "sinon";
+
+import * as React from "react";
+import { shallow, mount } from "enzyme";
+
+import IndividualAdminEditForm from "../IndividualAdminEditForm";
+import EditableInput from "../EditableInput";
+
+describe("IndividualAdminEditForm", () => {
+  let wrapper;
+  let editIndividualAdmin;
+  let adminData = {
+    email: "test@nypl.org",
+    password: "password"
+  };
+
+  let editableInputByName = (name) => {
+    let inputs = wrapper.find(EditableInput);
+    if (inputs.length >= 1) {
+      return inputs.filterWhere(input => input.props().name === name);
+    }
+    return [];
+  };
+
+  describe("rendering", () => {
+    beforeEach(() => {
+      editIndividualAdmin = stub();
+      wrapper = shallow(
+        <IndividualAdminEditForm
+          data={{ individualAdmins: [adminData] }}
+          csrfToken="token"
+          disabled={false}
+          editItem={editIndividualAdmin}
+          />
+      );
+    });
+
+    it("renders hidden csrf token", () => {
+      let input = wrapper.find("input[name=\"csrf_token\"]");
+      expect(input.props().value).to.equal("token");
+    });
+
+    it("renders email", () => {
+      let input = editableInputByName("email");
+      expect(input.props().value).not.to.be.ok;
+
+      wrapper.setProps({ item: adminData });
+      input = editableInputByName("email");
+      expect(input.props().value).to.equal("test@nypl.org");
+    });
+
+    it("renders password", () => {
+      let input = editableInputByName("password");
+      expect(input.props().value).not.to.be.ok;
+
+      wrapper.setProps({ item: adminData });
+      input = editableInputByName("password");
+      // Doesn't show the old password even if it's in the props.
+      expect(input.props().value).not.to.be.ok;
+    });
+  });
+
+  describe("behavior", () => {
+    beforeEach(() => {
+      editIndividualAdmin = stub().returns(new Promise<void>(resolve => resolve()));
+      wrapper = mount(
+        <IndividualAdminEditForm
+          data={{ individualAdmins: [adminData] }}
+          csrfToken="token"
+          disabled={false}
+          editItem={editIndividualAdmin}
+          />
+      );
+    });
+
+    it("submits data", () => {
+      wrapper.setProps({ item: adminData });
+      let input = wrapper.find("input[name='password']");
+      let inputElement = input.get(0);
+      inputElement.value = "newPassword";
+      input.simulate("change");
+
+      let form = wrapper.find("form");
+      form.simulate("submit");
+
+      expect(editIndividualAdmin.callCount).to.equal(1);
+      let formData = editIndividualAdmin.args[0][0];
+      expect(formData.get("csrf_token")).to.equal("token");
+      expect(formData.get("email")).to.equal("test@nypl.org");
+      expect(formData.get("password")).to.equal("newPassword");
+    });
+  });
+});

--- a/src/components/__tests__/IndividualAdmins-test.tsx
+++ b/src/components/__tests__/IndividualAdmins-test.tsx
@@ -4,40 +4,20 @@ import { stub } from "sinon";
 import * as React from "react";
 import { shallow } from "enzyme";
 
-import { EditableConfigList, EditFormProps } from "../EditableConfigList";
+import { IndividualAdmins } from "../IndividualAdmins";
 import ErrorMessage from "../ErrorMessage";
 import LoadingIndicator from "opds-web-client/lib/components/LoadingIndicator";
+import IndividualAdminEditForm from "../IndividualAdminEditForm";
 
-describe("EditableConfigList", () => {
-  interface Thing {
-    name: string;
-    label: string;
-  }
-
-  interface Things {
-    things: Thing[];
-  }
-
-  class ThingEditForm extends React.Component<EditFormProps<Things, Thing>, void> {
-    render(): JSX.Element {
-      return <div>Test</div>;
-    }
-  }
-
-  class ThingEditableConfigList extends EditableConfigList<Things, Thing> {
-    EditForm = ThingEditForm;
-    listDataKey = "things";
-    itemTypeName = "thing";
-    urlBase = "/admin/things/";
-    identifierKey = "name";
-    labelKey = "label";
-  }
-
+describe("IndividualAdmins", () => {
   let wrapper;
   let fetchData;
   let editItem;
-  let thingData = { name: "name", label: "label" };
-  let thingsData = { things: [thingData] };
+  let data = {
+    individualAdmins: [{
+      email: "test@nypl.org"
+    }]
+  };
 
   const pause = () => {
     return new Promise<void>(resolve => setTimeout(resolve, 0));
@@ -48,8 +28,8 @@ describe("EditableConfigList", () => {
     editItem = stub().returns(new Promise<void>(resolve => resolve()));
 
     wrapper = shallow(
-      <ThingEditableConfigList
-        data={thingsData}
+      <IndividualAdmins
+        data={data}
         fetchData={fetchData}
         editItem={editItem}
         csrfToken="token"
@@ -75,47 +55,47 @@ describe("EditableConfigList", () => {
     expect(loading.length).to.equal(1);
   });
 
-  it("shows thing list", () => {
-    let thing = wrapper.find("li");
-    expect(thing.length).to.equal(1);
-    expect(thing.text()).to.contain("label");
-    let editLink = thing.find("a");
-    expect(editLink.props().href).to.equal("/admin/things/edit/name");
+  it("shows individual admin list", () => {
+    let admin = wrapper.find("li");
+    expect(admin.length).to.equal(1);
+    expect(admin.text()).to.contain("test@nypl.org");
+    let editLink = admin.find("a");
+    expect(editLink.props().href).to.equal("/admin/web/config/individualAdmins/edit/test@nypl.org");
   });
 
   it("shows create link", () => {
     let createLink = wrapper.find("div > a");
     expect(createLink.length).to.equal(1);
-    expect(createLink.props().href).to.equal("/admin/things/create");
+    expect(createLink.props().href).to.equal("/admin/web/config/individualAdmins/create");
   });
 
   it("shows create form", () => {
-    let form = wrapper.find(ThingEditForm);
+    let form = wrapper.find(IndividualAdminEditForm);
     expect(form.length).to.equal(0);
     wrapper.setProps({ editOrCreate: "create" });
-    form = wrapper.find(ThingEditForm);
+    form = wrapper.find(IndividualAdminEditForm);
     expect(form.length).to.equal(1);
-    expect(form.props().data).to.deep.equal(thingsData);
+    expect(form.props().data).to.deep.equal(data);
     expect(form.props().item).to.be.undefined;
     expect(form.props().csrfToken).to.equal("token");
     expect(form.props().disabled).to.equal(false);
   });
 
   it("shows edit form", () => {
-    wrapper.setProps({ editOrCreate: "edit", identifier: "name" });
-    let form = wrapper.find(ThingEditForm);
+    wrapper.setProps({ editOrCreate: "edit", identifier: "test@nypl.org" });
+    let form = wrapper.find(IndividualAdminEditForm);
     expect(form.length).to.equal(1);
-    expect(form.props().data).to.deep.equal(thingsData);
-    expect(form.props().item).to.equal(thingData);
+    expect(form.props().data).to.deep.equal(data);
+    expect(form.props().item).to.equal(data.individualAdmins[0]);
     expect(form.props().csrfToken).to.equal("token");
     expect(form.props().disabled).to.equal(false);
   });
 
-  it("fetches data on mount and passes edit function to form", async () => {
+  it("fetches individual admins on mount and passes edit function to form", async () => {
     expect(fetchData.callCount).to.equal(1);
 
     wrapper.setProps({ editOrCreate: "create" });
-    let form = wrapper.find(ThingEditForm);
+    let form = wrapper.find(IndividualAdminEditForm);
 
     expect(editItem.callCount).to.equal(0);
     form.props().editItem();

--- a/src/components/__tests__/Setup-test.tsx
+++ b/src/components/__tests__/Setup-test.tsx
@@ -7,6 +7,7 @@ import { shallow } from "enzyme";
 import buildStore from "../../store";
 import Setup from "../Setup";
 import AdminAuthServices from "../AdminAuthServices";
+import IndividualAdmins from "../IndividualAdmins";
 
 describe("Setup", () => {
   let wrapper;
@@ -32,6 +33,15 @@ describe("Setup", () => {
     expect(adminAuthServices.props().store).to.equal(store);
     expect(adminAuthServices.props().csrfToken).to.equal("token");
     expect(adminAuthServices.props().editOrCreate).to.equal("create");
-    expect(adminAuthServices.props().adminAuthService).to.be.undefined;
+    expect(adminAuthServices.props().identifier).to.be.undefined;
+  });
+
+  it("shows individual admins create form", () => {
+    let individualAdmins = wrapper.find(IndividualAdmins);
+    expect(individualAdmins).to.be.ok;
+    expect(individualAdmins.props().store).to.equal(store);
+    expect(individualAdmins.props().csrfToken).to.equal("token");
+    expect(individualAdmins.props().editOrCreate).to.equal("create");
+    expect(individualAdmins.props().identifier).to.be.undefined;
   });
 });

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -141,22 +141,24 @@ export interface PathFor {
   (collectionUrl: string, bookUrl: string, tab?: string): string;
 }
 
-export interface AdminData {
-  email: string;
-  password?: string;
-}
-
 export interface AdminAuthServiceData {
-  name: string;
   provider: string;
   url?: string;
   username?: string;
   password?: string;
   domains?: string[];
-  admins?: AdminData[];
 }
 
 export interface AdminAuthServicesData {
   admin_auth_services: AdminAuthServiceData[];
   providers: string[];
+}
+
+export interface IndividualAdminData {
+  email: string;
+  password?: string;
+}
+
+export interface IndividualAdminsData {
+  individualAdmins?: IndividualAdminData[];
 }

--- a/src/reducers/__tests__/individualAdmins-test.ts
+++ b/src/reducers/__tests__/individualAdmins-test.ts
@@ -1,22 +1,17 @@
 import { expect } from "chai";
 
-import reducer, { AdminAuthServicesState } from "../adminAuthServices";
-import { AdminAuthServicesData } from "../../interfaces";
+import reducer, { IndividualAdminsState } from "../individualAdmins";
+import { IndividualAdminsData } from "../../interfaces";
 import ActionCreator from "../../actions";
 
-describe("admin auth services reducer", () => {
-  let adminAuthServicesData: AdminAuthServicesData = {
-    admin_auth_services: [{
-      provider: "OAuth provider",
-      domains: [],
-    }],
-    providers: [
-      "OAuth provider",
-      "some other provider"
-    ]
+describe("individual admins reducer", () => {
+  let individualAdminsData: IndividualAdminsData = {
+    individualAdmins: [{
+      email: "test@nypl.org"
+    }]
   };
 
-  let initState: AdminAuthServicesState = {
+  let initState: IndividualAdminsState = {
     data: null,
     isFetching: false,
     isEditing: false,
@@ -24,7 +19,7 @@ describe("admin auth services reducer", () => {
     isLoaded: false
   };
 
-  let errorState: AdminAuthServicesState = {
+  let errorState: IndividualAdminsState = {
     data: null,
     isFetching: false,
     isEditing: false,
@@ -36,8 +31,8 @@ describe("admin auth services reducer", () => {
     expect(reducer(undefined, {})).to.deep.equal(initState);
   });
 
-  it("handles ADMIN_AUTH_SERVICES_REQUEST", () => {
-    let action = { type: ActionCreator.ADMIN_AUTH_SERVICES_REQUEST, url: "test_url" };
+  it("handles INDIVIDUAL_ADMINS_REQUEST", () => {
+    let action = { type: ActionCreator.INDIVIDUAL_ADMINS_REQUEST, url: "test_url" };
 
     // start with empty state
     let newState = Object.assign({}, initState, {
@@ -53,8 +48,8 @@ describe("admin auth services reducer", () => {
     expect(reducer(errorState, action)).to.deep.equal(newState);
   });
 
-  it("handles ADMIN_AUTH_SERVICES_FAILURE", () => {
-    let action = { type: ActionCreator.ADMIN_AUTH_SERVICES_FAILURE, error: "test error" };
+  it("handles INDIVIDUAL_ADMINS_FAILURE", () => {
+    let action = { type: ActionCreator.INDIVIDUAL_ADMINS_FAILURE, error: "test error" };
     let oldState = Object.assign({}, initState, { isFetching: true });
     let newState = Object.assign({}, oldState, {
       fetchError: "test error",
@@ -64,18 +59,18 @@ describe("admin auth services reducer", () => {
     expect(reducer(oldState, action)).to.deep.equal(newState);
   });
 
-  it("handles ADMIN_AUTH_SERVICES_LOAD", () => {
-    let action = { type: ActionCreator.ADMIN_AUTH_SERVICES_LOAD, data: adminAuthServicesData };
+  it("handles INDIVIDUAL_ADMINS_LOAD", () => {
+    let action = { type: ActionCreator.INDIVIDUAL_ADMINS_LOAD, data: individualAdminsData };
     let newState = Object.assign({}, initState, {
-      data: adminAuthServicesData,
+      data: individualAdminsData,
       isFetching: false,
       isLoaded: true
     });
     expect(reducer(initState, action)).to.deep.equal(newState);
   });
 
-  it("handles EDIT_ADMIN_AUTH_SERVICE_REQUEST", () => {
-    let action = { type: ActionCreator.EDIT_ADMIN_AUTH_SERVICE_REQUEST, url: "test url" };
+  it("handles EDIT_INDIVIDUAL_ADMIN_REQUEST", () => {
+    let action = { type: ActionCreator.EDIT_INDIVIDUAL_ADMIN_REQUEST, url: "test url" };
 
     // start with empty state
     let newState = Object.assign({}, initState, {
@@ -91,8 +86,8 @@ describe("admin auth services reducer", () => {
     expect(reducer(errorState, action)).to.deep.equal(newState);
   });
 
-  it("handles EDIT_ADMIN_AUTH_SERVICE_FAILURE", () => {
-    let action = { type: ActionCreator.EDIT_ADMIN_AUTH_SERVICE_FAILURE, error: "test error" };
+  it("handles EDIT_INDIVIDUAL_ADMIN_FAILURE", () => {
+    let action = { type: ActionCreator.EDIT_INDIVIDUAL_ADMIN_FAILURE, error: "test error" };
     let oldState = Object.assign({}, initState, {
       isEditing: true
     });
@@ -103,8 +98,8 @@ describe("admin auth services reducer", () => {
     expect(reducer(oldState, action)).to.deep.equal(newState);
   });
 
-  it("handles EDIT_ADMIN_AUTH_SERVICE_SUCCESS", () => {
-    let action = { type: ActionCreator.EDIT_ADMIN_AUTH_SERVICE_SUCCESS };
+  it("handles EDIT_INDIVIDUAL_ADMIN_SUCCESS", () => {
+    let action = { type: ActionCreator.EDIT_INDIVIDUAL_ADMIN_SUCCESS };
     let oldState = Object.assign({}, initState, {
       isEditing: true
     });

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -7,6 +7,7 @@ import stats, { StatsState } from "./stats";
 import libraries, { LibrariesState } from "./libraries";
 import collections, { CollectionsState } from "./collections";
 import adminAuthServices, { AdminAuthServicesState } from "./adminAuthServices";
+import individualAdmins, { IndividualAdminsState } from "./individualAdmins";
 
 export interface State {
   book: BookState;
@@ -17,6 +18,7 @@ export interface State {
   libraries: LibrariesState;
   collections: CollectionsState;
   adminAuthServices: AdminAuthServicesState;
+  individualAdmins: IndividualAdminsState;
 }
 
 export default combineReducers<State>({
@@ -27,5 +29,6 @@ export default combineReducers<State>({
   stats,
   libraries,
   collections,
-  adminAuthServices
+  adminAuthServices,
+  individualAdmins
 });

--- a/src/reducers/individualAdmins.ts
+++ b/src/reducers/individualAdmins.ts
@@ -1,0 +1,64 @@
+import { RequestError } from "opds-web-client/lib/DataFetcher";
+import { IndividualAdminsData } from "../interfaces";
+import ActionCreator from "../actions";
+
+export interface IndividualAdminsState {
+  data: IndividualAdminsData;
+  isFetching: boolean;
+  isEditing: boolean;
+  fetchError: RequestError;
+  isLoaded: boolean;
+}
+
+const initialState: IndividualAdminsState = {
+  data: null,
+  isFetching: false,
+  isEditing: false,
+  fetchError: null,
+  isLoaded: false
+};
+
+export default(state: IndividualAdminsState = initialState, action) => {
+  switch (action.type) {
+    case ActionCreator.INDIVIDUAL_ADMINS_REQUEST:
+      return Object.assign({}, state, {
+        isFetching: true,
+        fetchError: null
+      });
+
+    case ActionCreator.INDIVIDUAL_ADMINS_LOAD:
+      return Object.assign({}, state, {
+        data: action.data,
+        isFetching: false,
+        isLoaded: true
+      });
+
+    case ActionCreator.INDIVIDUAL_ADMINS_FAILURE:
+      return Object.assign({}, state, {
+        fetchError: action.error,
+        isFetching: false,
+        isLoaded: true
+      });
+
+    case ActionCreator.EDIT_INDIVIDUAL_ADMIN_REQUEST:
+      return Object.assign({}, state, {
+        isEditing: true,
+        fetchError: null
+      });
+
+    case ActionCreator.EDIT_INDIVIDUAL_ADMIN_SUCCESS:
+      return Object.assign({}, state, {
+        isEditing: false,
+        fetchError: null
+      });
+
+    case ActionCreator.EDIT_INDIVIDUAL_ADMIN_FAILURE:
+      return Object.assign({}, state, {
+        isEditing: false,
+        fetchError: action.error
+      });
+
+    default:
+      return state;
+  }
+};


### PR DESCRIPTION
This supports https://github.com/NYPL-Simplified/circulation/pull/504