### PR TITLE
Added analytics service editing.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "description": "Web Front-end for Library Simplified Circulation Manager",
   "repository": {
     "type": "git",

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -4,7 +4,7 @@ import {
   LibrariesData, CollectionsData,
   AdminAuthServicesData, IndividualAdminsData,
   PatronAuthServicesData, SitewideSettingsData,
-  MetadataServicesData
+  MetadataServicesData, AnalyticsServicesData
 } from "./interfaces";
 import DataFetcher from "opds-web-client/lib/DataFetcher";
 import { RequestError, RequestRejector } from "opds-web-client/lib/DataFetcher";
@@ -35,6 +35,8 @@ export default class ActionCreator extends BaseActionCreator {
   static readonly EDIT_SITEWIDE_SETTING = "EDIT_SITEWIDE_SETTING";
   static readonly METADATA_SERVICES = "METADATA_SERVICES";
   static readonly EDIT_METADATA_SERVICE = "EDIT_METADATA_SERVICE";
+  static readonly ANALYTICS_SERVICES = "ANALYTICS_SERVICES";
+  static readonly EDIT_ANALYTICS_SERVICE = "EDIT_ANALYTICS_SERVICE";
 
   static readonly EDIT_BOOK_REQUEST = "EDIT_BOOK_REQUEST";
   static readonly EDIT_BOOK_SUCCESS = "EDIT_BOOK_SUCCESS";
@@ -292,5 +294,15 @@ export default class ActionCreator extends BaseActionCreator {
   editMetadataService(data: FormData) {
     const url = "/admin/metadata_services";
     return this.postForm(ActionCreator.EDIT_METADATA_SERVICE, url, data).bind(this);
+  }
+
+  fetchAnalyticsServices() {
+    const url = "/admin/analytics_services";
+    return this.fetchJSON<AnalyticsServicesData>(ActionCreator.ANALYTICS_SERVICES, url).bind(this);
+  }
+
+  editAnalyticsService(data: FormData) {
+    const url = "/admin/analytics_services";
+    return this.postForm(ActionCreator.EDIT_ANALYTICS_SERVICE, url, data).bind(this);
   }
 }

--- a/src/components/AnalyticsServices.tsx
+++ b/src/components/AnalyticsServices.tsx
@@ -1,0 +1,50 @@
+import EditableConfigList from "./EditableConfigList";
+import { connect } from "react-redux";
+import ActionCreator from "../actions";
+import { AnalyticsServicesData, AnalyticsServiceData } from "../interfaces";
+import ServiceEditForm from "./ServiceEditForm";
+
+export class AnalyticsServices extends EditableConfigList<AnalyticsServicesData, AnalyticsServiceData> {
+  EditForm = ServiceEditForm;
+  listDataKey = "analytics_services";
+  itemTypeName = "analytics service";
+  urlBase = "/admin/web/config/analytics/";
+  identifierKey = "id";
+  labelKey = "protocol";
+
+  label(item): string {
+    for (const protocol of this.props.data.protocols) {
+      if (protocol.name === item.protocol) {
+        return protocol.label;
+      }
+    }
+    return item.protocol;
+  }
+}
+
+function mapStateToProps(state, ownProps) {
+  const data = Object.assign({}, state.editor.analyticsServices && state.editor.analyticsServices.data || {});
+  if (state.editor.libraries && state.editor.libraries.data) {
+    data.allLibraries = state.editor.libraries.data.libraries;
+  }
+  return {
+    data: data,
+    fetchError: state.editor.analyticsServices.fetchError,
+    isFetching: state.editor.analyticsServices.isFetching || state.editor.analyticsServices.isEditing
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  let actions = new ActionCreator();
+  return {
+    fetchData: () => dispatch(actions.fetchAnalyticsServices()),
+    editItem: (data: FormData) => dispatch(actions.editAnalyticsService(data))
+  };
+}
+
+const ConnectedAnalyticsServices = connect<any, any, any>(
+  mapStateToProps,
+  mapDispatchToProps
+)(AnalyticsServices);
+
+export default ConnectedAnalyticsServices;

--- a/src/components/ConfigTabContainer.tsx
+++ b/src/components/ConfigTabContainer.tsx
@@ -6,6 +6,7 @@ import IndividualAdmins from "./IndividualAdmins";
 import PatronAuthServices from "./PatronAuthServices";
 import SitewideSettings from "./SitewideSettings";
 import MetadataServices from "./MetadataServices";
+import AnalyticsServices from "./AnalyticsServices";
 import { TabContainer, TabContainerProps } from "./TabContainer";
 
 export interface ConfigTabContainerProps extends TabContainerProps {
@@ -66,6 +67,14 @@ export default class ConfigTabContainer extends TabContainer<ConfigTabContainerP
       ),
       metadata: (
         <MetadataServices
+          store={this.props.store}
+          csrfToken={this.props.csrfToken}
+          editOrCreate={this.props.editOrCreate}
+          identifier={this.props.identifier}
+          />
+      ),
+      analytics: (
+        <AnalyticsServices
           store={this.props.store}
           csrfToken={this.props.csrfToken}
           editOrCreate={this.props.editOrCreate}

--- a/src/components/__tests__/AnalyticsServices-test.tsx
+++ b/src/components/__tests__/AnalyticsServices-test.tsx
@@ -1,0 +1,58 @@
+import { expect } from "chai";
+import { stub } from "sinon";
+
+import * as React from "react";
+import { shallow } from "enzyme";
+
+import { AnalyticsServices } from "../AnalyticsServices";
+
+describe("AnalyticsServices", () => {
+  let wrapper;
+  let fetchData;
+  let editItem;
+  let data = {
+    analytics_services: [{
+      id: 2,
+      protocol: "test protocol",
+      settings: {
+        "test_setting": "test setting"
+      }
+    }],
+    protocols: [{
+      name: "test protocol",
+      label: "test protocol label",
+      sitewide: false,
+      settings: []
+    }],
+    allLibraries: [{
+      short_name: "nypl"
+    }]
+  };
+
+  const pause = () => {
+    return new Promise<void>(resolve => setTimeout(resolve, 0));
+  };
+
+  beforeEach(() => {
+    fetchData = stub();
+    editItem = stub().returns(new Promise<void>(resolve => resolve()));
+
+    wrapper = shallow(
+      <AnalyticsServices
+        data={data}
+        fetchData={fetchData}
+        editItem={editItem}
+        csrfToken="token"
+        isFetching={false}
+        />
+    );
+  });
+
+  it("shows analytics service list", () => {
+    let service = wrapper.find("li");
+    expect(service.length).to.equal(1);
+    expect(service.text()).to.contain("test protocol label");
+    let editLink = service.find("a");
+    expect(editLink.props().href).to.equal("/admin/web/config/analytics/edit/2");
+  });
+});

--- a/src/components/__tests__/ConfigTabContainer-test.tsx
+++ b/src/components/__tests__/ConfigTabContainer-test.tsx
@@ -13,6 +13,7 @@ import IndividualAdmins from "../IndividualAdmins";
 import PatronAuthServices from "../PatronAuthServices";
 import SitewideSettings from "../SitewideSettings";
 import MetadataServices from "../MetadataServices";
+import AnalyticsServices from "../AnalyticsServices";
 import { mockRouterContext } from "./routing";
 
 
@@ -54,7 +55,7 @@ describe("ConfigTabContainer", () => {
     const componentClasses = [
       Libraries, Collections, AdminAuthServices,
       IndividualAdmins, PatronAuthServices, SitewideSettings,
-      MetadataServices
+      MetadataServices, AnalyticsServices
     ];
     for (const componentClass of componentClasses) {
       const component = wrapper.find(componentClass);

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -207,3 +207,9 @@ export interface MetadataServiceData extends ServiceData {}
 export interface MetadataServicesData extends ServicesData {
   metadata_services: MetadataServiceData[];
 }
+
+export interface AnalyticsServiceData extends ServiceData {}
+
+export interface AnalyticsServicesData extends ServicesData {
+  analytics_services: AnalyticsServiceData[];
+}

--- a/src/reducers/analyticsServices.ts
+++ b/src/reducers/analyticsServices.ts
@@ -1,0 +1,5 @@
+import { AnalyticsServicesData } from "../interfaces";
+import ActionCreator from "../actions";
+import createFetchEditReducer from "./createFetchEditReducer";
+
+export default createFetchEditReducer<AnalyticsServicesData>(ActionCreator.ANALYTICS_SERVICES, ActionCreator.EDIT_ANALYTICS_SERVICE);

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -11,10 +11,12 @@ import individualAdmins from "./individualAdmins";
 import patronAuthServices from "./patronAuthServices";
 import sitewideSettings from "./sitewideSettings";
 import metadataServices from "./metadataServices";
+import analyticsServices from "./analyticsServices";
 import { FetchEditState } from "./createFetchEditReducer";
 import {
   LibrariesData, CollectionsData, AdminAuthServicesData, IndividualAdminsData,
-  PatronAuthServicesData, SitewideSettingsData, MetadataServicesData
+  PatronAuthServicesData, SitewideSettingsData, MetadataServicesData,
+  AnalyticsServicesData
 } from "../interfaces";
 
 
@@ -31,6 +33,7 @@ export interface State {
   patronAuthServices: FetchEditState<PatronAuthServicesData>;
   sitewideSettings: FetchEditState<SitewideSettingsData>;
   metadataServices: FetchEditState<MetadataServicesData>;
+  analyticsServices: FetchEditState<AnalyticsServicesData>;
 }
 
 export default combineReducers<State>({
@@ -45,5 +48,6 @@ export default combineReducers<State>({
   individualAdmins,
   patronAuthServices,
   sitewideSettings,
-  metadataServices
+  metadataServices,
+  analyticsServices
 });


### PR DESCRIPTION
This branch adds an analytics tab to the configuration section of the admin interface. It mostly uses the same code as patron authentication, admin authentication, and metadata integration configuration, so the changes here are mostly to define all the necessary constants and insert the tab.