### PR TITLE
Don't show the create button for an admin auth service if one already exists.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.0.42",
+  "version": "0.0.43",
   "description": "Web Front-end for Library Simplified Circulation Manager",
   "repository": {
     "type": "git",

--- a/src/components/AdminAuthServices.tsx
+++ b/src/components/AdminAuthServices.tsx
@@ -11,6 +11,7 @@ export class AdminAuthServices extends EditableConfigList<AdminAuthServicesData,
   urlBase = "/admin/web/config/adminAuth/";
   identifierKey = "protocol";
   labelKey = "protocol";
+  limitOne = true;
 }
 
 function mapStateToProps(state, ownProps) {


### PR DESCRIPTION
If there's an admin auth service already, the server won't let you create a new one. This tiny change hides the create button in that case, so you don't try it and get an error. Once the server supports more admin auth options we can remove this.