### PR TITLE
Library registration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.0.38",
+  "version": "0.0.39",
   "description": "Web Front-end for Library Simplified Circulation Manager",
   "repository": {
     "type": "git",

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -47,6 +47,7 @@ export default class ActionCreator extends BaseActionCreator {
   static readonly EDIT_SEARCH_SERVICE = "EDIT_SEARCH_SERVICE";
   static readonly DISCOVERY_SERVICES = "DISCOVERY_SERVICES";
   static readonly EDIT_DISCOVERY_SERVICE = "EDIT_DISCOVERY_SERVICE";
+  static readonly REGISTER_LIBRARY = "REGISTER_LIBRARY";
 
   static readonly EDIT_BOOK_REQUEST = "EDIT_BOOK_REQUEST";
   static readonly EDIT_BOOK_SUCCESS = "EDIT_BOOK_SUCCESS";
@@ -354,5 +355,10 @@ export default class ActionCreator extends BaseActionCreator {
   editDiscoveryService(data: FormData) {
     const url = "/admin/discovery_services";
     return this.postForm(ActionCreator.EDIT_DISCOVERY_SERVICE, url, data).bind(this);
+  }
+
+  registerLibrary(data: FormData) {
+    const url = "/admin/library_registrations";
+    return this.postForm(ActionCreator.REGISTER_LIBRARY, url, data).bind(this);
   }
 }

--- a/src/components/DiscoveryServiceEditForm.tsx
+++ b/src/components/DiscoveryServiceEditForm.tsx
@@ -1,0 +1,36 @@
+import * as React from "react";
+import ServiceEditForm from "./ServiceEditForm";
+import { DiscoveryServicesData } from "../interfaces";
+
+export default class DiscoveryServiceEditForm extends ServiceEditForm<DiscoveryServicesData> {
+  context: { registerLibrary: (library) => void };
+
+  static contextTypes = {
+    registerLibrary: React.PropTypes.func
+  };
+
+  render(): JSX.Element {
+    return (
+      <div>
+        {super.render()}
+        { this.props.item && this.props.data && this.props.data.allLibraries && this.props.data.allLibraries.length > 0 &&
+          <div>
+            <h2>Register libraries</h2>
+            { this.props.data.allLibraries.map(library =>
+                <div className="discovery-service-library" key={library.short_name}>
+                  <button
+                    type="button"
+                    className="btn btn-default"
+                    disabled={this.props.disabled}
+                    onClick={() => this.context.registerLibrary(library)}
+                    >Register</button>
+                  {library.name}
+                </div>
+              )
+            }
+          </div>
+        }
+      </div>
+    );
+  }
+}

--- a/src/components/DiscoveryServices.tsx
+++ b/src/components/DiscoveryServices.tsx
@@ -1,24 +1,50 @@
-import EditableConfigList from "./EditableConfigList";
+import * as React from "react";
+import { GenericEditableConfigList, EditableConfigListProps } from "./EditableConfigList";
 import { connect } from "react-redux";
 import ActionCreator from "../actions";
-import { DiscoveryServicesData, DiscoveryServiceData } from "../interfaces";
-import ServiceEditForm from "./ServiceEditForm";
+import { DiscoveryServicesData, DiscoveryServiceData, LibraryData } from "../interfaces";
+import DiscoveryServiceEditForm from "./DiscoveryServiceEditForm";
 
-export class DiscoveryServices extends EditableConfigList<DiscoveryServicesData, DiscoveryServiceData> {
-  EditForm = ServiceEditForm;
+export interface DiscoveryServicesProps extends EditableConfigListProps<DiscoveryServicesData> {
+  registerLibrary: (library: LibraryData) => void;
+}
+
+export class DiscoveryServices extends GenericEditableConfigList<DiscoveryServicesData, DiscoveryServiceData, DiscoveryServicesProps> {
+  EditForm = DiscoveryServiceEditForm;
   listDataKey = "discovery_services";
   itemTypeName = "discovery service";
   urlBase = "/admin/web/config/discovery/";
   identifierKey = "id";
   labelKey = "name";
+
+  static childContextTypes: React.ValidationMap<any> = {
+    registerLibrary: React.PropTypes.func
+  };
+
+  getChildContext() {
+    return {
+      registerLibrary: (library: LibraryData) => {
+        if (this.itemToEdit()) {
+          const data = new (window as any).FormData();
+          data.append("csrf_token", this.props.csrfToken);
+          data.append("library_short_name", library.short_name);
+          data.append("integration_id", this.itemToEdit().id);
+          this.props.registerLibrary(data);
+        }
+      }
+    };
+  }
 }
 
 function mapStateToProps(state, ownProps) {
   const data = Object.assign({}, state.editor.discoveryServices && state.editor.discoveryServices.data || {});
+  if (state.editor.libraries && state.editor.libraries.data) {
+    data.allLibraries = state.editor.libraries.data.libraries;
+  }
   return {
     data: data,
-    fetchError: state.editor.discoveryServices.fetchError,
-    isFetching: state.editor.discoveryServices.isFetching || state.editor.discoveryServices.isEditing
+    fetchError: state.editor.discoveryServices.fetchError || (state.editor.registerLibrary && state.editor.registerLibrary.fetchError),
+    isFetching: state.editor.discoveryServices.isFetching || state.editor.discoveryServices.isEditing || (state.editor.registerLibrary && state.editor.registerLibrary.isFetching)
   };
 }
 
@@ -26,7 +52,8 @@ function mapDispatchToProps(dispatch) {
   let actions = new ActionCreator();
   return {
     fetchData: () => dispatch(actions.fetchDiscoveryServices()),
-    editItem: (data: FormData) => dispatch(actions.editDiscoveryService(data))
+    editItem: (data: FormData) => dispatch(actions.editDiscoveryService(data)),
+    registerLibrary: (data: FormData) => dispatch(actions.registerLibrary(data))
   };
 }
 

--- a/src/components/EditableConfigList.tsx
+++ b/src/components/EditableConfigList.tsx
@@ -27,7 +27,7 @@ export interface EditFormProps<T, U> {
   listDataKey: string;
 }
 
-export abstract class EditableConfigList<T, U> extends React.Component<EditableConfigListProps<T>, void> {
+export abstract class GenericEditableConfigList<T, U, V extends EditableConfigListProps<T>> extends React.Component<V, void> {
   abstract EditForm: new(props: EditFormProps<T, U>) => React.Component<EditFormProps<T, U>, any>;
   abstract listDataKey: string;
   abstract itemTypeName: string;
@@ -133,5 +133,7 @@ export abstract class EditableConfigList<T, U> extends React.Component<EditableC
     return null;
   }
 }
+
+export abstract class EditableConfigList<T, U> extends GenericEditableConfigList<T, U, EditableConfigListProps<T>> {}
 
 export default EditableConfigList;

--- a/src/components/__tests__/DiscoveryServiceEditForm-test.tsx
+++ b/src/components/__tests__/DiscoveryServiceEditForm-test.tsx
@@ -1,0 +1,98 @@
+import { expect } from "chai";
+import { stub } from "sinon";
+
+import * as React from "react";
+import { shallow } from "enzyme";
+
+import DiscoveryServiceEditForm from "../DiscoveryServiceEditForm";
+
+describe("DiscoveryServiceEditForm", () => {
+  let wrapper;
+  let editService;
+  let registerLibrary;
+  let serviceData = {
+    id: 1,
+    protocol: "protocol 1"
+  };
+  let protocolsData = [{
+    name: "protocol 1",
+    label: "protocol 1 label",
+    settings: [],
+    library_settings: []
+  }];
+  let allLibraries = [
+    { "short_name": "nypl", name: "New York Public Library" },
+    { "short_name": "bpl", name: "Brooklyn Public Library" }
+  ];
+  let servicesData = {
+    discovery_services: [serviceData],
+    protocols: protocolsData,
+    allLibraries: allLibraries
+  };
+
+  describe("rendering", () => {
+    beforeEach(() => {
+      editService = stub();
+      registerLibrary = stub();
+      wrapper = shallow(
+        <DiscoveryServiceEditForm
+          csrfToken="token"
+          disabled={false}
+          data={servicesData}
+          editItem={editService}
+          urlBase="url base"
+          listDataKey="discovery_services"
+          />,
+        { registerLibrary: registerLibrary }
+      );
+    });
+
+    it("doesn't render libraries in create form", () => {
+      let libraries = wrapper.find(".discovery-service-library");
+      expect(libraries.length).to.equal(0);
+    });
+
+    it("renders all libraries in edit form", () => {
+      wrapper.setProps({ item: serviceData });
+      let libraries = wrapper.find(".discovery-service-library");
+      expect(libraries.length).to.equal(2);
+      expect(libraries.at(0).text()).to.contain("New York Public Library");
+      expect(libraries.at(1).text()).to.contain("Brooklyn Public Library");
+    });
+  });
+
+  describe("behavior", () => {
+    beforeEach(() => {
+      editService = stub();
+      registerLibrary = stub();
+      wrapper = shallow(
+        <DiscoveryServiceEditForm
+          csrfToken="token"
+          disabled={false}
+          data={servicesData}
+          item={serviceData}
+          editItem={editService}
+          urlBase="url base"
+          listDataKey="discovery_services"
+          />,
+        { context: { registerLibrary } }
+      );
+    });
+
+    it("registers a library", () => {
+      let libraries = wrapper.find(".discovery-service-library");
+
+      expect(registerLibrary.callCount).to.equal(0);
+
+      let nyplButton = libraries.at(0).find("button");
+      nyplButton.simulate("click");
+
+      expect(registerLibrary.callCount).to.equal(1);
+
+      let bplButton = libraries.at(1).find("button");
+      bplButton.simulate("click");
+
+      expect(registerLibrary.callCount).to.equal(2);
+    });
+  });
+});

--- a/src/components/__tests__/DiscoveryServices-test.tsx
+++ b/src/components/__tests__/DiscoveryServices-test.tsx
@@ -1,0 +1,37 @@
+import { expect } from "chai";
+import { stub } from "sinon";
+
+import * as React from "react";
+import { shallow } from "enzyme";
+
+import { DiscoveryServices } from "../DiscoveryServices";
+
+describe("DiscoveryServices", () => {
+  let wrapper;
+  let registerLibrary;
+  beforeEach(() => {
+    registerLibrary = stub();
+    wrapper = shallow(
+      <DiscoveryServices
+        csrfToken="token"
+        editOrCreate="edit"
+        data={{ discovery_services: [{ id: "2", protocol: "test protocol" }], protocols: [] }}
+        identifier="2"
+        registerLibrary={registerLibrary}
+        />
+    );
+  });
+
+  it("includes registerLibrary in child context", () => {
+    let context = wrapper.instance().getChildContext();
+
+    const library = { short_name: "nypl" };
+    context.registerLibrary(library);
+
+    expect(registerLibrary.callCount).to.equal(1);
+    const formData = registerLibrary.args[0][0];
+    expect(formData.get("csrf_token")).to.equal("token");
+    expect(formData.get("library_short_name")).to.equal("nypl");
+    expect(formData.get("integration_id")).to.equal("2");
+  });
+});

--- a/src/reducers/__tests__/registerLibrary-test.ts
+++ b/src/reducers/__tests__/registerLibrary-test.ts
@@ -1,0 +1,40 @@
+import { expect } from "chai";
+
+import reducer, { RegisterLibraryState } from "../registerLibrary";
+import ActionCreator from "../../actions";
+
+describe("registerLibrary reducer", () => {
+  let initState: RegisterLibraryState = {
+    isFetching: false,
+    fetchError: null
+  };
+
+  let errorState: RegisterLibraryState = {
+    isFetching: false,
+    fetchError: { status: 401, response: "test error", url: "test url" }
+  };
+
+  it("returns initial state for unrecognized action", () => {
+    expect(reducer(undefined, {})).to.deep.equal(initState);
+  });
+
+  it("handles register library request", () => {
+    let action = { type: `${ActionCreator.REGISTER_LIBRARY}_${ActionCreator.REQUEST}` };
+    let newState = Object.assign({}, initState, { isFetching: true });
+    expect(reducer(initState, action)).to.deep.equal(newState);
+    expect(reducer(errorState, action)).to.deep.equal(newState);
+  });
+
+  it("handles register library failure", () => {
+    let action = { type: `${ActionCreator.REGISTER_LIBRARY}_${ActionCreator.FAILURE}`, error: "test error" };
+    let oldState = Object.assign({}, initState, { isFetching: true });
+    let newState = Object.assign({}, oldState, { fetchError: "test error", isFetching: false });
+    expect(reducer(oldState, action)).to.deep.equal(newState);
+  });
+
+  it("handles register library success", () => {
+    let action = { type: `${ActionCreator.REGISTER_LIBRARY}_${ActionCreator.SUCCESS}` };
+    let oldState = Object.assign({}, initState, { isFetching: true, fetchError: "test error" });
+    expect(reducer(oldState, action)).to.deep.equal(initState);
+  });
+});

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -16,6 +16,7 @@ import drmServices from "./drmServices";
 import cdnServices from "./cdnServices";
 import searchServices from "./searchServices";
 import discoveryServices from "./discoveryServices";
+import registerLibrary, { RegisterLibraryState } from "./registerLibrary";
 import { FetchEditState } from "./createFetchEditReducer";
 import {
   LibrariesData, CollectionsData, AdminAuthServicesData, IndividualAdminsData,
@@ -43,6 +44,7 @@ export interface State {
   cdnServices: FetchEditState<CDNServicesData>;
   searchServices: FetchEditState<SearchServicesData>;
   discoveryServices: FetchEditState<DiscoveryServicesData>;
+  registerLibrary: RegisterLibraryState;
 }
 
 export default combineReducers<State>({
@@ -62,5 +64,6 @@ export default combineReducers<State>({
   drmServices,
   cdnServices,
   searchServices,
-  discoveryServices
+  discoveryServices,
+  registerLibrary
 });

--- a/src/reducers/registerLibrary.ts
+++ b/src/reducers/registerLibrary.ts
@@ -1,0 +1,37 @@
+import { RequestError } from "opds-web-client/lib/DataFetcher";
+import ActionCreator from "../actions";
+
+export interface RegisterLibraryState {
+  isFetching: boolean;
+  fetchError: RequestError;
+}
+
+const initialState: RegisterLibraryState = {
+  isFetching: false,
+  fetchError: null
+};
+
+export default (state: RegisterLibraryState = initialState, action) => {
+  switch (action.type) {
+    case `${ActionCreator.REGISTER_LIBRARY}_${ActionCreator.REQUEST}`:
+      return Object.assign({}, state, {
+        isFetching: true,
+        fetchError: null
+      });
+
+    case `${ActionCreator.REGISTER_LIBRARY}_${ActionCreator.FAILURE}`:
+      return Object.assign({}, state, {
+        isFetching: false,
+        fetchError: action.error
+      });
+
+    case `${ActionCreator.REGISTER_LIBRARY}_${ActionCreator.SUCCESS}`:
+      return Object.assign({}, state, {
+        isFetching: false,
+        fetchError: null
+      });
+
+    default:
+      return state;
+  }
+};

--- a/src/stylesheets/app.scss
+++ b/src/stylesheets/app.scss
@@ -14,6 +14,7 @@
 @import "complaints";
 @import "config_tab_container";
 @import "dashboard";
+@import "discovery_service_edit_form";
 @import "edit_form";
 @import "editable_input";
 @import "editor";

--- a/src/stylesheets/discovery_service_edit_form.scss
+++ b/src/stylesheets/discovery_service_edit_form.scss
@@ -1,0 +1,8 @@
+.discovery-service-library {
+  margin: 10px;
+  padding: 5px;
+
+  button {
+    margin-right: 10px;
+  }
+}


### PR DESCRIPTION
This is the UI for https://github.com/NYPL-Simplified/circulation/issues/577. On the discovery service edit page, there's a list of libraries with register buttons. While registering, the page shows the "Loading" popup, and if there's an error, it shows up at the top of the page.