### PR TITLE
Multi-library dropdown in header

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "description": "Web Front-end for Library Simplified Circulation Manager",
   "repository": {
     "type": "git",

--- a/src/components/CatalogHandler.tsx
+++ b/src/components/CatalogHandler.tsx
@@ -19,25 +19,34 @@ export interface CatalogHandlerProps extends React.Props<CatalogHandler> {
   };
 }
 
-export interface CatalogHandlerContext {
-  homeUrl: string;
-}
-
 export default class CatalogHandler extends React.Component<CatalogHandlerProps, any> {
-  context: CatalogHandlerContext;
-
-  static contextTypes: React.ValidationMap<CatalogHandlerContext> = {
-    homeUrl: React.PropTypes.string.isRequired
-  };
-
   static childContextTypes: React.ValidationMap<any> = {
-    tab: React.PropTypes.string
+    tab: React.PropTypes.string,
+    library: React.PropTypes.string
   };
 
   getChildContext() {
     return {
-      tab: this.props.params.tab
+      tab: this.props.params.tab,
+      library: this.getLibrary()
     };
+  }
+
+  getLibrary(): string {
+    let { collectionUrl, bookUrl } = this.props.params;
+    if (collectionUrl) {
+      let urlParts = collectionUrl.split("/");
+      if (urlParts.length > 0) {
+        return urlParts[0];
+      }
+    }
+    if (bookUrl) {
+      let urlParts = bookUrl.split("/");
+      if (urlParts.length > 0) {
+        return urlParts[0];
+      }
+    }
+    return null;
   }
 
   expandCollectionUrl(url: string): string {
@@ -53,11 +62,16 @@ export default class CatalogHandler extends React.Component<CatalogHandlerProps,
   }
 
   render(): JSX.Element {
+    if (!this.getLibrary()) {
+      return (
+        <Header />
+      );
+    }
+
     let { collectionUrl, bookUrl } = this.props.params;
 
     collectionUrl =
       this.expandCollectionUrl(collectionUrl) ||
-      this.context.homeUrl ||
       null;
     bookUrl = this.expandBookUrl(bookUrl) || null;
 

--- a/src/components/ContextProvider.tsx
+++ b/src/components/ContextProvider.tsx
@@ -6,7 +6,6 @@ import { State } from "../reducers/index";
 
 export interface ContextProviderProps extends React.Props<any> {
   csrfToken: string;
-  homeUrl: string;
   showCircEventsDownload?: boolean;
   settingUp?: boolean;
 }
@@ -49,7 +48,6 @@ export default class ContextProvider extends React.Component<ContextProviderProp
     editorStore: React.PropTypes.object.isRequired,
     pathFor: React.PropTypes.func.isRequired,
     csrfToken: React.PropTypes.string.isRequired,
-    homeUrl: React.PropTypes.string.isRequired,
     showCircEventsDownload: React.PropTypes.bool.isRequired,
     settingUp: React.PropTypes.bool.isRequired
   };
@@ -59,7 +57,6 @@ export default class ContextProvider extends React.Component<ContextProviderProp
       editorStore: this.store,
       pathFor: this.pathFor,
       csrfToken: this.props.csrfToken,
-      homeUrl: this.props.homeUrl,
       showCircEventsDownload: this.props.showCircEventsDownload || false,
       settingUp: this.props.settingUp || false
     };

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -5,6 +5,7 @@ import { Store } from "redux";
 import { State } from "../reducers/index";
 import ActionCreator from "../actions";
 import { LibraryData, LibrariesData } from "../interfaces";
+import EditableInput from "./EditableInput";
 import CatalogLink from "opds-web-client/lib/components/CatalogLink";
 import { Link } from "react-router";
 import { Navbar, Nav, NavItem } from "react-bootstrap";
@@ -36,7 +37,8 @@ export class Header extends React.Component<HeaderProps, any> {
             Admin
           </Navbar.Brand>
           { this.props.libraries && this.props.libraries.length > 0 &&
-            <select
+            <EditableInput
+              elementType="select"
               ref="library"
               value={this.context.library}
               onChange={this.changeLibrary}
@@ -48,7 +50,7 @@ export class Header extends React.Component<HeaderProps, any> {
                   <option key={library.short_name} value={library.short_name}>{library.name || library.short_name}</option>
                 )
               }
-            </select>
+            </EditableInput>
           }
           <Navbar.Toggle />
         </Navbar.Header>
@@ -101,7 +103,7 @@ export class Header extends React.Component<HeaderProps, any> {
   }
 
   changeLibrary() {
-    let library = (this.refs["library"] as any).value;
+    let library = (this.refs["library"] as any).getValue();
     if (library) {
       this.context.router.push("/admin/web/collection/" + library + "%2Fgroups");
     }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,18 +1,32 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
+import { connect } from "react-redux";
+import { Store } from "redux";
+import { State } from "../reducers/index";
+import ActionCreator from "../actions";
+import { LibraryData, LibrariesData } from "../interfaces";
 import CatalogLink from "opds-web-client/lib/components/CatalogLink";
 import { Link } from "react-router";
 import { Navbar, Nav, NavItem } from "react-bootstrap";
+import { Router } from "opds-web-client/lib/interfaces";
 
 export interface HeaderProps extends React.Props<Header> {
+  libraries?: LibraryData[];
+  fetchLibraries?: () => Promise<LibrariesData>;
 }
 
-export default class Header extends React.Component<HeaderProps, any> {
-  context: { homeUrl: string };
+export class Header extends React.Component<HeaderProps, any> {
+  context: { library: string, router: Router };
 
   static contextTypes = {
-    homeUrl: React.PropTypes.string.isRequired
+    library: React.PropTypes.string,
+    router: React.PropTypes.object.isRequired
   };
+
+  constructor(props) {
+    super(props);
+    this.changeLibrary = this.changeLibrary.bind(this);
+  }
 
   render(): JSX.Element {
     return (
@@ -21,32 +35,53 @@ export default class Header extends React.Component<HeaderProps, any> {
           <Navbar.Brand>
             Admin
           </Navbar.Brand>
+          { this.props.libraries && this.props.libraries.length > 0 &&
+            <select
+              ref="library"
+              value={this.context.library}
+              onChange={this.changeLibrary}
+              >
+              { !this.context.library &&
+                <option>Select a library</option>
+              }
+              { this.props.libraries.map(library =>
+                  <option key={library.short_name} value={library.short_name}>{library.name || library.short_name}</option>
+                )
+              }
+            </select>
+          }
           <Navbar.Toggle />
         </Navbar.Header>
 
         <Navbar.Collapse>
           <Nav>
-            <li>
-              <CatalogLink
-                collectionUrl={this.context.homeUrl}
-                bookUrl={null}>
-                Catalog
-              </CatalogLink>
-            </li>
-            <li>
-              <CatalogLink
-                collectionUrl={"/admin/complaints"}
-                bookUrl={null}>
-                Complaints
-              </CatalogLink>
-            </li>
-            <li>
-              <CatalogLink
-                collectionUrl={"/admin/suppressed"}
-                bookUrl={null}>
-                Hidden Books
-              </CatalogLink>
-            </li>
+            { this.context.library &&
+              <li>
+                <CatalogLink
+                  collectionUrl={"/" + this.context.library + "/groups"}
+                  bookUrl={null}>
+                  Catalog
+                </CatalogLink>
+              </li>
+            }
+            { this.context.library &&
+              <li>
+                <CatalogLink
+                  collectionUrl={"/" + this.context.library + "/admin/complaints"}
+                  bookUrl={null}>
+                  Complaints
+                </CatalogLink>
+              </li>
+            }
+            { this.context.library &&
+              <li>
+                <CatalogLink
+                  collectionUrl={"/" + this.context.library + "/admin/suppressed"}
+                  bookUrl={null}>
+                  Hidden Books
+                </CatalogLink>
+              </li>
+            }
             <li>
               <Link to="/admin/web/dashboard">Dashboard</Link>
             </li>
@@ -58,4 +93,54 @@ export default class Header extends React.Component<HeaderProps, any> {
       </Navbar>
     );
   }
+
+  componentWillMount() {
+    if (this.props.fetchLibraries) {
+      this.props.fetchLibraries();
+    }
+  }
+
+  changeLibrary() {
+    let library = (this.refs["library"] as any).value;
+    if (library) {
+      this.context.router.push("/admin/web/collection/" + library + "%2Fgroups");
+    }
+  }
 }
+
+function mapStateToProps(state, ownProps) {
+  return {
+    libraries: state.editor.libraries && state.editor.libraries.data && state.editor.libraries.data.libraries
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  let actions = new ActionCreator();
+  return {
+    fetchLibraries: () => dispatch(actions.fetchLibraries())
+  };
+}
+
+const ConnectedHeader = connect<any, any, any>(
+  mapStateToProps,
+  mapDispatchToProps,
+)(Header);
+
+/** HeaderWithStore is a wrapper component to pass the store as a prop to the
+    ConnectedHeader, since it's not in the regular place in the context. */
+export default class HeaderWithStore extends React.Component<any, any> {
+  context: { editorStore: Store<State> };
+
+  static contextTypes = {
+    editorStore: React.PropTypes.object.isRequired
+  };
+
+  render(): JSX.Element {
+    return (
+      <ConnectedHeader
+        store={this.context.editorStore}
+        />
+    );
+  }
+}
+

--- a/src/components/__tests__/CatalogHandler-test.tsx
+++ b/src/components/__tests__/CatalogHandler-test.tsx
@@ -6,6 +6,8 @@ import * as jsdom from "jsdom";
 
 import CatalogHandler from "../CatalogHandler";
 import OPDSCatalog from "opds-web-client/lib/components/OPDSCatalog";
+import Header from "../Header";
+import BookDetailsContainer from "../BookDetailsContainer";
 
 describe("CatalogHandler", () => {
   let wrapper;
@@ -17,42 +19,55 @@ describe("CatalogHandler", () => {
   beforeEach(() => {
     (jsdom as any).changeURL(window, host + "/test");
     params = {
-      collectionUrl: "collectionurl",
+      collectionUrl: "library/collectionurl",
       bookUrl: "bookurl",
       tab: "tab"
-    };
-    context = {
-      homeUrl: "home url"
     };
     wrapper = shallow(
       <CatalogHandler
         params={params}
-        />,
-      { context }
+        />
     );
   });
 
   it("renders OPDSCatalog", () => {
     let catalog = wrapper.find(OPDSCatalog);
-    expect(catalog.prop("collectionUrl")).to.equal(host + "/collectionurl");
+    expect(catalog.prop("collectionUrl")).to.equal(host + "/library/collectionurl");
     expect(catalog.prop("bookUrl")).to.equal(host + "/works/bookurl");
-    expect(catalog.prop("BookDetailsContainer").name).to.equal("BookDetailsContainer");
-    expect(catalog.prop("Header").name).to.equal("Header");
+    expect(catalog.prop("BookDetailsContainer").name).to.equal(BookDetailsContainer.name);
+    expect(catalog.prop("Header").name).to.equal(Header.name);
     expect(catalog.prop("computeBreadcrumbs")).to.be.ok;
     let pageTitleTemplate = catalog.prop("pageTitleTemplate");
     expect(pageTitleTemplate("Collection", "Book")).to.equal("Circulation Manager - Book");
     expect(pageTitleTemplate("Collection", null)).to.equal("Circulation Manager - Collection");
   });
 
-  it("uses home url as default collection url", () => {
+  it("only renders header when there's no library", () => {
     let newParams = Object.assign({}, params, { collectionUrl: null, bookUrl: null, tab: null });
     wrapper.setProps({ params: newParams });
     let catalog = wrapper.find(OPDSCatalog);
-    expect(catalog.prop("collectionUrl")).to.equal("home url");
+    expect(catalog.length).to.equal(0);
+    let header = wrapper.find(Header);
+    expect(header.length).to.equal(1);
   });
 
   it("includes tab in child context", () => {
     let context = wrapper.instance().getChildContext();
     expect(context.tab).to.equal("tab");
+  });
+
+  it("includes library in child context", () => {
+    let context = wrapper.instance().getChildContext();
+    expect(context.library).to.equal("library");
+
+    let newParams = Object.assign({}, params, { collectionUrl: null, bookUrl: "library/bookurl" });
+    wrapper.setProps({ params: newParams });
+    context = wrapper.instance().getChildContext();
+    expect(context.library).to.equal("library");
+
+    newParams = Object.assign({}, params, { collectionUrl: null, bookUrl: null });
+    wrapper.setProps({ params: newParams });
+    context = wrapper.instance().getChildContext();
+    expect(context.library).to.equal(null);
   });
 });

--- a/src/components/__tests__/ContextProvider-test.tsx
+++ b/src/components/__tests__/ContextProvider-test.tsx
@@ -14,8 +14,7 @@ describe("ContextProvider", () => {
   beforeEach(() => {
     wrapper = shallow(
       <ContextProvider
-        csrfToken="token"
-        homeUrl="home url">
+        csrfToken="token">
         <FakeChild />
       </ContextProvider>
     );
@@ -27,7 +26,6 @@ describe("ContextProvider", () => {
     expect(context.editorStore.getState().catalog).to.be.ok;
     expect(context.pathFor).to.equal(wrapper.instance().pathFor);
     expect(context.csrfToken).to.equal("token");
-    expect(context.homeUrl).to.equal("home url");
   });
 
   it("renders child", () => {

--- a/src/components/__tests__/Header-test.tsx
+++ b/src/components/__tests__/Header-test.tsx
@@ -5,6 +5,7 @@ import * as React from "react";
 import { shallow, mount } from "enzyme";
 
 import { Header } from "../Header";
+import EditableInput from "../EditableInput";
 import CatalogLink from "opds-web-client/lib/components/CatalogLink";
 import { Link } from "react-router";
 
@@ -28,7 +29,7 @@ describe("Header", () => {
     });
 
     it("shows library dropdown when libraries are available", () => {
-      let select = wrapper.find("select");
+      let select = wrapper.find(EditableInput);
       expect(select.length).to.equal(0);
 
       let libraries = [
@@ -36,8 +37,9 @@ describe("Header", () => {
         { short_name: "bpl" }
       ];
       wrapper.setProps({ libraries });
-      select = wrapper.find("select");
+      select = wrapper.find(EditableInput);
       expect(select.length).to.equal(1);
+      expect(select.props().elementType).to.equal("select");
       expect(select.props().value).to.equal("nypl");
       let options = select.children();
       expect(options.length).to.equal(2);
@@ -47,11 +49,11 @@ describe("Header", () => {
       expect(options.at(1).props().value).to.equal("bpl");
 
       wrapper.setContext({ library: "bpl" });
-      select = wrapper.find("select");
+      select = wrapper.find(EditableInput);
       expect(select.props().value).to.equal("bpl");
 
       wrapper.setContext({});
-      select = wrapper.find("select");
+      select = wrapper.find(EditableInput);
       options = select.children();
       expect(options.length).to.equal(3);
       expect(options.at(0).text()).to.equal("Select a library");

--- a/src/components/__tests__/Header-test.tsx
+++ b/src/components/__tests__/Header-test.tsx
@@ -2,9 +2,9 @@ import { expect } from "chai";
 import { stub } from "sinon";
 
 import * as React from "react";
-import { shallow } from "enzyme";
+import { shallow, mount } from "enzyme";
 
-import Header from "../Header";
+import { Header } from "../Header";
 import CatalogLink from "opds-web-client/lib/components/CatalogLink";
 import { Link } from "react-router";
 
@@ -14,7 +14,7 @@ describe("Header", () => {
 
   beforeEach(() => {
     push = stub();
-    context = { homeUrl: "home url" };
+    context = { library: "nypl" };
 
     wrapper = shallow(
       <Header />,
@@ -22,38 +22,129 @@ describe("Header", () => {
     );
   });
 
-  it("shows the brand name", () => {
-    expect(wrapper.containsMatchingElement("Admin")).to.equal(true);
+  describe("rendering", () => {
+    it("shows the brand name", () => {
+      expect(wrapper.containsMatchingElement("Admin")).to.equal(true);
+    });
+
+    it("shows library dropdown when libraries are available", () => {
+      let select = wrapper.find("select");
+      expect(select.length).to.equal(0);
+
+      let libraries = [
+        { short_name: "nypl", name: "NYPL" },
+        { short_name: "bpl" }
+      ];
+      wrapper.setProps({ libraries });
+      select = wrapper.find("select");
+      expect(select.length).to.equal(1);
+      expect(select.props().value).to.equal("nypl");
+      let options = select.children();
+      expect(options.length).to.equal(2);
+      expect(options.at(0).text()).to.equal("NYPL");
+      expect(options.at(0).props().value).to.equal("nypl");
+      expect(options.at(1).text()).to.equal("bpl");
+      expect(options.at(1).props().value).to.equal("bpl");
+
+      wrapper.setContext({ library: "bpl" });
+      select = wrapper.find("select");
+      expect(select.props().value).to.equal("bpl");
+
+      wrapper.setContext({});
+      select = wrapper.find("select");
+      options = select.children();
+      expect(options.length).to.equal(3);
+      expect(options.at(0).text()).to.equal("Select a library");
+      expect(options.at(1).text()).to.equal("NYPL");
+      expect(options.at(1).props().value).to.equal("nypl");
+      expect(options.at(2).text()).to.equal("bpl");
+      expect(options.at(2).props().value).to.equal("bpl");
+    });
+
+    it("shows catalog links when there's a library", () => {
+      let catalogLinks = wrapper.find(CatalogLink);
+
+      expect(catalogLinks.length).to.equal(3);
+
+      let mainCatalogLink = catalogLinks.at(0);
+      expect(mainCatalogLink.prop("collectionUrl")).to.equal("/nypl/groups");
+      expect(mainCatalogLink.prop("bookUrl")).to.equal(null);
+      expect(mainCatalogLink.children().text()).to.equal("Catalog");
+
+      let complaintsLink = catalogLinks.at(1);
+      expect(complaintsLink.prop("collectionUrl")).to.equal("/nypl/admin/complaints");
+      expect(complaintsLink.prop("bookUrl")).to.equal(null);
+      expect(complaintsLink.children().text()).to.equal("Complaints");
+
+      let hiddenLink = catalogLinks.at(2);
+      expect(hiddenLink.prop("collectionUrl")).to.equal("/nypl/admin/suppressed");
+      expect(hiddenLink.prop("bookUrl")).to.equal(null);
+      expect(hiddenLink.children().text()).to.equal("Hidden Books");
+
+      wrapper.setContext({});
+      catalogLinks = wrapper.find(CatalogLink);
+      expect(catalogLinks.length).to.equal(0);
+    });
+
+    it("shows sitewide links", () => {
+      let links = wrapper.find(Link);
+
+      let dashboardLink = links.at(0);
+      expect(dashboardLink.prop("to")).to.equal("/admin/web/dashboard");
+      expect(dashboardLink.children().text()).to.equal("Dashboard");
+
+      let settingsLink = links.at(1);
+      expect(settingsLink.prop("to")).to.equal("/admin/web/config");
+      expect(settingsLink.children().text()).to.equal("Configuration");
+    });
   });
 
-  it("shows links", () => {
-    let catalogLinks = wrapper.find(CatalogLink);
+  describe("behavior", () => {
+    it("fetches libraries on mount", () => {
+      let fetchLibraries = stub();
+      wrapper = shallow(
+        <Header
+          fetchLibraries={fetchLibraries}
+          />
+      );
+      expect(fetchLibraries.callCount).to.equal(1);
+    });
 
-    expect(catalogLinks.length).to.equal(3);
+    it("changes library", async () => {
+      let libraries = [
+        { short_name: "nypl", name: "NYPL" },
+        { short_name: "bpl" }
+      ];
+      let childContextTypes = {
+        router: React.PropTypes.object.isRequired,
+        pathFor: React.PropTypes.func.isRequired
+      };
+      let fullContext = Object.assign({}, context, {
+        pathFor: stub().returns("url"),
+        router: {
+          createHref: stub(),
+          push: stub(),
+          isActive: stub(),
+          replace: stub(),
+          go: stub(),
+          goBack: stub(),
+          goForward: stub(),
+          setRouteLeaveHook: stub()
+        }
+      });
+      wrapper = mount(
+        <Header
+          libraries={libraries}
+          />,
+        { context: fullContext, childContextTypes }
+      );
+      let select = wrapper.find("select") as any;
+      let selectElement = select.get(0);
+      selectElement.value = "bpl";
+      select.simulate("change");
 
-    let homeLink = catalogLinks.at(0);
-    expect(homeLink.prop("collectionUrl")).to.equal("home url");
-    expect(homeLink.prop("bookUrl")).to.equal(null);
-    expect(homeLink.children().text()).to.equal("Catalog");
-
-    let complaintsLink = catalogLinks.at(1);
-    expect(complaintsLink.prop("collectionUrl")).to.equal("/admin/complaints");
-    expect(complaintsLink.prop("bookUrl")).to.equal(null);
-    expect(complaintsLink.children().text()).to.equal("Complaints");
-
-    let hiddenLink = catalogLinks.at(2);
-    expect(hiddenLink.prop("collectionUrl")).to.equal("/admin/suppressed");
-    expect(hiddenLink.prop("bookUrl")).to.equal(null);
-    expect(hiddenLink.children().text()).to.equal("Hidden Books");
-
-    let links = wrapper.find(Link);
-
-    let dashboardLink = links.at(0);
-    expect(dashboardLink.prop("to")).to.equal("/admin/web/dashboard");
-    expect(dashboardLink.children().text()).to.equal("Dashboard");
-
-    let settingsLink = links.at(1);
-    expect(settingsLink.prop("to")).to.equal("/admin/web/config");
-    expect(settingsLink.children().text()).to.equal("Configuration");
+      expect(fullContext.router.push.callCount).to.equal(1);
+      expect(fullContext.router.push.args[0][0]).to.equal("/admin/web/collection/bpl%2Fgroups");
+    });
   });
 });

--- a/src/stylesheets/header.scss
+++ b/src/stylesheets/header.scss
@@ -4,3 +4,8 @@
   margin-right: 10px;
   margin-top: -5px;
 }
+
+.navbar-header select {
+  color: $pagetextcolor;
+  margin-top: 15px;
+}

--- a/src/stylesheets/header.scss
+++ b/src/stylesheets/header.scss
@@ -5,7 +5,12 @@
   margin-top: -5px;
 }
 
-.navbar-header select {
-  color: $pagetextcolor;
-  margin-top: 15px;
+.navbar-header .form-group {
+  display: inline-block;
+  margin-top: 7px;
+}
+
+.navbar-header .form-control {
+  display: inline-block;
+  width: auto;
 }


### PR DESCRIPTION
This branch makes the admin interface work better when there are multiple libraries on the circulation manager.

The header has a dropdown with a list of the libraries in the system. When you select a different library, you're sent to that library's catalog page. When you're on a page like configuration that's not specific to a library, the library-related links don't show and the dropdown doesn't show a selected library, but you can select one to get back to the library's catalog.

This still needs work, but at least now you can get to the catalogs for all the libraries instead of being stuck on the default library.