### PR TITLE
Fixed book url shortening for multi-library.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "description": "Web Front-end for Library Simplified Circulation Manager",
   "repository": {
     "type": "git",

--- a/src/components/CatalogHandler.tsx
+++ b/src/components/CatalogHandler.tsx
@@ -28,12 +28,11 @@ export default class CatalogHandler extends React.Component<CatalogHandlerProps,
   getChildContext() {
     return {
       tab: this.props.params.tab,
-      library: this.getLibrary()
+      library: this.getLibrary(this.props.params.collectionUrl, this.props.params.bookUrl)
     };
   }
 
-  getLibrary(): string {
-    let { collectionUrl, bookUrl } = this.props.params;
+  getLibrary(collectionUrl, bookUrl): string {
     if (collectionUrl) {
       let urlParts = collectionUrl.split("/");
       if (urlParts.length > 0) {
@@ -56,13 +55,16 @@ export default class CatalogHandler extends React.Component<CatalogHandlerProps,
   }
 
   expandBookUrl(url: string): string {
-    return url ?
-      document.location.origin + "/works/" + url :
-      url;
+    if (url) {
+      const library = this.getLibrary(null, url);
+      return document.location.origin + "/" + library + "/works/" + url.replace(library + "/", "");
+    } else {
+      return url;
+    }
   }
 
   render(): JSX.Element {
-    if (!this.getLibrary()) {
+    if (!this.getLibrary(this.props.params.collectionUrl, this.props.params.bookUrl)) {
       return (
         <Header />
       );

--- a/src/components/ContextProvider.tsx
+++ b/src/components/ContextProvider.tsx
@@ -39,9 +39,17 @@ export default class ContextProvider extends React.Component<ContextProviderProp
   }
 
   prepareBookUrl(url: string): string {
-    return encodeURIComponent(
-      url.replace(document.location.origin + "/works/", "").replace(/\/$/, "").replace(/^\//, "")
-    );
+    const regexp = new RegExp(document.location.origin + "/(.*)/works/(.*)");
+    const match = regexp.exec(url);
+    if (match) {
+      const library = match[1];
+      const work = match[2];
+      return encodeURIComponent(
+        library + "/" + work
+      );
+    } else {
+      return url;
+    }
   }
 
   static childContextTypes: React.ValidationMap<any> = {

--- a/src/components/__tests__/CatalogHandler-test.tsx
+++ b/src/components/__tests__/CatalogHandler-test.tsx
@@ -20,7 +20,7 @@ describe("CatalogHandler", () => {
     (jsdom as any).changeURL(window, host + "/test");
     params = {
       collectionUrl: "library/collectionurl",
-      bookUrl: "bookurl",
+      bookUrl: "library/bookurl",
       tab: "tab"
     };
     wrapper = shallow(
@@ -33,7 +33,7 @@ describe("CatalogHandler", () => {
   it("renders OPDSCatalog", () => {
     let catalog = wrapper.find(OPDSCatalog);
     expect(catalog.prop("collectionUrl")).to.equal(host + "/library/collectionurl");
-    expect(catalog.prop("bookUrl")).to.equal(host + "/works/bookurl");
+    expect(catalog.prop("bookUrl")).to.equal(host + "/library/works/bookurl");
     expect(catalog.prop("BookDetailsContainer").name).to.equal(BookDetailsContainer.name);
     expect(catalog.prop("Header").name).to.equal(Header.name);
     expect(catalog.prop("computeBreadcrumbs")).to.be.ok;

--- a/src/components/__tests__/ContextProvider-test.tsx
+++ b/src/components/__tests__/ContextProvider-test.tsx
@@ -48,8 +48,8 @@ describe("ContextProvider", () => {
     it("prepares book url", () => {
       let host = "http://example.com";
       (jsdom as any).changeURL(window, host + "/test");
-      let url = host + "/works/Axis%20360/Axis%20360%20ID/0016201449";
-      expect(wrapper.instance().prepareBookUrl(url)).to.equal("Axis%2520360%2FAxis%2520360%2520ID%2F0016201449");
+      let url = host + "/library/works/Axis%20360/Axis%20360%20ID/0016201449";
+      expect(wrapper.instance().prepareBookUrl(url)).to.equal("library%2FAxis%2520360%2FAxis%2520360%2520ID%2F0016201449");
     });
 
     it("returns a path with collection, book, and tab", () => {


### PR DESCRIPTION
This fixes the shortened book urls now that the library short name is part of the url.

The long urls look like http://circulation/library/works/abcd, and they're shortened to /book/library/abcd. The old code assumed that /works was the beginning of the url.

This change won't work for default library urls where the short name isn't in the url, but for the admin interface it should be fine to always use the urls with the library short name.