### PR TITLE
Enabled and default facet config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "description": "Web Front-end for Library Simplified Circulation Manager",
   "repository": {
     "type": "git",

--- a/src/components/EditableInput.tsx
+++ b/src/components/EditableInput.tsx
@@ -10,7 +10,8 @@ export default class EditableInput extends React.Component<EditableInputProps, a
   constructor(props) {
     super(props);
     this.state = {
-      value: props.value || ""
+      value: props.value || "",
+      checked: props.checked || false
     };
     this.handleChange = this.handleChange.bind(this);
   }
@@ -42,6 +43,7 @@ export default class EditableInput extends React.Component<EditableInputProps, a
       name: this.props.name,
       ref: "element",
       value: this.state.value,
+      checked: this.state.checked,
       onChange: this.handleChange,
       style: this.props.style,
       placeholder: this.props.placeholder,
@@ -54,13 +56,24 @@ export default class EditableInput extends React.Component<EditableInputProps, a
         value: props.value || ""
       });
     }
+    if (props.checked !== this.props.checked) {
+      this.setState({
+        checked: props.checked || false
+      });
+    }
   }
 
   handleChange() {
     if (!this.props.readOnly && (!this.props.onChange || this.props.onChange() !== false)) {
-      this.setState({
-        value: this.getValue()
-      });
+      if (this.props.type === "checkbox") {
+        this.setState({
+          checked: !this.state.checked
+        });
+      } else {
+        this.setState({
+          value: this.getValue()
+        });
+      }
     }
   }
 
@@ -69,6 +82,6 @@ export default class EditableInput extends React.Component<EditableInputProps, a
   }
 
   clear() {
-    this.setState({ value: "" });
+    this.setState({ value: "", checked: false });
   }
 }

--- a/src/components/LibraryEditForm.tsx
+++ b/src/components/LibraryEditForm.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import EditableInput from "./EditableInput";
+import ProtocolFormField from "./ProtocolFormField";
 import { LibrariesData, LibraryData } from "../interfaces";
 
 export interface LibraryEditFormProps {
@@ -82,12 +83,9 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
             />
         }
         { this.props.data && this.props.data.settings && this.props.data.settings.map(setting =>
-          <EditableInput
-            elementType="input"
-            type="text"
+          <ProtocolFormField
+            field={setting}
             disabled={this.props.disabled}
-            name={setting.key}
-            label={setting.label}
             value={this.props.item && this.props.item.settings && this.props.item.settings[setting.key]}
             />
           )

--- a/src/components/PatronAuthServiceEditForm.tsx
+++ b/src/components/PatronAuthServiceEditForm.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import EditableInput from "./EditableInput";
+import ProtocolFormField from "./ProtocolFormField";
 import { PatronAuthServiceLibrary, PatronAuthServicesData, PatronAuthServiceData, ProtocolData } from "../interfaces";
 
 export interface PatronAuthServiceEditFormProps {
@@ -66,33 +67,11 @@ export default class PatronAuthServiceEditForm extends React.Component<PatronAut
           <p>{ this.protocolDescription() }</p>
         }
         { this.props.data && this.props.data.protocols && this.protocolFields() && this.protocolFields().map(field =>
-            <div key={field.key}>
-              { field.type === "text" || field.type === undefined &&
-                <EditableInput
-                  elementType="input"
-                  type="text"
-                  disabled={this.props.disabled}
-                  name={field.key}
-                  label={field.label + (field.optional ? " (optional)" : "")}
-                  value={this.props.item && this.props.item.settings && this.props.item.settings[field.key]}
-                  />
-              }
-              { field.type === "select" &&
-                <EditableInput
-                  elementType="select"
-                  disabled={this.props.disabled}
-                  readOnly={!!(this.props.item && this.props.item[field.key])}
-                  name={field.key}
-                  label={field.label + (field.optional ? " (optional)" : "")}
-                  value={this.props.item && this.props.item.settings && this.props.item.settings[field.key]}
-                  >
-                  { field.options && field.options.map(option =>
-                      <option key={option.key} value={option.key}>{option.label}</option>
-                    )
-                  }
-                </EditableInput>
-              }
-            </div>
+            <ProtocolFormField
+              field={field}
+              disabled={this.props.disabled}
+              value={this.props.item && this.props.item.settings && this.props.item.settings[field.key]}
+              />
           )
         }
         <div class="form-group">
@@ -127,33 +106,11 @@ export default class PatronAuthServiceEditForm extends React.Component<PatronAut
               }
             </select>
            { this.props.data && this.props.data.protocols && this.protocolLibraryFields() && this.protocolLibraryFields().map(field =>
-                <div key={field.key}>
-                  { field.type === "text" || field.type === undefined &&
-                    <EditableInput
-                      elementType="input"
-                      type="text"
-                      disabled={this.props.disabled}
-                      name={field.key}
-                      label={field.label + (field.optional ? " (optional)" : "")}
-                      ref={field.key}
-                      />
-                  }
-                  { field.type === "select" &&
-                    <EditableInput
-                      elementType="select"
-                      disabled={this.props.disabled}
-                      readOnly={!!(this.props.item && this.props.item[field.key])}
-                      name={field.key}
-                      label={field.label + (field.optional ? " (optional)" : "")}
-                      ref={field.key}
-                      >
-                      { field.options && field.options.map(option =>
-                          <option key={option.key} value={option.key}>{option.label}</option>
-                        )
-                      }
-                    </EditableInput>
-                  }
-                </div>
+                <ProtocolFormField
+                  field={field}
+                  disabled={this.props.disabled}
+                  ref={field.key}
+                  />
               )
             }
             <button

--- a/src/components/ProtocolFormField.tsx
+++ b/src/components/ProtocolFormField.tsx
@@ -1,0 +1,48 @@
+import * as React from "react";
+import EditableInput from "./EditableInput";
+import { ProtocolField } from "../interfaces";
+
+export interface ProtocolFormFieldProps {
+  field: ProtocolField;
+  disabled: boolean;
+  value?: string;
+}
+
+export default class ProtocolFormField extends React.Component<ProtocolFormFieldProps, void> {
+  render(): JSX.Element {
+    const field = this.props.field;
+    if (field.type === "text" || field.type === undefined) {
+      return (
+        <EditableInput
+          elementType="input"
+          type="text"
+          disabled={this.props.disabled}
+          name={field.key}
+          label={field.label + (field.optional ? " (optional)" : "")}
+          value={this.props.value}
+          ref="element"
+          />
+      );
+    } else if (field.type === "select") {
+      return (
+        <EditableInput
+          elementType="select"
+          disabled={this.props.disabled}
+          name={field.key}
+          label={field.label + (field.optional ? " (optional)" : "")}
+          value={this.props.value}
+          ref="element"
+          >
+          { field.options && field.options.map(option =>
+              <option key={option.key} value={option.key}>{option.label}</option>
+            )
+          }
+        </EditableInput>
+      );
+    }
+  }
+
+  getValue() {
+    return (this.refs["element"] as any).getValue();
+  }
+}

--- a/src/components/ProtocolFormField.tsx
+++ b/src/components/ProtocolFormField.tsx
@@ -5,7 +5,7 @@ import { ProtocolField } from "../interfaces";
 export interface ProtocolFormFieldProps {
   field: ProtocolField;
   disabled: boolean;
-  value?: string;
+  value?: string | string[];
 }
 
 export default class ProtocolFormField extends React.Component<ProtocolFormFieldProps, void> {
@@ -38,6 +38,23 @@ export default class ProtocolFormField extends React.Component<ProtocolFormField
             )
           }
         </EditableInput>
+      );
+    } else if (field.type === "list") {
+      return (
+        <div>
+          <h3>{field.label}</h3>
+          { field.options && field.options.map(option =>
+              <EditableInput
+                elementType="input"
+                type="checkbox"
+                disabled={this.props.disabled}
+                name={`${field.key}_${option.key}`}
+                label={option.label}
+                checked={this.props.value && (this.props.value.indexOf(option.key) !== -1)}
+                />
+            )
+          }
+        </div>
       );
     }
   }

--- a/src/components/__tests__/EditableInput-test.tsx
+++ b/src/components/__tests__/EditableInput-test.tsx
@@ -17,6 +17,7 @@ describe("EditableInput", () => {
         label="label"
         name="name"
         disabled={false}
+        checked={true}
         value="initial value">
         <option>option</option>
       </EditableInput>
@@ -32,6 +33,7 @@ describe("EditableInput", () => {
     expect(wrapper.state().value).to.equal("initial value");
     let input = wrapper.find("input");
     expect(input.prop("value")).to.equal("initial value");
+    expect(input.prop("checked")).to.equal(true);
   });
 
   it("shows children from props", () => {
@@ -40,10 +42,12 @@ describe("EditableInput", () => {
   });
 
   it("updates state and value when props change", () => {
-    wrapper.setProps({ value: "new value" });
+    wrapper.setProps({ value: "new value", checked: false });
     expect(wrapper.state().value).to.equal("new value");
+    expect(wrapper.state().checked).to.equal(false);
     let input = wrapper.find("input");
     expect(input.prop("value")).to.equal("new value");
+    expect(input.prop("checked")).to.equal(false);
   });
 
   it("updates value in state when input changes", () => {
@@ -62,6 +66,23 @@ describe("EditableInput", () => {
     inputElement.value = "new value";
     input.simulate("change");
     expect(wrapper.state().value).to.equal("new value");
+
+    // This also works with a checkbox.
+    wrapper = mount(
+      <EditableInput
+        elementType="input"
+        type="checkbox"
+        label="label"
+        name="name"
+        disabled={false}
+        checked={true}
+        />
+    );
+    input = wrapper.find("input");
+    inputElement = input.get(0) as any;
+    inputElement.checked = false;
+    input.simulate("change");
+    expect(wrapper.state().checked).to.equal(false);
   });
 
   it("disables", () => {
@@ -114,7 +135,9 @@ describe("EditableInput", () => {
 
     (wrapper.instance() as EditableInput).clear();
     expect(wrapper.state("value")).to.equal("");
+    expect(wrapper.state("checked")).to.equal(false);
     let inputElement = wrapper.find("input").get(0) as any;
     expect(inputElement.value).to.equal("");
+    expect(inputElement.checked).to.equal(false);
   });
 });

--- a/src/components/__tests__/LibraryEditForm-test.tsx
+++ b/src/components/__tests__/LibraryEditForm-test.tsx
@@ -6,6 +6,7 @@ import { shallow, mount } from "enzyme";
 
 import LibraryEditForm from "../LibraryEditForm";
 import EditableInput from "../EditableInput";
+import ProtocolFormField from "../ProtocolFormField";
 
 describe("LibraryEditForm", () => {
   let wrapper;
@@ -29,6 +30,14 @@ describe("LibraryEditForm", () => {
     let inputs = wrapper.find(EditableInput);
     if (inputs.length >= 1) {
       return inputs.filterWhere(input => input.props().name === name);
+    }
+    return [];
+  };
+
+  let protocolFormFieldByKey = (key) => {
+    let formFields = wrapper.find(ProtocolFormField);
+    if (formFields.length >= 1) {
+      return formFields.filterWhere(formField => formField.props().field.key === key);
     }
     return [];
   };
@@ -117,17 +126,17 @@ describe("LibraryEditForm", () => {
     });
 
     it("renders settings", () => {
-      let privacyInput = editableInputByName("privacy-policy");
-      expect(privacyInput.props().label).to.equal("Privacy Policy");
+      let privacyInput = protocolFormFieldByKey("privacy-policy");
+      expect(privacyInput.props().field).to.equal(settingFields[0]);
       expect(privacyInput.props().value).not.to.be.ok;
-      let copyrightInput = editableInputByName("copyright");
-      expect(copyrightInput.props().label).to.equal("Copyright");
+      let copyrightInput = protocolFormFieldByKey("copyright");
+      expect(copyrightInput.props().field).to.equal(settingFields[1]);
       expect(copyrightInput.props().value).not.to.be.ok;
 
       wrapper.setProps({ item: libraryData });
-      privacyInput = editableInputByName("privacy-policy");
+      privacyInput = protocolFormFieldByKey("privacy-policy");
       expect(privacyInput.props().value).to.equal("http://privacy");
-      copyrightInput = editableInputByName("copyright");
+      copyrightInput = protocolFormFieldByKey("copyright");
       expect(copyrightInput.props().value).to.equal("http://copyright");
     });
   });

--- a/src/components/__tests__/PatronAuthServiceEditForm-test.tsx
+++ b/src/components/__tests__/PatronAuthServiceEditForm-test.tsx
@@ -6,6 +6,7 @@ import { shallow, mount } from "enzyme";
 
 import PatronAuthServiceEditForm from "../PatronAuthServiceEditForm";
 import EditableInput from "../EditableInput";
+import ProtocolFormField from "../ProtocolFormField";
 
 describe("PatronAuthServiceEditForm", () => {
   let wrapper;
@@ -52,7 +53,8 @@ describe("PatronAuthServiceEditForm", () => {
       fields: [
         { key: "text_setting", label: "text label" },
         { key: "protocol2_setting", label: "protocol2 label" },
-      ]
+      ],
+      library_fields: []
     }
   ];
   let allLibraries = [
@@ -69,6 +71,14 @@ describe("PatronAuthServiceEditForm", () => {
     let inputs = wrapper.find(EditableInput);
     if (inputs.length >= 1) {
       return inputs.filterWhere(input => input.props().name === name);
+    }
+    return [];
+  };
+
+  let protocolFormFieldByKey = (key) => {
+    let formFields = wrapper.find(ProtocolFormField);
+    if (formFields.length >= 1) {
+      return formFields.filterWhere(formField => formField.props().field.key === key);
     }
     return [];
   };
@@ -129,23 +139,15 @@ describe("PatronAuthServiceEditForm", () => {
     });
 
     it("renders protocol fields", () => {
-      let input = editableInputByName("text_setting");
+      let input = protocolFormFieldByKey("text_setting");
       expect(input.props().value).not.to.be.ok;
-      expect(input.props().label).to.equal("text label (optional)");
-      expect(input.props().type).to.equal("text");
+      expect(input.props().field).to.equal(protocolsData[0].fields[0]);
 
-      input = editableInputByName("select_setting");
+      input = protocolFormFieldByKey("select_setting");
       expect(input.props().value).not.to.be.ok;
-      expect(input.props().label).to.equal("select label");
-      expect(input.props().elementType).to.equal("select");
-      let children = input.find("option");
-      expect(children.length).to.equal(2);
-      expect(children.at(0).props().value).to.equal("option1");
-      expect(children.at(0).text()).to.contain("option 1");
-      expect(children.at(1).props().value).to.equal("option2");
-      expect(children.at(1).text()).to.contain("option 2");
+      expect(input.props().field).to.equal(protocolsData[0].fields[1]);
 
-      input = editableInputByName("protocol2_setting");
+      input = protocolFormFieldByKey("protocol2_setting");
       expect(input.length).to.equal(0);
 
       wrapper = shallow(
@@ -158,14 +160,14 @@ describe("PatronAuthServiceEditForm", () => {
           />
       );
 
-      input = editableInputByName("text_setting");
+      input = protocolFormFieldByKey("text_setting");
       expect(input.props().value).to.equal("text setting");
-      expect(input.props().label).to.equal("text label (optional)");
+      expect(input.props().field).to.equal(protocolsData[0].fields[0]);
 
-      input = editableInputByName("select_setting");
+      input = protocolFormFieldByKey("select_setting");
       expect(input.props().value).to.equal("option2");
 
-      input = editableInputByName("protocol2_setting");
+      input = protocolFormFieldByKey("protocol2_setting");
       expect(input.length).to.equal(0);
     });
 
@@ -197,21 +199,13 @@ describe("PatronAuthServiceEditForm", () => {
       expect(options.at(0).props().value).to.equal("nypl");
       expect(options.at(1).props().value).to.equal("bpl");
 
-      let input = editableInputByName("library_text_setting");
+      let input = protocolFormFieldByKey("library_text_setting");
       expect(input.props().value).not.to.be.ok;
-      expect(input.props().label).to.equal("library text label (optional)");
-      expect(input.props().type).to.equal("text");
+      expect(input.props().field).to.equal(protocolsData[0].library_fields[0]);
 
-      input = editableInputByName("library_select_setting");
+      input = protocolFormFieldByKey("library_select_setting");
       expect(input.props().value).not.to.be.ok;
-      expect(input.props().label).to.equal("library select label");
-      expect(input.props().elementType).to.equal("select");
-      let children = input.find("option");
-      expect(children.length).to.equal(2);
-      expect(children.at(0).props().value).to.equal("option3");
-      expect(children.at(0).text()).to.contain("option 3");
-      expect(children.at(1).props().value).to.equal("option4");
-      expect(children.at(1).text()).to.contain("option 4");
+      expect(input.props().field).to.equal(protocolsData[0].library_fields[1]);
 
       wrapper = shallow(
         <PatronAuthServiceEditForm
@@ -229,21 +223,13 @@ describe("PatronAuthServiceEditForm", () => {
       expect(options.length).to.equal(1);
       expect(options.at(0).props().value).to.equal("bpl");
 
-      input = editableInputByName("library_text_setting");
+      input = protocolFormFieldByKey("library_text_setting");
       expect(input.props().value).not.to.be.ok;
-      expect(input.props().label).to.equal("library text label (optional)");
-      expect(input.props().type).to.equal("text");
+      expect(input.props().field).to.equal(protocolsData[0].library_fields[0]);
 
-      input = editableInputByName("library_select_setting");
+      input = protocolFormFieldByKey("library_select_setting");
       expect(input.props().value).not.to.be.ok;
-      expect(input.props().label).to.equal("library select label");
-      expect(input.props().elementType).to.equal("select");
-      children = input.find("option");
-      expect(children.length).to.equal(2);
-      expect(children.at(0).props().value).to.equal("option3");
-      expect(children.at(0).text()).to.contain("option 3");
-      expect(children.at(1).props().value).to.equal("option4");
-      expect(children.at(1).text()).to.contain("option 4");
+      expect(input.props().field).to.equal(protocolsData[0].library_fields[1]);
     });
   });
 
@@ -261,11 +247,11 @@ describe("PatronAuthServiceEditForm", () => {
     });
 
     it("changes fields when protocol changes", () => {
-      let textSettingInput = editableInputByName("text_setting");
-      let selectSettingInput = editableInputByName("select_setting");
-      let libraryTextSettingInput = editableInputByName("library_text_setting");
-      let librarySelectSettingInput = editableInputByName("library_select_setting");
-      let protocol2SettingInput = editableInputByName("protocol2_setting");
+      let textSettingInput = protocolFormFieldByKey("text_setting");
+      let selectSettingInput = protocolFormFieldByKey("select_setting");
+      let libraryTextSettingInput = protocolFormFieldByKey("library_text_setting");
+      let librarySelectSettingInput = protocolFormFieldByKey("library_select_setting");
+      let protocol2SettingInput = protocolFormFieldByKey("protocol2_setting");
       expect(textSettingInput.length).to.equal(1);
       expect(selectSettingInput.length).to.equal(1);
       expect(libraryTextSettingInput.length).to.equal(1);
@@ -277,11 +263,11 @@ describe("PatronAuthServiceEditForm", () => {
       selectElement.value = "protocol 2";
       select.simulate("change");
 
-      textSettingInput = editableInputByName("text_setting");
-      selectSettingInput = editableInputByName("select_setting");
-      libraryTextSettingInput = editableInputByName("library_text_setting");
-      librarySelectSettingInput = editableInputByName("library_select_setting");
-      protocol2SettingInput = editableInputByName("protocol2_setting");
+      textSettingInput = protocolFormFieldByKey("text_setting");
+      selectSettingInput = protocolFormFieldByKey("select_setting");
+      libraryTextSettingInput = protocolFormFieldByKey("library_text_setting");
+      librarySelectSettingInput = protocolFormFieldByKey("library_select_setting");
+      protocol2SettingInput = protocolFormFieldByKey("protocol2_setting");
       expect(textSettingInput.length).to.equal(1);
       expect(selectSettingInput.length).to.equal(0);
       expect(libraryTextSettingInput.length).to.equal(0);
@@ -291,11 +277,11 @@ describe("PatronAuthServiceEditForm", () => {
       selectElement.value = "protocol 1";
       select.simulate("change");
 
-      textSettingInput = editableInputByName("text_setting");
-      selectSettingInput = editableInputByName("select_setting");
-      libraryTextSettingInput = editableInputByName("library_text_setting");
-      librarySelectSettingInput = editableInputByName("library_select_setting");
-      protocol2SettingInput = editableInputByName("protocol2_setting");
+      textSettingInput = protocolFormFieldByKey("text_setting");
+      selectSettingInput = protocolFormFieldByKey("select_setting");
+      libraryTextSettingInput = protocolFormFieldByKey("library_text_setting");
+      librarySelectSettingInput = protocolFormFieldByKey("library_select_setting");
+      protocol2SettingInput = protocolFormFieldByKey("protocol2_setting");
       expect(textSettingInput.length).to.equal(1);
       expect(selectSettingInput.length).to.equal(1);
       expect(libraryTextSettingInput.length).to.equal(1);

--- a/src/components/__tests__/ProtocolFormField-test.tsx
+++ b/src/components/__tests__/ProtocolFormField-test.tsx
@@ -1,0 +1,85 @@
+import { expect } from "chai";
+
+import * as React from "react";
+import { shallow } from "enzyme";
+
+import ProtocolFormField from "../ProtocolFormField";
+import EditableInput from "../EditableInput";
+
+describe("ProtocolFormField", () => {
+  it("renders text field", () => {
+    const field = {
+      key: "field",
+      label: "label"
+    };
+    const wrapper = shallow(
+      <ProtocolFormField
+        field={field}
+        disabled={true}
+        />
+    );
+
+    let input = wrapper.find(EditableInput);
+    expect(input.length).to.equal(1);
+    expect(input.prop("disabled")).to.equal(true);
+    expect(input.prop("name")).to.equal("field");
+    expect(input.prop("label")).to.equal("label");
+    expect(input.prop("value")).to.be.undefined;
+
+    wrapper.setProps({ value: "test" });
+    input = wrapper.find(EditableInput);
+    expect(input.prop("value")).to.equal("test");
+  });
+
+  it("renders optional field", () => {
+    const field = {
+      key: "field",
+      label: "label",
+      optional: true
+    };
+    const wrapper = shallow(
+      <ProtocolFormField
+        field={field}
+        disabled={false}
+        />
+    );
+
+    let input = wrapper.find(EditableInput);
+    expect(input.length).to.equal(1);
+    expect(input.prop("disabled")).to.equal(false);
+    expect(input.prop("name")).to.equal("field");
+    expect(input.prop("label")).to.equal("label (optional)");
+    expect(input.prop("value")).to.be.undefined;
+  });
+
+  it("renders select field", () => {
+    const field = {
+      key: "field",
+      label: "label",
+      type: "select",
+      options: [
+        { key: "option1", label: "option 1" },
+        { key: "option2", label: "option 2" }
+      ]
+    };
+    const wrapper = shallow(
+      <ProtocolFormField
+        field={field}
+        disabled={false}
+        />
+    );
+
+    let input = wrapper.find(EditableInput);
+    expect(input.length).to.equal(1);
+    expect(input.prop("disabled")).to.equal(false);
+    expect(input.prop("name")).to.equal("field");
+    expect(input.prop("label")).to.equal("label");
+    expect(input.prop("value")).to.be.undefined;
+    let children = input.find("option");
+    expect(children.length).to.equal(2);
+    expect(children.at(0).prop("value")).to.equal("option1");
+    expect(children.at(0).text()).to.contain("option 1");
+    expect(children.at(1).prop("value")).to.equal("option2");
+    expect(children.at(1).text()).to.contain("option 2");
+  });
+});

--- a/src/components/__tests__/ProtocolFormField-test.tsx
+++ b/src/components/__tests__/ProtocolFormField-test.tsx
@@ -82,4 +82,49 @@ describe("ProtocolFormField", () => {
     expect(children.at(1).prop("value")).to.equal("option2");
     expect(children.at(1).text()).to.contain("option 2");
   });
+
+  it("renders list field", () => {
+    const field = {
+      key: "field",
+      label: "label",
+      type: "list",
+      options: [
+        { key: "option1", label: "option 1" },
+        { key: "option2", label: "option 2" },
+        { key: "option3", label: "option 3" }
+      ]
+    };
+    const wrapper = shallow(
+      <ProtocolFormField
+        field={field}
+        disabled={false}
+        />
+    );
+
+    expect(wrapper.find("div").text()).to.contain("label");
+
+    let input = wrapper.find(EditableInput);
+    expect(input.length).to.equal(3);
+
+    expect(input.at(0).prop("name")).to.equal("field_option1");
+    expect(input.at(1).prop("name")).to.equal("field_option2");
+    expect(input.at(2).prop("name")).to.equal("field_option3");
+
+    expect(input.at(0).prop("label")).to.equal("option 1");
+    expect(input.at(1).prop("label")).to.equal("option 2");
+    expect(input.at(2).prop("label")).to.equal("option 3");
+
+    expect(input.at(0).prop("checked")).not.to.be.ok;
+    expect(input.at(1).prop("checked")).not.to.be.ok;
+    expect(input.at(2).prop("checked")).not.to.be.ok;
+
+    wrapper.setProps({ value: ["option1", "option3"] });
+
+    input = wrapper.find(EditableInput);
+    expect(input.length).to.equal(3);
+
+    expect(input.at(0).prop("checked")).to.be.ok;
+    expect(input.at(1).prop("checked")).not.to.be.ok;
+    expect(input.at(2).prop("checked")).to.be.ok;
+  });
 });

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -109,7 +109,7 @@ export interface LibraryData {
   library_registry_short_name?: string;
   library_registry_shared_secret?: string;
   settings?: {
-    [key: string]: string;
+    [key: string]: string | string[];
   };
 }
 


### PR DESCRIPTION
This moves the code to create form fields to a new component that can be used by all the configuration editing components, and support for a configuration setting with a list of options where the admin can select any number of the options. This is handled by showing a checkbox for each option. The design will need to be redone later.