### PR TITLE
Made library-related header links update when library changes.

### DIFF
--- a/src/components/CatalogHandler.tsx
+++ b/src/components/CatalogHandler.tsx
@@ -22,13 +22,13 @@ export interface CatalogHandlerProps extends React.Props<CatalogHandler> {
 export default class CatalogHandler extends React.Component<CatalogHandlerProps, any> {
   static childContextTypes: React.ValidationMap<any> = {
     tab: React.PropTypes.string,
-    library: React.PropTypes.string
+    library: React.PropTypes.func
   };
 
   getChildContext() {
     return {
       tab: this.props.params.tab,
-      library: this.getLibrary(this.props.params.collectionUrl, this.props.params.bookUrl)
+      library: () => this.getLibrary(this.props.params.collectionUrl, this.props.params.bookUrl)
     };
   }
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -17,10 +17,10 @@ export interface HeaderProps extends React.Props<Header> {
 }
 
 export class Header extends React.Component<HeaderProps, any> {
-  context: { library: string, router: Router };
+  context: { library: () => string, router: Router };
 
   static contextTypes = {
-    library: React.PropTypes.string,
+    library: React.PropTypes.func,
     router: React.PropTypes.object.isRequired
   };
 
@@ -40,7 +40,7 @@ export class Header extends React.Component<HeaderProps, any> {
             <EditableInput
               elementType="select"
               ref="library"
-              value={this.context.library}
+              value={this.context.library && this.context.library()}
               onChange={this.changeLibrary}
               >
               { !this.context.library &&
@@ -60,21 +60,21 @@ export class Header extends React.Component<HeaderProps, any> {
             <Nav>
               <li>
                 <CatalogLink
-                  collectionUrl={"/" + this.context.library + "/groups"}
+                  collectionUrl={"/" + this.context.library() + "/groups"}
                   bookUrl={null}>
                   Catalog
                 </CatalogLink>
               </li>
               <li>
                 <CatalogLink
-                  collectionUrl={"/" + this.context.library + "/admin/complaints"}
+                  collectionUrl={"/" + this.context.library() + "/admin/complaints"}
                   bookUrl={null}>
                   Complaints
                 </CatalogLink>
               </li>
               <li>
                 <CatalogLink
-                  collectionUrl={"/" + this.context.library + "/admin/suppressed"}
+                  collectionUrl={"/" + this.context.library() + "/admin/suppressed"}
                   bookUrl={null}>
                   Hidden Books
                 </CatalogLink>
@@ -104,6 +104,7 @@ export class Header extends React.Component<HeaderProps, any> {
     let library = (this.refs["library"] as any).getValue();
     if (library) {
       this.context.router.push("/admin/web/collection/" + library + "%2Fgroups");
+      this.forceUpdate();
     }
   }
 }

--- a/src/components/__tests__/CatalogHandler-test.tsx
+++ b/src/components/__tests__/CatalogHandler-test.tsx
@@ -58,16 +58,16 @@ describe("CatalogHandler", () => {
 
   it("includes library in child context", () => {
     let context = wrapper.instance().getChildContext();
-    expect(context.library).to.equal("library");
+    expect(context.library()).to.equal("library");
 
     let newParams = Object.assign({}, params, { collectionUrl: null, bookUrl: "library/bookurl" });
     wrapper.setProps({ params: newParams });
     context = wrapper.instance().getChildContext();
-    expect(context.library).to.equal("library");
+    expect(context.library()).to.equal("library");
 
     newParams = Object.assign({}, params, { collectionUrl: null, bookUrl: null });
     wrapper.setProps({ params: newParams });
     context = wrapper.instance().getChildContext();
-    expect(context.library).to.equal(null);
+    expect(context.library()).to.equal(null);
   });
 });

--- a/src/components/__tests__/Header-test.tsx
+++ b/src/components/__tests__/Header-test.tsx
@@ -15,7 +15,7 @@ describe("Header", () => {
 
   beforeEach(() => {
     push = stub();
-    context = { library: "nypl" };
+    context = { library: () => "nypl" };
 
     wrapper = shallow(
       <Header />,
@@ -48,7 +48,7 @@ describe("Header", () => {
       expect(options.at(1).text()).to.equal("bpl");
       expect(options.at(1).props().value).to.equal("bpl");
 
-      wrapper.setContext({ library: "bpl" });
+      wrapper.setContext({ library: () => "bpl" });
       select = wrapper.find(EditableInput);
       expect(select.props().value).to.equal("bpl");
 


### PR DESCRIPTION
I thought React components would re-render on context changes, but they don't. This meant that the header wouldn't update to show a new library when it changed in the context. I had to change the context to have a function that returns the library instead of a string, and also call forceUpdate when the library changes.