### PR TITLE
DRM service editing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "description": "Web Front-end for Library Simplified Circulation Manager",
   "repository": {
     "type": "git",

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -4,7 +4,8 @@ import {
   LibrariesData, CollectionsData,
   AdminAuthServicesData, IndividualAdminsData,
   PatronAuthServicesData, SitewideSettingsData,
-  MetadataServicesData, AnalyticsServicesData
+  MetadataServicesData, AnalyticsServicesData,
+  DRMServicesData
 } from "./interfaces";
 import DataFetcher from "opds-web-client/lib/DataFetcher";
 import { RequestError, RequestRejector } from "opds-web-client/lib/DataFetcher";
@@ -37,6 +38,8 @@ export default class ActionCreator extends BaseActionCreator {
   static readonly EDIT_METADATA_SERVICE = "EDIT_METADATA_SERVICE";
   static readonly ANALYTICS_SERVICES = "ANALYTICS_SERVICES";
   static readonly EDIT_ANALYTICS_SERVICE = "EDIT_ANALYTICS_SERVICE";
+  static readonly DRM_SERVICES = "DRM_SERVICES";
+  static readonly EDIT_DRM_SERVICE = "EDIT_DRM_SERVICE";
 
   static readonly EDIT_BOOK_REQUEST = "EDIT_BOOK_REQUEST";
   static readonly EDIT_BOOK_SUCCESS = "EDIT_BOOK_SUCCESS";
@@ -304,5 +307,15 @@ export default class ActionCreator extends BaseActionCreator {
   editAnalyticsService(data: FormData) {
     const url = "/admin/analytics_services";
     return this.postForm(ActionCreator.EDIT_ANALYTICS_SERVICE, url, data).bind(this);
+  }
+
+  fetchDRMServices() {
+    const url = "/admin/drm_services";
+    return this.fetchJSON<DRMServicesData>(ActionCreator.DRM_SERVICES, url).bind(this);
+  }
+
+  editDRMService(data: FormData) {
+    const url = "/admin/drm_services";
+    return this.postForm(ActionCreator.EDIT_DRM_SERVICE, url, data).bind(this);
   }
 }

--- a/src/components/ConfigTabContainer.tsx
+++ b/src/components/ConfigTabContainer.tsx
@@ -7,6 +7,7 @@ import PatronAuthServices from "./PatronAuthServices";
 import SitewideSettings from "./SitewideSettings";
 import MetadataServices from "./MetadataServices";
 import AnalyticsServices from "./AnalyticsServices";
+import DRMServices from "./DRMServices";
 import { TabContainer, TabContainerProps } from "./TabContainer";
 
 export interface ConfigTabContainerProps extends TabContainerProps {
@@ -80,6 +81,14 @@ export default class ConfigTabContainer extends TabContainer<ConfigTabContainerP
           editOrCreate={this.props.editOrCreate}
           identifier={this.props.identifier}
           />
+      ),
+      drm: (
+        <DRMServices
+          store={this.props.store}
+          csrfToken={this.props.csrfToken}
+          editOrCreate={this.props.editOrCreate}
+          identifier={this.props.identifier}
+          />
       )
     };
   }
@@ -100,6 +109,8 @@ export default class ConfigTabContainer extends TabContainer<ConfigTabContainerP
       return "Patron Authentication";
     } else if (name === "sitewideSettings") {
       return "Sitewide Settings";
+    } else if (name === "drm") {
+      return "DRM";
     } else {
       return super.tabDisplayName(name);
     }

--- a/src/components/DRMServices.tsx
+++ b/src/components/DRMServices.tsx
@@ -1,0 +1,41 @@
+import EditableConfigList from "./EditableConfigList";
+import { connect } from "react-redux";
+import ActionCreator from "../actions";
+import { DRMServicesData, DRMServiceData } from "../interfaces";
+import ServiceEditForm from "./ServiceEditForm";
+
+export class DRMServices extends EditableConfigList<DRMServicesData, DRMServiceData> {
+  EditForm = ServiceEditForm;
+  listDataKey = "drm_services";
+  itemTypeName = "DRM service";
+  urlBase = "/admin/web/config/drm/";
+  identifierKey = "id";
+  labelKey = "protocol";
+}
+
+function mapStateToProps(state, ownProps) {
+  const data = Object.assign({}, state.editor.drmServices && state.editor.drmServices.data || {});
+  if (state.editor.libraries && state.editor.libraries.data) {
+    data.allLibraries = state.editor.libraries.data.libraries;
+  }
+  return {
+    data: data,
+    fetchError: state.editor.drmServices.fetchError,
+    isFetching: state.editor.drmServices.isFetching || state.editor.drmServices.isEditing
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  let actions = new ActionCreator();
+  return {
+    fetchData: () => dispatch(actions.fetchDRMServices()),
+    editItem: (data: FormData) => dispatch(actions.editDRMService(data))
+  };
+}
+
+const ConnectedDRMServices = connect<any, any, any>(
+  mapStateToProps,
+  mapDispatchToProps
+)(DRMServices);
+
+export default ConnectedDRMServices;

--- a/src/components/LibraryEditForm.tsx
+++ b/src/components/LibraryEditForm.tsx
@@ -12,19 +12,7 @@ export interface LibraryEditFormProps {
   urlBase: string;
 }
 
-export interface LibraryEditFormState {
-  useRandomSecret: boolean;
-}
-
-export default class LibraryEditForm extends React.Component<LibraryEditFormProps, LibraryEditFormState> {
-  constructor(props) {
-    super(props);
-    this.state = {
-      useRandomSecret: false
-    };
-    this.handleRandomSecretChange = this.handleRandomSecretChange.bind(this);
-  }
-
+export default class LibraryEditForm extends React.Component<LibraryEditFormProps, void> {
   render(): JSX.Element {
     return (
       <form ref="form" onSubmit={this.save.bind(this)} className="edit-form">
@@ -54,35 +42,6 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
           label="Short name"
           value={this.props.item && this.props.item.short_name}
           />
-        <EditableInput
-          elementType="input"
-          type="text"
-          disabled={this.props.disabled}
-          name="library_registry_short_name"
-          label="Short name (for library registry)"
-          value={this.props.item && this.props.item.library_registry_short_name}
-          />
-        { (!this.props.item || !this.props.item.library_registry_shared_secret) &&
-          <EditableInput
-            elementType="input"
-            type="checkbox"
-            disabled={this.props.disabled}
-            name="random_library_registry_shared_secret"
-            label="Set the library registry shared secret to a random value"
-            onChange={this.handleRandomSecretChange}
-            ref="randomSecret"
-            />
-        }
-        { !this.state.useRandomSecret &&
-          <EditableInput
-            elementType="input"
-            type="text"
-            disabled={this.props.disabled}
-            name="library_registry_shared_secret"
-            label="Shared secret (for library registry)"
-            value={this.props.item && this.props.item.library_registry_shared_secret}
-            />
-        }
         { this.props.data && this.props.data.settings && this.props.data.settings.map(setting =>
           <ProtocolFormField
             setting={setting}
@@ -111,10 +70,5 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
         window.location.href = this.props.urlBase;
       }
     });
-  }
-
-  handleRandomSecretChange() {
-    const value = !this.state.useRandomSecret;
-    this.setState({ useRandomSecret: value });
   }
 }

--- a/src/components/ProtocolFormField.tsx
+++ b/src/components/ProtocolFormField.tsx
@@ -144,7 +144,7 @@ export default class ProtocolFormField extends React.Component<ProtocolFormField
 
   randomize() {
     const element = (this.refs["element"] as any);
-    const chars = "1234567890abcdef";
+    const chars = "1234567890abcdefghijklmnopqrstuvwxyz!@#$%^&*()";
     let random = "";
     for (let i = 0; i < 32; i++) {
       random += chars.charAt(Math.floor(Math.random() * chars.length));

--- a/src/components/ProtocolFormField.tsx
+++ b/src/components/ProtocolFormField.tsx
@@ -20,21 +20,35 @@ export default class ProtocolFormField extends React.Component<ProtocolFormField
     };
     this.addListItem = this.addListItem.bind(this);
     this.removeListItem = this.removeListItem.bind(this);
+    this.randomize = this.randomize.bind(this);
   }
 
   render(): JSX.Element {
     const setting = this.props.setting;
     if (setting.type === "text" || setting.type === undefined) {
       return (
-        <EditableInput
-          elementType="input"
-          type="text"
-          disabled={this.props.disabled}
-          name={setting.key}
-          label={setting.label + (setting.optional ? " (optional)" : "")}
-          value={this.props.value || setting.default}
-          ref="element"
-          />
+        <div className={setting.randomizable ? "randomizable" : ""}>
+          <EditableInput
+            elementType="input"
+            type="text"
+            disabled={this.props.disabled}
+            name={setting.key}
+            label={setting.label + (setting.optional ? " (optional)" : "")}
+            value={this.props.value || setting.default}
+            ref="element"
+            />
+            { setting.randomizable &&
+              <div className="text-right">
+                <button
+                  className="btn btn-default"
+                  disabled={this.props.disabled}
+                  onClick={this.randomize}
+                  type="button">
+                  Set to random value
+                </button>
+              </div>
+            }
+        </div>
       );
     } else if (setting.type === "select") {
       return (
@@ -126,5 +140,15 @@ export default class ProtocolFormField extends React.Component<ProtocolFormField
     const listItem = (this.refs["addListItem"] as any).getValue();
     this.setState({ listItems: this.state.listItems.concat(listItem) });
     (this.refs["addListItem"] as any).clear();
+  }
+
+  randomize() {
+    const element = (this.refs["element"] as any);
+    const chars = "1234567890abcdef";
+    let random = "";
+    for (let i = 0; i < 32; i++) {
+      random += chars.charAt(Math.floor(Math.random() * chars.length));
+    }
+    element.setState({ value: random });
   }
 }

--- a/src/components/ProtocolFormField.tsx
+++ b/src/components/ProtocolFormField.tsx
@@ -37,7 +37,7 @@ export default class ProtocolFormField extends React.Component<ProtocolFormField
             value={this.props.value || setting.default}
             ref="element"
             />
-            { setting.randomizable &&
+            { setting.randomizable && !this.props.value &&
               <div className="text-right">
                 <button
                   className="btn btn-default"

--- a/src/components/__tests__/ConfigTabContainer-test.tsx
+++ b/src/components/__tests__/ConfigTabContainer-test.tsx
@@ -14,6 +14,7 @@ import PatronAuthServices from "../PatronAuthServices";
 import SitewideSettings from "../SitewideSettings";
 import MetadataServices from "../MetadataServices";
 import AnalyticsServices from "../AnalyticsServices";
+import DRMServices from "../DRMServices";
 import { mockRouterContext } from "./routing";
 
 
@@ -49,13 +50,14 @@ describe("ConfigTabContainer", () => {
     expect(linkTexts).to.contain("Patron Authentication");
     expect(linkTexts).to.contain("Sitewide Settings");
     expect(linkTexts).to.contain("Metadata");
+    expect(linkTexts).to.contain("DRM");
   });
 
   it("shows components", () => {
     const componentClasses = [
       Libraries, Collections, AdminAuthServices,
       IndividualAdmins, PatronAuthServices, SitewideSettings,
-      MetadataServices, AnalyticsServices
+      MetadataServices, AnalyticsServices, DRMServices
     ];
     for (const componentClass of componentClasses) {
       const component = wrapper.find(componentClass);

--- a/src/components/__tests__/LibraryEditForm-test.tsx
+++ b/src/components/__tests__/LibraryEditForm-test.tsx
@@ -15,7 +15,6 @@ describe("LibraryEditForm", () => {
     uuid: "uuid",
     name: "name",
     short_name: "short_name",
-    library_registry_short_name: "registry name",
     settings: {
       "privacy-policy": "http://privacy",
       "copyright": "http://copyright"
@@ -88,44 +87,6 @@ describe("LibraryEditForm", () => {
       expect(input.props().value).to.equal("short_name");
     });
 
-    it("renders registry short name", () => {
-      let input = editableInputByName("library_registry_short_name");
-      expect(input.props().value).not.to.be.ok;
-
-      wrapper.setProps({ item: libraryData });
-      input = editableInputByName("library_registry_short_name");
-      expect(input.props().value).to.equal("registry name");
-    });
-
-    it("renders random registry shared secret checkbox", () => {
-      let input = editableInputByName("random_library_registry_shared_secret");
-      expect(input.props().label).to.contain("random");
-      expect(input.props().type).to.equal("checkbox");
-
-      // it's still there if there's a library but no shared secret
-      wrapper.setProps({ item: libraryData });
-      input = editableInputByName("random_library_registry_shared_secret");
-      expect(input.props().label).to.contain("random");
-      expect(input.props().type).to.equal("checkbox");
-
-      // but it's gone if there's a library with a secret
-      libraryData = Object.assign({}, libraryData, {
-        library_registry_shared_secret: "secret"
-      });
-      wrapper.setProps({ item: libraryData });
-      input = editableInputByName("random_library_registry_shared_secret");
-      expect(input.length).to.equal(0);
-    });
-
-    it("renders registry shared secret", () => {
-      let input = editableInputByName("library_registry_shared_secret");
-      expect(input.props().value).not.to.be.ok;
-
-      wrapper.setProps({ item: libraryData });
-      input = editableInputByName("library_registry_shared_secret");
-      expect(input.props().value).to.equal("secret");
-    });
-
     it("renders settings", () => {
       let privacyInput = protocolFormFieldByKey("privacy-policy");
       expect(privacyInput.props().setting).to.equal(settingFields[0]);
@@ -156,20 +117,6 @@ describe("LibraryEditForm", () => {
       );
     });
 
-    it("shows and hides secret field when random secret is selected/unselected", () => {
-      let randomSecret = editableInputByName("random_library_registry_shared_secret");
-      let secret = editableInputByName("library_registry_shared_secret");
-      expect(secret.length).to.equal(1);
-
-      randomSecret.find("input").simulate("change");
-      secret = editableInputByName("library_registry_shared_secret");
-      expect(secret.length).to.equal(0);
-
-      randomSecret.find("input").simulate("change");
-      secret = editableInputByName("library_registry_shared_secret");
-      expect(secret.length).to.equal(1);
-    });
-
     it("submits data", () => {
       wrapper.setProps({ item: libraryData });
 
@@ -182,7 +129,6 @@ describe("LibraryEditForm", () => {
       expect(formData.get("uuid")).to.equal("uuid");
       expect(formData.get("name")).to.equal("name");
       expect(formData.get("short_name")).to.equal("short_name");
-      expect(formData.get("library_registry_short_name")).to.equal("registry name");
       expect(formData.get("privacy-policy")).to.equal("http://privacy");
       expect(formData.get("copyright")).to.equal("http://copyright");
     });

--- a/src/components/__tests__/ProtocolFormField-test.tsx
+++ b/src/components/__tests__/ProtocolFormField-test.tsx
@@ -52,6 +52,34 @@ describe("ProtocolFormField", () => {
     expect(input.prop("value")).to.be.undefined;
   });
 
+  it("renders randomizable setting", () => {
+    const setting = {
+      key: "setting",
+      label: "label",
+      randomizable: true
+    };
+    const wrapper = mount(
+      <ProtocolFormField
+        setting={setting}
+        disabled={false}
+        />
+    );
+
+    let input = wrapper.find(EditableInput);
+    expect(input.length).to.equal(1);
+    expect(input.prop("disabled")).to.equal(false);
+    expect(input.prop("name")).to.equal("setting");
+    expect(input.prop("value")).to.be.undefined;
+    let button = wrapper.find("button");
+    expect(button.length).to.equal(1);
+    expect(button.prop("disabled")).to.equal(false);
+    expect(button.text()).to.contain("random");
+
+    button.simulate("click");
+    expect((wrapper.instance() as ProtocolFormField).getValue()).to.be.ok;
+    expect((wrapper.instance() as ProtocolFormField).getValue().length).to.equal(32);
+  });
+
   it("renders setting with default", () => {
     const setting = {
       key: "setting",

--- a/src/components/__tests__/ProtocolFormField-test.tsx
+++ b/src/components/__tests__/ProtocolFormField-test.tsx
@@ -78,6 +78,13 @@ describe("ProtocolFormField", () => {
     button.simulate("click");
     expect((wrapper.instance() as ProtocolFormField).getValue()).to.be.ok;
     expect((wrapper.instance() as ProtocolFormField).getValue().length).to.equal(32);
+
+    wrapper.setProps({ value: "test" });
+    input = wrapper.find(EditableInput);
+    expect(input.length).to.equal(1);
+    expect(input.prop("value")).to.equal("test");
+    button = wrapper.find("button");
+    expect(button.length).to.equal(0);
   });
 
   it("renders setting with default", () => {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -106,8 +106,6 @@ export interface LibraryData {
   uuid?: string;
   name?: string;
   short_name?: string;
-  library_registry_short_name?: string;
-  library_registry_shared_secret?: string;
   settings?: {
     [key: string]: string | string[];
   };
@@ -133,6 +131,7 @@ export interface SettingData {
   label: string;
   default?: string;
   optional?: boolean;
+  randomizable?: boolean;
   type?: string;
   options?: SettingData[];
 }
@@ -212,4 +211,10 @@ export interface AnalyticsServiceData extends ServiceData {}
 
 export interface AnalyticsServicesData extends ServicesData {
   analytics_services: AnalyticsServiceData[];
+}
+
+export interface DRMServiceData extends ServiceData {}
+
+export interface DRMServicesData extends ServicesData {
+  drm_services: DRMServiceData[];
 }

--- a/src/reducers/drmServices.ts
+++ b/src/reducers/drmServices.ts
@@ -1,0 +1,5 @@
+import { DRMServicesData } from "../interfaces";
+import ActionCreator from "../actions";
+import createFetchEditReducer from "./createFetchEditReducer";
+
+export default createFetchEditReducer<DRMServicesData>(ActionCreator.DRM_SERVICES, ActionCreator.EDIT_DRM_SERVICE);

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -12,11 +12,12 @@ import patronAuthServices from "./patronAuthServices";
 import sitewideSettings from "./sitewideSettings";
 import metadataServices from "./metadataServices";
 import analyticsServices from "./analyticsServices";
+import drmServices from "./drmServices";
 import { FetchEditState } from "./createFetchEditReducer";
 import {
   LibrariesData, CollectionsData, AdminAuthServicesData, IndividualAdminsData,
   PatronAuthServicesData, SitewideSettingsData, MetadataServicesData,
-  AnalyticsServicesData
+  AnalyticsServicesData, DRMServicesData
 } from "../interfaces";
 
 
@@ -34,6 +35,7 @@ export interface State {
   sitewideSettings: FetchEditState<SitewideSettingsData>;
   metadataServices: FetchEditState<MetadataServicesData>;
   analyticsServices: FetchEditState<AnalyticsServicesData>;
+  drmServices: FetchEditState<DRMServicesData>;
 }
 
 export default combineReducers<State>({
@@ -49,5 +51,6 @@ export default combineReducers<State>({
   patronAuthServices,
   sitewideSettings,
   metadataServices,
-  analyticsServices
+  analyticsServices,
+  drmServices
 });

--- a/src/stylesheets/app.scss
+++ b/src/stylesheets/app.scss
@@ -18,4 +18,5 @@
 @import "editor";
 @import "genre_form";
 @import "header";
+@import "protocol_form_field";
 @import "stats";

--- a/src/stylesheets/protocol_form_field.scss
+++ b/src/stylesheets/protocol_form_field.scss
@@ -1,0 +1,8 @@
+.randomizable {
+  .form-group {
+    margin-bottom: 0px;
+  }
+  .text-right {
+    margin-bottom: 15px;
+  }
+}


### PR DESCRIPTION
This branch adds a DRM configuration tab, and removes the library registry short name and shared secret from the library edit form, since they're now go with the DRM integration.

I also made it so that a random secret can be generated client-side, if the setting has "randomizable" set to true. There is now a "Set to random value" button by the text field, instead of a separate checkbox for setting to a random value that hides the text field.