### PR TITLE
Parent dropdown for collections

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "description": "Web Front-end for Library Simplified Circulation Manager",
   "repository": {
     "type": "git",

--- a/src/components/EditableConfigList.tsx
+++ b/src/components/EditableConfigList.tsx
@@ -24,6 +24,7 @@ export interface EditFormProps<T, U> {
   disabled: boolean;
   editItem: (data: FormData) => Promise<void>;
   urlBase: string;
+  listDataKey: string;
 }
 
 export abstract class EditableConfigList<T, U> extends React.Component<EditableConfigListProps<T>, void> {
@@ -80,6 +81,7 @@ export abstract class EditableConfigList<T, U> extends React.Component<EditableC
               disabled={this.props.isFetching}
               editItem={this.editItem}
               urlBase={this.urlBase}
+              listDataKey={this.listDataKey}
               />
           </div>
         }
@@ -94,6 +96,7 @@ export abstract class EditableConfigList<T, U> extends React.Component<EditableC
               disabled={this.props.isFetching}
               editItem={this.editItem}
               urlBase={this.urlBase}
+              listDataKey={this.listDataKey}
               />
           </div>
         }

--- a/src/components/IndividualAdminEditForm.tsx
+++ b/src/components/IndividualAdminEditForm.tsx
@@ -9,6 +9,7 @@ export interface IndividualAdminEditFormProps {
   disabled: boolean;
   editItem: (data: FormData) => Promise<void>;
   urlBase: string;
+  listDataKey: string;
 }
 
 export interface IndividualAdminEditFormContext {

--- a/src/components/LibraryEditForm.tsx
+++ b/src/components/LibraryEditForm.tsx
@@ -10,6 +10,7 @@ export interface LibraryEditFormProps {
   disabled: boolean;
   editItem: (data: FormData) => Promise<void>;
   urlBase: string;
+  listDataKey: string;
 }
 
 export default class LibraryEditForm extends React.Component<LibraryEditFormProps, void> {

--- a/src/components/ServiceEditForm.tsx
+++ b/src/components/ServiceEditForm.tsx
@@ -11,10 +11,12 @@ export interface ServiceEditFormProps<T> {
   disabled: boolean;
   editItem: (data: FormData) => Promise<void>;
   urlBase: string;
+  listDataKey: string;
 }
 
 export interface ServiceEditFormState {
   protocol: string;
+  parentId: string | null;
   libraries: LibraryWithSettingsData[];
 }
 
@@ -27,9 +29,11 @@ export default class ServiceEditForm<T extends ServicesData> extends React.Compo
     }
     this.state = {
       protocol: (this.props.item && this.props.item.protocol) || defaultProtocol,
+      parentId: (this.props.item && this.props.item.parent_id && String(this.props.item.parent_id)) || null,
       libraries: (this.props.item && this.props.item.libraries) || []
     };
     this.handleProtocolChange = this.handleProtocolChange.bind(this);
+    this.handleParentChange = this.handleParentChange.bind(this);
     this.addLibrary = this.addLibrary.bind(this);
     this.removeLibrary = this.removeLibrary.bind(this);
     this.save = this.save.bind(this);
@@ -75,6 +79,23 @@ export default class ServiceEditForm<T extends ServicesData> extends React.Compo
         </EditableInput>
         { this.protocolDescription() &&
           <p>{ this.protocolDescription() }</p>
+        }
+        { this.props.data && this.allowsParent() && (this.availableParents().length > 0) &&
+          <EditableInput
+            elementType="select"
+            disabled={this.props.disabled}
+            name="parent_id"
+            label="Parent"
+            value={this.state.parentId}
+            ref="parent"
+            onChange={this.handleParentChange}
+            >
+            <option value="none">None</option>
+            { this.availableParents().map(parent =>
+                <option key={parent.id} value={parent.id}>{parent.name || parent.id}</option>
+              )
+            }
+          </EditableInput>
         }
         { this.props.data && this.props.data.protocols && this.protocolSettings() && this.protocolSettings().map(setting =>
             <ProtocolFormField
@@ -147,6 +168,7 @@ export default class ServiceEditForm<T extends ServicesData> extends React.Compo
 
   componentWillReceiveProps(newProps) {
     let protocol = this.state.protocol;
+    let parentId = this.state.parentId;
     let libraries = this.state.libraries;
     if (newProps.item && newProps.item.protocol) {
       if (!this.props.item || !this.props.item.protocol || (this.props.item.protocol !== newProps.item.protocol)) {
@@ -156,12 +178,19 @@ export default class ServiceEditForm<T extends ServicesData> extends React.Compo
     if (!protocol && this.availableProtocols(newProps).length > 0) {
         protocol = this.availableProtocols(newProps)[0].name;
     }
+
+    if (newProps.item && newProps.item.parent_id) {
+      if (!this.props.item || !this.props.item.parent_id || (this.props.item.parent_id !== newProps.item.parent_id)) {
+        parentId = newProps.item.parent_id;
+      }
+    }
+
     if (newProps.item && newProps.item.libraries) {
       if (!this.props.item || !this.props.item.libraries || (this.props.item.libraries !== newProps.item.libraries)) {
         libraries = newProps.item.libraries;
       }
     }
-    this.setState({ protocol, libraries });
+    this.setState({ protocol, parentId, libraries });
   }
 
   availableProtocols(props?): ProtocolData[] {
@@ -183,14 +212,48 @@ export default class ServiceEditForm<T extends ServicesData> extends React.Compo
 
   handleProtocolChange() {
     const protocol = (this.refs["protocol"] as any).getValue();
-    this.setState({ protocol, libraries: this.state.libraries });
+    this.setState({ protocol, parentId: this.state.parentId, libraries: this.state.libraries });
+  }
+
+  allowsParent(): boolean {
+    if (this.state.protocol && this.props.data.protocols) {
+      for (const protocol of this.props.data.protocols) {
+        if (protocol.name === this.state.protocol) {
+          return !!protocol.child_settings;
+        }
+      }
+    }
+    return false;
+  }
+
+  availableParents() {
+    const allServices = this.props.data && this.props.data[this.props.listDataKey] || [];
+    const availableParents = [];
+    for (const service of allServices) {
+      if (service.protocol === this.state.protocol && service.id !== (this.props.item && this.props.item.id)) {
+        availableParents.push(service);
+      }
+    }
+    return availableParents;
+  }
+
+  handleParentChange() {
+    let parentId = (this.refs["parent"] as any).getValue();
+    if (parentId === "none") {
+      parentId = null;
+    }
+    this.setState({ protocol: this.state.protocol, parentId, libraries: this.state.libraries });
   }
 
   protocolSettings() {
     if (this.state.protocol && this.props.data.protocols) {
       for (const protocol of this.props.data.protocols) {
         if (protocol.name === this.state.protocol) {
-          return protocol.settings;
+          if (this.state.parentId) {
+            return protocol.child_settings;
+          } else {
+            return protocol.settings;
+          }
         }
       }
     }
@@ -244,7 +307,7 @@ export default class ServiceEditForm<T extends ServicesData> extends React.Compo
 
   removeLibrary(library) {
     const libraries = this.state.libraries.filter(stateLibrary => stateLibrary.short_name !== library.short_name);
-    this.setState({ protocol: this.state.protocol, libraries });
+    this.setState({ protocol: this.state.protocol, parentId: this.state.parentId, libraries });
   }
 
   addLibrary() {
@@ -257,7 +320,7 @@ export default class ServiceEditForm<T extends ServicesData> extends React.Compo
       }
     }
     const libraries = this.state.libraries.concat(newLibrary);
-    this.setState({ protocol: this.state.protocol, libraries });
+    this.setState({ protocol: this.state.protocol, parentId: this.state.parentId, libraries });
   }
 
   save(event) {

--- a/src/components/SitewideSettingEditForm.tsx
+++ b/src/components/SitewideSettingEditForm.tsx
@@ -9,6 +9,7 @@ export interface SitewideSettingEditFormProps {
   disabled: boolean;
   editItem: (data: FormData) => Promise<void>;
   urlBase: string;
+  listDataKey: string;
 }
 
 export default class SitewideSettingEditForm extends React.Component<SitewideSettingEditFormProps, void> {

--- a/src/components/__tests__/EditableConfigList-test.tsx
+++ b/src/components/__tests__/EditableConfigList-test.tsx
@@ -134,6 +134,7 @@ describe("EditableConfigList", () => {
     expect(form.props().item).to.be.undefined;
     expect(form.props().csrfToken).to.equal("token");
     expect(form.props().disabled).to.equal(false);
+    expect(form.props().listDataKey).to.equal("things");
   });
 
   it("shows edit form", () => {
@@ -144,6 +145,7 @@ describe("EditableConfigList", () => {
     expect(form.props().item).to.equal(thingData);
     expect(form.props().csrfToken).to.equal("token");
     expect(form.props().disabled).to.equal(false);
+    expect(form.props().listDataKey).to.equal("things");
   });
 
   it("fetches data on mount and passes edit function to form", async () => {

--- a/src/components/__tests__/IndividualAdminEditForm-test.tsx
+++ b/src/components/__tests__/IndividualAdminEditForm-test.tsx
@@ -32,7 +32,8 @@ describe("IndividualAdminEditForm", () => {
           csrfToken="token"
           disabled={false}
           editItem={editIndividualAdmin}
-          urlBase={"url base"}
+          urlBase="url base"
+          listDataKey="admins"
           />
       );
     });
@@ -71,7 +72,8 @@ describe("IndividualAdminEditForm", () => {
           csrfToken="token"
           disabled={false}
           editItem={editIndividualAdmin}
-          urlBase={"url base"}
+          urlBase="url base"
+          listDataKey="admins"
           />
       );
     });

--- a/src/components/__tests__/LibraryEditForm-test.tsx
+++ b/src/components/__tests__/LibraryEditForm-test.tsx
@@ -50,7 +50,8 @@ describe("LibraryEditForm", () => {
           csrfToken="token"
           disabled={false}
           editItem={editLibrary}
-          urlBase={"url base"}
+          urlBase="url base"
+          listDataKey="libraries"
           />
       );
     });
@@ -112,7 +113,8 @@ describe("LibraryEditForm", () => {
           csrfToken="token"
           disabled={false}
           editItem={editLibrary}
-          urlBase={"url base"}
+          urlBase="url base"
+          listDataKey="libraries"
           />
       );
     });

--- a/src/components/__tests__/SitewideSettingEditForm-test.tsx
+++ b/src/components/__tests__/SitewideSettingEditForm-test.tsx
@@ -41,7 +41,8 @@ describe("SitewideSettingEditForm", () => {
           csrfToken="token"
           disabled={false}
           editItem={editSitewideSetting}
-          urlBase={"url base"}
+          urlBase="url base"
+          listDataKey="settings"
           />
       );
     });
@@ -57,7 +58,8 @@ describe("SitewideSettingEditForm", () => {
           csrfToken="token"
           disabled={false}
           editItem={editSitewideSetting}
-          urlBase={"url base"}
+          urlBase="url base"
+          listDataKey="settings"
           />
       );
       let message = wrapper.find("p");
@@ -108,7 +110,8 @@ describe("SitewideSettingEditForm", () => {
           csrfToken="token"
           disabled={false}
           editItem={editSitewideSetting}
-          urlBase={"url base"}
+          urlBase="url base"
+          listDataKey="settings"
           />
       );
     });

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -142,6 +142,7 @@ export interface ProtocolData {
   description?: string;
   sitewide?: boolean;
   settings: SettingData[];
+  child_settings?: SettingData[];
   library_settings?: SettingData[];
 }
 
@@ -149,6 +150,7 @@ export interface ServiceData {
   id?: string | number;
   name?: string;
   protocol: string;
+  parent_id?: string | number;
   settings?: {
     [key: string]: string;
   };


### PR DESCRIPTION
This branch adds a parent dropdown to the service edit form. It's only used when the protocol has "child_settings", which only Overdrive does for now. It also only shows if there is at least one other Overdrive collection that could be the parent.

When the dropdown shows, it has "None" and all the other Overdrive collections in the system. If "None" is selected, the rest of the form will have the protocol's "settings", and if a parent is selected, the rest of the form will have the protocol's "child_settings".