### PR TITLE
Added CDN and search configuration tabs.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "description": "Web Front-end for Library Simplified Circulation Manager",
   "repository": {
     "type": "git",

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -5,7 +5,7 @@ import {
   AdminAuthServicesData, IndividualAdminsData,
   PatronAuthServicesData, SitewideSettingsData,
   MetadataServicesData, AnalyticsServicesData,
-  DRMServicesData
+  DRMServicesData, CDNServicesData
 } from "./interfaces";
 import DataFetcher from "opds-web-client/lib/DataFetcher";
 import { RequestError, RequestRejector } from "opds-web-client/lib/DataFetcher";
@@ -40,6 +40,8 @@ export default class ActionCreator extends BaseActionCreator {
   static readonly EDIT_ANALYTICS_SERVICE = "EDIT_ANALYTICS_SERVICE";
   static readonly DRM_SERVICES = "DRM_SERVICES";
   static readonly EDIT_DRM_SERVICE = "EDIT_DRM_SERVICE";
+  static readonly CDN_SERVICES = "CDN_SERVICES";
+  static readonly EDIT_CDN_SERVICE = "EDIT_CDN_SERVICE";
 
   static readonly EDIT_BOOK_REQUEST = "EDIT_BOOK_REQUEST";
   static readonly EDIT_BOOK_SUCCESS = "EDIT_BOOK_SUCCESS";
@@ -317,5 +319,15 @@ export default class ActionCreator extends BaseActionCreator {
   editDRMService(data: FormData) {
     const url = "/admin/drm_services";
     return this.postForm(ActionCreator.EDIT_DRM_SERVICE, url, data).bind(this);
+  }
+
+  fetchCDNServices() {
+    const url = "/admin/cdn_services";
+    return this.fetchJSON<CDNServicesData>(ActionCreator.CDN_SERVICES, url).bind(this);
+  }
+
+  editCDNService(data: FormData) {
+    const url = "/admin/cdn_services";
+    return this.postForm(ActionCreator.EDIT_CDN_SERVICE, url, data).bind(this);
   }
 }

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -5,7 +5,7 @@ import {
   AdminAuthServicesData, IndividualAdminsData,
   PatronAuthServicesData, SitewideSettingsData,
   MetadataServicesData, AnalyticsServicesData,
-  DRMServicesData, CDNServicesData
+  DRMServicesData, CDNServicesData, SearchServicesData
 } from "./interfaces";
 import DataFetcher from "opds-web-client/lib/DataFetcher";
 import { RequestError, RequestRejector } from "opds-web-client/lib/DataFetcher";
@@ -42,6 +42,8 @@ export default class ActionCreator extends BaseActionCreator {
   static readonly EDIT_DRM_SERVICE = "EDIT_DRM_SERVICE";
   static readonly CDN_SERVICES = "CDN_SERVICES";
   static readonly EDIT_CDN_SERVICE = "EDIT_CDN_SERVICE";
+  static readonly SEARCH_SERVICES = "SEARCH_SERVICES";
+  static readonly EDIT_SEARCH_SERVICE = "EDIT_SEARCH_SERVICE";
 
   static readonly EDIT_BOOK_REQUEST = "EDIT_BOOK_REQUEST";
   static readonly EDIT_BOOK_SUCCESS = "EDIT_BOOK_SUCCESS";
@@ -329,5 +331,15 @@ export default class ActionCreator extends BaseActionCreator {
   editCDNService(data: FormData) {
     const url = "/admin/cdn_services";
     return this.postForm(ActionCreator.EDIT_CDN_SERVICE, url, data).bind(this);
+  }
+
+  fetchSearchServices() {
+    const url = "/admin/search_services";
+    return this.fetchJSON<SearchServicesData>(ActionCreator.SEARCH_SERVICES, url).bind(this);
+  }
+
+  editSearchService(data: FormData) {
+    const url = "/admin/search_services";
+    return this.postForm(ActionCreator.EDIT_SEARCH_SERVICE, url, data).bind(this);
   }
 }

--- a/src/components/CDNServices.tsx
+++ b/src/components/CDNServices.tsx
@@ -1,0 +1,42 @@
+import EditableConfigList from "./EditableConfigList";
+import { connect } from "react-redux";
+import ActionCreator from "../actions";
+import { CDNServicesData, CDNServiceData } from "../interfaces";
+import ServiceEditForm from "./ServiceEditForm";
+
+export class CDNServices extends EditableConfigList<CDNServicesData, CDNServiceData> {
+  EditForm = ServiceEditForm;
+  listDataKey = "cdn_services";
+  itemTypeName = "CDN service";
+  urlBase = "/admin/web/config/cdn/";
+  identifierKey = "id";
+  labelKey = "protocol";
+
+  label(item): string {
+    return item.settings && item.settings.url;
+  }
+}
+
+function mapStateToProps(state, ownProps) {
+  const data = Object.assign({}, state.editor.cdnServices && state.editor.cdnServices.data || {});
+  return {
+    data: data,
+    fetchError: state.editor.cdnServices.fetchError,
+    isFetching: state.editor.cdnServices.isFetching || state.editor.cdnServices.isEditing
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  let actions = new ActionCreator();
+  return {
+    fetchData: () => dispatch(actions.fetchCDNServices()),
+    editItem: (data: FormData) => dispatch(actions.editCDNService(data))
+  };
+}
+
+const ConnectedCDNServices = connect<any, any, any>(
+  mapStateToProps,
+  mapDispatchToProps
+)(CDNServices);
+
+export default ConnectedCDNServices;

--- a/src/components/ConfigTabContainer.tsx
+++ b/src/components/ConfigTabContainer.tsx
@@ -9,6 +9,7 @@ import MetadataServices from "./MetadataServices";
 import AnalyticsServices from "./AnalyticsServices";
 import DRMServices from "./DRMServices";
 import CDNServices from "./CDNServices";
+import SearchServices from "./SearchServices";
 import { TabContainer, TabContainerProps } from "./TabContainer";
 
 export interface ConfigTabContainerProps extends TabContainerProps {
@@ -93,6 +94,14 @@ export default class ConfigTabContainer extends TabContainer<ConfigTabContainerP
       ),
       cdn: (
         <CDNServices
+          store={this.props.store}
+          csrfToken={this.props.csrfToken}
+          editOrCreate={this.props.editOrCreate}
+          identifier={this.props.identifier}
+          />
+      ),
+      search: (
+        <SearchServices
           store={this.props.store}
           csrfToken={this.props.csrfToken}
           editOrCreate={this.props.editOrCreate}

--- a/src/components/ConfigTabContainer.tsx
+++ b/src/components/ConfigTabContainer.tsx
@@ -8,6 +8,7 @@ import SitewideSettings from "./SitewideSettings";
 import MetadataServices from "./MetadataServices";
 import AnalyticsServices from "./AnalyticsServices";
 import DRMServices from "./DRMServices";
+import CDNServices from "./CDNServices";
 import { TabContainer, TabContainerProps } from "./TabContainer";
 
 export interface ConfigTabContainerProps extends TabContainerProps {
@@ -89,6 +90,14 @@ export default class ConfigTabContainer extends TabContainer<ConfigTabContainerP
           editOrCreate={this.props.editOrCreate}
           identifier={this.props.identifier}
           />
+      ),
+      cdn: (
+        <CDNServices
+          store={this.props.store}
+          csrfToken={this.props.csrfToken}
+          editOrCreate={this.props.editOrCreate}
+          identifier={this.props.identifier}
+          />
       )
     };
   }
@@ -111,6 +120,8 @@ export default class ConfigTabContainer extends TabContainer<ConfigTabContainerP
       return "Sitewide Settings";
     } else if (name === "drm") {
       return "DRM";
+    } else if (name === "cdn") {
+      return "CDN";
     } else {
       return super.tabDisplayName(name);
     }

--- a/src/components/EditableConfigList.tsx
+++ b/src/components/EditableConfigList.tsx
@@ -33,6 +33,7 @@ export abstract class EditableConfigList<T, U> extends React.Component<EditableC
   abstract urlBase: string;
   abstract identifierKey: string;
   abstract labelKey: string;
+  limitOne = false;
 
   constructor(props) {
     super(props);
@@ -66,7 +67,7 @@ export abstract class EditableConfigList<T, U> extends React.Component<EditableC
           </div>
         }
 
-        { !this.props.isFetching && !this.props.editOrCreate &&
+        { !this.props.isFetching && !this.props.editOrCreate && (!this.limitOne || this.props.data[this.listDataKey] && this.props.data[this.listDataKey].length === 0) &&
           <a href={this.urlBase + "create"}>Create a new {this.itemTypeName}</a>
         }
 

--- a/src/components/SearchServices.tsx
+++ b/src/components/SearchServices.tsx
@@ -1,0 +1,39 @@
+import EditableConfigList from "./EditableConfigList";
+import { connect } from "react-redux";
+import ActionCreator from "../actions";
+import { SearchServicesData, SearchServiceData } from "../interfaces";
+import ServiceEditForm from "./ServiceEditForm";
+
+export class SearchServices extends EditableConfigList<SearchServicesData, SearchServiceData> {
+  EditForm = ServiceEditForm;
+  listDataKey = "search_services";
+  itemTypeName = "search service";
+  urlBase = "/admin/web/config/search/";
+  identifierKey = "id";
+  labelKey = "protocol";
+  limitOne = true;
+}
+
+function mapStateToProps(state, ownProps) {
+  const data = Object.assign({}, state.editor.searchServices && state.editor.searchServices.data || {});
+  return {
+    data: data,
+    fetchError: state.editor.searchServices.fetchError,
+    isFetching: state.editor.searchServices.isFetching || state.editor.searchServices.isEditing
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  let actions = new ActionCreator();
+  return {
+    fetchData: () => dispatch(actions.fetchSearchServices()),
+    editItem: (data: FormData) => dispatch(actions.editSearchService(data))
+  };
+}
+
+const ConnectedSearchServices = connect<any, any, any>(
+  mapStateToProps,
+  mapDispatchToProps
+)(SearchServices);
+
+export default ConnectedSearchServices;

--- a/src/components/__tests__/CDNServices-test.tsx
+++ b/src/components/__tests__/CDNServices-test.tsx
@@ -1,0 +1,56 @@
+import { expect } from "chai";
+import { stub } from "sinon";
+
+import * as React from "react";
+import { shallow } from "enzyme";
+
+import { CDNServices } from "../CDNServices";
+
+describe("CDNServices", () => {
+  let wrapper;
+  let fetchData;
+  let editItem;
+  let data = {
+    cdn_services: [{
+      id: 2,
+      protocol: "test protocol",
+      settings: {
+        "url": "test url"
+      }
+    }],
+    protocols: [{
+      name: "test protocol",
+      sitewide: true,
+      settings: [{
+        "key": "url", "label": "url"
+      }]
+    }]
+  };
+
+  const pause = () => {
+    return new Promise<void>(resolve => setTimeout(resolve, 0));
+  };
+
+  beforeEach(() => {
+    fetchData = stub();
+    editItem = stub().returns(new Promise<void>(resolve => resolve()));
+
+    wrapper = shallow(
+      <CDNServices
+        data={data}
+        fetchData={fetchData}
+        editItem={editItem}
+        csrfToken="token"
+        isFetching={false}
+        />
+    );
+  });
+
+  it("shows cdn service list", () => {
+    let service = wrapper.find("li");
+    expect(service.length).to.equal(1);
+    expect(service.text()).to.contain("test url");
+    let editLink = service.find("a");
+    expect(editLink.props().href).to.equal("/admin/web/config/cdn/edit/2");
+  });
+});

--- a/src/components/__tests__/ConfigTabContainer-test.tsx
+++ b/src/components/__tests__/ConfigTabContainer-test.tsx
@@ -15,6 +15,7 @@ import SitewideSettings from "../SitewideSettings";
 import MetadataServices from "../MetadataServices";
 import AnalyticsServices from "../AnalyticsServices";
 import DRMServices from "../DRMServices";
+import CDNServices from "../CDNServices";
 import { mockRouterContext } from "./routing";
 
 
@@ -51,13 +52,15 @@ describe("ConfigTabContainer", () => {
     expect(linkTexts).to.contain("Sitewide Settings");
     expect(linkTexts).to.contain("Metadata");
     expect(linkTexts).to.contain("DRM");
+    expect(linkTexts).to.contain("CDN");
   });
 
   it("shows components", () => {
     const componentClasses = [
       Libraries, Collections, AdminAuthServices,
       IndividualAdmins, PatronAuthServices, SitewideSettings,
-      MetadataServices, AnalyticsServices, DRMServices
+      MetadataServices, AnalyticsServices, DRMServices,
+      CDNServices
     ];
     for (const componentClass of componentClasses) {
       const component = wrapper.find(componentClass);

--- a/src/components/__tests__/ConfigTabContainer-test.tsx
+++ b/src/components/__tests__/ConfigTabContainer-test.tsx
@@ -16,6 +16,7 @@ import MetadataServices from "../MetadataServices";
 import AnalyticsServices from "../AnalyticsServices";
 import DRMServices from "../DRMServices";
 import CDNServices from "../CDNServices";
+import SearchServices from "../SearchServices";
 import { mockRouterContext } from "./routing";
 
 
@@ -60,7 +61,7 @@ describe("ConfigTabContainer", () => {
       Libraries, Collections, AdminAuthServices,
       IndividualAdmins, PatronAuthServices, SitewideSettings,
       MetadataServices, AnalyticsServices, DRMServices,
-      CDNServices
+      CDNServices, SearchServices
     ];
     for (const componentClass of componentClasses) {
       const component = wrapper.find(componentClass);

--- a/src/components/__tests__/EditableConfigList-test.tsx
+++ b/src/components/__tests__/EditableConfigList-test.tsx
@@ -37,6 +37,10 @@ describe("EditableConfigList", () => {
     }
   }
 
+  class OneThingEditableConfigList extends ThingEditableConfigList {
+    limitOne = true;
+  }
+
   let wrapper;
   let fetchData;
   let editItem;
@@ -91,6 +95,33 @@ describe("EditableConfigList", () => {
     let createLink = wrapper.find("div > a");
     expect(createLink.length).to.equal(1);
     expect(createLink.props().href).to.equal("/admin/things/create");
+  });
+
+  it("hides create link if only one item is allowed and it already exists", () => {
+    wrapper = shallow(
+      <OneThingEditableConfigList
+        data={thingsData}
+        fetchData={fetchData}
+        editItem={editItem}
+        csrfToken="token"
+        isFetching={false}
+        />
+    );
+    let createLink = wrapper.find("div > a");
+    expect(createLink.length).to.equal(0);
+
+    wrapper = shallow(
+      <OneThingEditableConfigList
+        data={{ things: [] }}
+        fetchData={fetchData}
+        editItem={editItem}
+        csrfToken="token"
+        isFetching={false}
+        />
+    );
+    createLink = wrapper.find("div > a");
+    expect(createLink.length).to.equal(1);
+    expect(createLink.prop("href")).to.equal("/admin/things/create");
   });
 
   it("shows create form", () => {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -218,3 +218,9 @@ export interface DRMServiceData extends ServiceData {}
 export interface DRMServicesData extends ServicesData {
   drm_services: DRMServiceData[];
 }
+
+export interface CDNServiceData extends ServiceData {}
+
+export interface CDNServicesData extends ServicesData {
+  cdn_services: CDNServiceData[];
+}

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -224,3 +224,9 @@ export interface CDNServiceData extends ServiceData {}
 export interface CDNServicesData extends ServicesData {
   cdn_services: CDNServiceData[];
 }
+
+export interface SearchServiceData extends ServiceData {}
+
+export interface SearchServicesData extends ServicesData {
+  search_services: SearchServiceData[];
+}

--- a/src/reducers/cdnServices.ts
+++ b/src/reducers/cdnServices.ts
@@ -1,0 +1,5 @@
+import { CDNServicesData } from "../interfaces";
+import ActionCreator from "../actions";
+import createFetchEditReducer from "./createFetchEditReducer";
+
+export default createFetchEditReducer<CDNServicesData>(ActionCreator.CDN_SERVICES, ActionCreator.EDIT_CDN_SERVICE);

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -13,11 +13,12 @@ import sitewideSettings from "./sitewideSettings";
 import metadataServices from "./metadataServices";
 import analyticsServices from "./analyticsServices";
 import drmServices from "./drmServices";
+import cdnServices from "./cdnServices";
 import { FetchEditState } from "./createFetchEditReducer";
 import {
   LibrariesData, CollectionsData, AdminAuthServicesData, IndividualAdminsData,
   PatronAuthServicesData, SitewideSettingsData, MetadataServicesData,
-  AnalyticsServicesData, DRMServicesData
+  AnalyticsServicesData, DRMServicesData, CDNServicesData
 } from "../interfaces";
 
 
@@ -36,6 +37,7 @@ export interface State {
   metadataServices: FetchEditState<MetadataServicesData>;
   analyticsServices: FetchEditState<AnalyticsServicesData>;
   drmServices: FetchEditState<DRMServicesData>;
+  cdnServices: FetchEditState<CDNServicesData>;
 }
 
 export default combineReducers<State>({
@@ -52,5 +54,6 @@ export default combineReducers<State>({
   sitewideSettings,
   metadataServices,
   analyticsServices,
-  drmServices
+  drmServices,
+  cdnServices
 });

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -14,11 +14,12 @@ import metadataServices from "./metadataServices";
 import analyticsServices from "./analyticsServices";
 import drmServices from "./drmServices";
 import cdnServices from "./cdnServices";
+import searchServices from "./searchServices";
 import { FetchEditState } from "./createFetchEditReducer";
 import {
   LibrariesData, CollectionsData, AdminAuthServicesData, IndividualAdminsData,
   PatronAuthServicesData, SitewideSettingsData, MetadataServicesData,
-  AnalyticsServicesData, DRMServicesData, CDNServicesData
+  AnalyticsServicesData, DRMServicesData, CDNServicesData, SearchServicesData
 } from "../interfaces";
 
 
@@ -38,6 +39,7 @@ export interface State {
   analyticsServices: FetchEditState<AnalyticsServicesData>;
   drmServices: FetchEditState<DRMServicesData>;
   cdnServices: FetchEditState<CDNServicesData>;
+  searchServices: FetchEditState<SearchServicesData>;
 }
 
 export default combineReducers<State>({
@@ -55,5 +57,6 @@ export default combineReducers<State>({
   metadataServices,
   analyticsServices,
   drmServices,
-  cdnServices
+  cdnServices,
+  searchServices
 });

--- a/src/reducers/searchServices.ts
+++ b/src/reducers/searchServices.ts
@@ -1,0 +1,5 @@
+import { SearchServicesData } from "../interfaces";
+import ActionCreator from "../actions";
+import createFetchEditReducer from "./createFetchEditReducer";
+
+export default createFetchEditReducer<SearchServicesData>(ActionCreator.SEARCH_SERVICES, ActionCreator.EDIT_SEARCH_SERVICE);


### PR DESCRIPTION
This is pretty straightforward. 

For CDNs, the only thing different than other tabs is CDNServices.label, which shows the CDN URL in the list of services.

For search, I added a way to make it so if there's already an integration you won't get a create link, since there can be only one search integration. This should maybe come from the server, but I think it's okay to be here for now.