### PR TITLE
Defaults for list with options and fixed collections with no parent

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "description": "Web Front-end for Library Simplified Circulation Manager",
   "repository": {
     "type": "git",

--- a/src/components/ProtocolFormField.tsx
+++ b/src/components/ProtocolFormField.tsx
@@ -97,7 +97,7 @@ export default class ProtocolFormField extends React.Component<ProtocolFormField
                 disabled={this.props.disabled}
                 name={`${setting.key}_${option.key}`}
                 label={option.label}
-                checked={this.props.value && (this.props.value.indexOf(option.key) !== -1)}
+                checked={(this.props.value && (this.props.value.indexOf(option.key) !== -1)) || (!this.props.value && setting.default && setting.default.indexOf(option.key) !== -1)}
                 />
             )
           }

--- a/src/components/ServiceEditForm.tsx
+++ b/src/components/ServiceEditForm.tsx
@@ -89,7 +89,7 @@ export default class ServiceEditForm<T extends ServicesData> extends React.Compo
             ref="parent"
             onChange={this.handleParentChange}
             >
-            <option value="none">None</option>
+            <option value="">None</option>
             { this.availableParents().map(parent =>
                 <option key={parent.id} value={parent.id}>{parent.name || parent.id}</option>
               )
@@ -233,7 +233,7 @@ export default class ServiceEditForm<T extends ServicesData> extends React.Compo
 
   handleParentChange() {
     let parentId = (this.refs["parent"] as any).getValue();
-    if (parentId === "none") {
+    if (parentId === "") {
       parentId = null;
     }
     this.setState({ protocol: this.state.protocol, parentId, libraries: this.state.libraries });

--- a/src/components/__tests__/ProtocolFormField-test.tsx
+++ b/src/components/__tests__/ProtocolFormField-test.tsx
@@ -183,7 +183,8 @@ describe("ProtocolFormField", () => {
         { key: "option1", label: "option 1" },
         { key: "option2", label: "option 2" },
         { key: "option3", label: "option 3" }
-      ]
+      ],
+      default: ["option2", "option3"]
     };
     const wrapper = shallow(
       <ProtocolFormField
@@ -208,8 +209,8 @@ describe("ProtocolFormField", () => {
     expect(input.at(2).prop("label")).to.equal("option 3");
 
     expect(input.at(0).prop("checked")).not.to.be.ok;
-    expect(input.at(1).prop("checked")).not.to.be.ok;
-    expect(input.at(2).prop("checked")).not.to.be.ok;
+    expect(input.at(1).prop("checked")).to.be.ok;
+    expect(input.at(2).prop("checked")).to.be.ok;
 
     wrapper.setProps({ value: ["option1", "option3"] });
 

--- a/src/components/__tests__/ServiceEditForm-test.tsx
+++ b/src/components/__tests__/ServiceEditForm-test.tsx
@@ -558,7 +558,7 @@ describe("ServiceEditForm", () => {
       input = protocolFormFieldByKey("child_setting");
       expect(input.length).to.equal(1);
 
-      selectElement.value = "none";
+      selectElement.value = "";
       select.simulate("change");
 
       input = protocolFormFieldByKey("parent_setting");

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -130,7 +130,7 @@ export interface SettingData {
   key: string;
   label: string;
   description?: string;
-  default?: string;
+  default?: string | string[];
   optional?: boolean;
   randomizable?: boolean;
   type?: string;


### PR DESCRIPTION
This fixes two things: the lists of enabled facets didn't have anything checked by default and it was annoying to have to do it for every library, and collections with no parent were causing an error because they were sending "none" instead of a falsy value as the parent id.