### PR TITLE
Added library registration status to discovery service edit page.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.0.43",
+  "version": "0.0.44",
   "description": "Web Front-end for Library Simplified Circulation Manager",
   "repository": {
     "type": "git",

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -6,7 +6,7 @@ import {
   PatronAuthServicesData, SitewideSettingsData,
   MetadataServicesData, AnalyticsServicesData,
   CDNServicesData, SearchServicesData,
-  DiscoveryServicesData
+  DiscoveryServicesData, LibraryRegistrationsData
 } from "./interfaces";
 import DataFetcher from "opds-web-client/lib/DataFetcher";
 import { RequestError, RequestRejector } from "opds-web-client/lib/DataFetcher";
@@ -46,6 +46,7 @@ export default class ActionCreator extends BaseActionCreator {
   static readonly DISCOVERY_SERVICES = "DISCOVERY_SERVICES";
   static readonly EDIT_DISCOVERY_SERVICE = "EDIT_DISCOVERY_SERVICE";
   static readonly REGISTER_LIBRARY = "REGISTER_LIBRARY";
+  static readonly LIBRARY_REGISTRATIONS = "LIBRARY_REGISTRATIONS";
 
   static readonly EDIT_BOOK_REQUEST = "EDIT_BOOK_REQUEST";
   static readonly EDIT_BOOK_SUCCESS = "EDIT_BOOK_SUCCESS";
@@ -348,5 +349,10 @@ export default class ActionCreator extends BaseActionCreator {
   registerLibrary(data: FormData) {
     const url = "/admin/library_registrations";
     return this.postForm(ActionCreator.REGISTER_LIBRARY, url, data).bind(this);
+  }
+
+  fetchLibraryRegistrations() {
+    const url = "/admin/library_registrations";
+    return this.fetchJSON<LibraryRegistrationsData>(ActionCreator.LIBRARY_REGISTRATIONS, url).bind(this);
   }
 }

--- a/src/components/DiscoveryServiceEditForm.tsx
+++ b/src/components/DiscoveryServiceEditForm.tsx
@@ -18,13 +18,48 @@ export default class DiscoveryServiceEditForm extends ServiceEditForm<DiscoveryS
             <h2>Register libraries</h2>
             { this.props.data.allLibraries.map(library =>
                 <div className="discovery-service-library" key={library.short_name}>
-                  <button
-                    type="button"
-                    className="btn btn-default"
-                    disabled={this.props.disabled}
-                    onClick={() => this.context.registerLibrary(library)}
-                    >Register</button>
-                  {library.name}
+                  { this.getRegistrationStatus(library) === "success" &&
+                    <div>
+                      { library.name }
+                      <span className="bg-success">
+                        Registered
+                      </span>
+                      <button
+                        type="button"
+                        className="btn btn-default"
+                        disabled={this.props.disabled}
+                        onClick={() => this.context.registerLibrary(library)}
+                        >Update registration</button>
+                    </div>
+                  }
+                  { this.getRegistrationStatus(library) === "failure" &&
+                    <div>
+                      { library.name }
+                      <span className="bg-danger">
+                        Registration failed
+                      </span>
+                      <button
+                        type="button"
+                        className="btn btn-default"
+                        disabled={this.props.disabled}
+                        onClick={() => this.context.registerLibrary(library)}
+                        >Retry registration</button>
+                    </div>
+                  }
+                  { this.getRegistrationStatus(library) === null &&
+                    <div>
+                      { library.name }
+                      <span className="bg-warning">
+                        Not registered
+                      </span>
+                      <button
+                        type="button"
+                        className="btn btn-default"
+                        disabled={this.props.disabled}
+                        onClick={() => this.context.registerLibrary(library)}
+                        >Register</button>
+                    </div>
+                  }
                 </div>
               )
             }
@@ -32,5 +67,20 @@ export default class DiscoveryServiceEditForm extends ServiceEditForm<DiscoveryS
         }
       </div>
     );
+  }
+
+  getRegistrationStatus(library): string | null {
+    const serviceId = this.props.item && this.props.item.id;
+    const libraryRegistrations = this.props.data && this.props.data.libraryRegistrations || [];
+    for (const serviceInfo of libraryRegistrations) {
+      if (serviceInfo.id === serviceId) {
+        for (const libraryInfo of serviceInfo.libraries) {
+          if (libraryInfo.short_name === library.short_name) {
+            return libraryInfo.status;
+          }
+        }
+      }
+    }
+    return null;
   }
 }

--- a/src/components/__tests__/DiscoveryServiceEditForm-test.tsx
+++ b/src/components/__tests__/DiscoveryServiceEditForm-test.tsx
@@ -22,12 +22,21 @@ describe("DiscoveryServiceEditForm", () => {
   }];
   let allLibraries = [
     { "short_name": "nypl", name: "New York Public Library" },
-    { "short_name": "bpl", name: "Brooklyn Public Library" }
+    { "short_name": "bpl", name: "Brooklyn Public Library" },
+    { "short_name": "qpl", name: "Queens Public Library" }
   ];
+  let libraryRegistrationsData = [{
+    id: 1,
+    libraries: [
+      { short_name: "nypl", status: "success" },
+      { short_name: "bpl", status: "failure" }
+    ]
+  }];
   let servicesData = {
     discovery_services: [serviceData],
     protocols: protocolsData,
-    allLibraries: allLibraries
+    allLibraries: allLibraries,
+    libraryRegistrations: libraryRegistrationsData
   };
 
   describe("rendering", () => {
@@ -52,12 +61,16 @@ describe("DiscoveryServiceEditForm", () => {
       expect(libraries.length).to.equal(0);
     });
 
-    it("renders all libraries in edit form", () => {
+    it("renders all libraries in edit form, with registration status", () => {
       wrapper.setProps({ item: serviceData });
       let libraries = wrapper.find(".discovery-service-library");
-      expect(libraries.length).to.equal(2);
+      expect(libraries.length).to.equal(3);
       expect(libraries.at(0).text()).to.contain("New York Public Library");
+      expect(libraries.at(0).text()).to.contain("Registered");
       expect(libraries.at(1).text()).to.contain("Brooklyn Public Library");
+      expect(libraries.at(1).text()).to.contain("Registration failed");
+      expect(libraries.at(2).text()).to.contain("Queens Public Library");
+      expect(libraries.at(2).text()).to.contain("Not registered");
     });
   });
 
@@ -93,6 +106,11 @@ describe("DiscoveryServiceEditForm", () => {
       bplButton.simulate("click");
 
       expect(registerLibrary.callCount).to.equal(2);
+
+      let qplButton = libraries.at(2).find("button");
+      qplButton.simulate("click");
+
+      expect(registerLibrary.callCount).to.equal(3);
     });
   });
 });

--- a/src/components/__tests__/DiscoveryServices-test.tsx
+++ b/src/components/__tests__/DiscoveryServices-test.tsx
@@ -9,8 +9,10 @@ import { DiscoveryServices } from "../DiscoveryServices";
 describe("DiscoveryServices", () => {
   let wrapper;
   let registerLibrary;
+  let fetchLibraryRegistrations;
   beforeEach(() => {
-    registerLibrary = stub();
+    registerLibrary = stub().returns(new Promise<void>(resolve => resolve()));
+    fetchLibraryRegistrations = stub();
     wrapper = shallow(
       <DiscoveryServices
         csrfToken="token"
@@ -18,12 +20,15 @@ describe("DiscoveryServices", () => {
         data={{ discovery_services: [{ id: "2", protocol: "test protocol" }], protocols: [] }}
         identifier="2"
         registerLibrary={registerLibrary}
+        fetchLibraryRegistrations={fetchLibraryRegistrations}
         />
     );
   });
 
-  it("includes registerLibrary in child context", () => {
+  it("includes registerLibrary in child context, and fetches library registrations on mount and after registering", async () => {
     let context = wrapper.instance().getChildContext();
+
+    expect(fetchLibraryRegistrations.callCount).to.equal(1);
 
     const library = { short_name: "nypl" };
     context.registerLibrary(library);
@@ -33,5 +38,9 @@ describe("DiscoveryServices", () => {
     expect(formData.get("csrf_token")).to.equal("token");
     expect(formData.get("library_short_name")).to.equal("nypl");
     expect(formData.get("integration_id")).to.equal("2");
+
+    let pause = new Promise<void>(resolve => setTimeout(resolve, 0));
+    await pause;
+    expect(fetchLibraryRegistrations.callCount).to.equal(2);
   });
 });

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -232,4 +232,18 @@ export interface DiscoveryServiceData extends ServiceData {}
 
 export interface DiscoveryServicesData extends ServicesData {
   discovery_services: DiscoveryServiceData[];
+  libraryRegistrations?: LibraryRegistrationData[];
+}
+
+export interface LibraryDataWithStatus extends LibraryData {
+  status: string;
+}
+
+export interface LibraryRegistrationData {
+  id: string | number;
+  libraries: LibraryDataWithStatus[];
+}
+
+export interface LibraryRegistrationsData {
+  library_registrations: LibraryRegistrationData[];
 }

--- a/src/reducers/__tests__/createFetchEditReducer-test.ts
+++ b/src/reducers/__tests__/createFetchEditReducer-test.ts
@@ -30,9 +30,11 @@ describe("fetch-edit reducer", () => {
   };
 
   let reducer = createFetchEditReducer<TestData>("TEST_FETCH", "TEST_EDIT");
+  let fetchOnlyReducer = createFetchEditReducer<TestData>("TEST_FETCH");
 
   it("returns initial state for unrecognized action", () => {
     expect(reducer(undefined, {})).to.deep.equal(initState);
+    expect(fetchOnlyReducer(undefined, {})).to.deep.equal(initState);
   });
 
   it("handles fetch request", () => {
@@ -43,6 +45,7 @@ describe("fetch-edit reducer", () => {
       isFetching: true
     });
     expect(reducer(initState, action)).to.deep.equal(newState);
+    expect(fetchOnlyReducer(initState, action)).to.deep.equal(newState);
 
     // start with error state
     newState = Object.assign({}, errorState, {
@@ -50,6 +53,7 @@ describe("fetch-edit reducer", () => {
       fetchError: null
     });
     expect(reducer(errorState, action)).to.deep.equal(newState);
+    expect(fetchOnlyReducer(errorState, action)).to.deep.equal(newState);
   });
 
   it("handles fetch failure", () => {
@@ -61,6 +65,7 @@ describe("fetch-edit reducer", () => {
       isLoaded: true
     });
     expect(reducer(oldState, action)).to.deep.equal(newState);
+    expect(fetchOnlyReducer(oldState, action)).to.deep.equal(newState);
   });
 
   it("handles load", () => {
@@ -71,6 +76,7 @@ describe("fetch-edit reducer", () => {
       isLoaded: true
     });
     expect(reducer(initState, action)).to.deep.equal(newState);
+    expect(fetchOnlyReducer(initState, action)).to.deep.equal(newState);
   });
 
   it("handles edit request", () => {
@@ -81,6 +87,8 @@ describe("fetch-edit reducer", () => {
       isEditing: true
     });
     expect(reducer(initState, action)).to.deep.equal(newState);
+    // fetch only reducer does nothing
+    expect(fetchOnlyReducer(initState, action)).to.deep.equal(initState);
 
     // start with error state
     newState = Object.assign({}, errorState, {
@@ -88,6 +96,8 @@ describe("fetch-edit reducer", () => {
       fetchError: null
     });
     expect(reducer(errorState, action)).to.deep.equal(newState);
+    // fetch only reducer does nothing
+    expect(fetchOnlyReducer(errorState, action)).to.deep.equal(errorState);
   });
 
   it("handles edit failure", () => {
@@ -100,6 +110,8 @@ describe("fetch-edit reducer", () => {
       isEditing: false
     });
     expect(reducer(oldState, action)).to.deep.equal(newState);
+    // fetch only reducer does nothing
+    expect(fetchOnlyReducer(oldState, action)).to.deep.equal(oldState);
   });
 
   it("handles edit success", () => {
@@ -111,5 +123,7 @@ describe("fetch-edit reducer", () => {
       isEditing: false
     });
     expect(reducer(oldState, action)).to.deep.equal(newState);
+    // fetch only reducer does nothing
+    expect(fetchOnlyReducer(oldState, action)).to.deep.equal(oldState);
   });
 });

--- a/src/reducers/createFetchEditReducer.ts
+++ b/src/reducers/createFetchEditReducer.ts
@@ -13,7 +13,7 @@ export interface FetchEditReducer<T> {
   (state: FetchEditState<T>, action): FetchEditState<T>;
 }
 
-export default<T> (fetchPrefix: string, editPrefix: string): FetchEditReducer<T> => {
+export default<T> (fetchPrefix: string, editPrefix?: string): FetchEditReducer<T> => {
   const initialState: FetchEditState<T> = {
     data: null,
     isFetching: false,
@@ -44,25 +44,32 @@ export default<T> (fetchPrefix: string, editPrefix: string): FetchEditReducer<T>
           isLoaded: true
         });
 
-      case `${editPrefix}_${ActionCreator.REQUEST}`:
-        return Object.assign({}, state, {
-          isEditing: true,
-          fetchError: null
-        });
-
-      case `${editPrefix}_${ActionCreator.SUCCESS}`:
-        return Object.assign({}, state, {
-          isEditing: false,
-          fetchError: null
-        });
-
-      case `${editPrefix}_${ActionCreator.FAILURE}`:
-        return Object.assign({}, state, {
-          isEditing: false,
-          fetchError: action.error
-        });
 
       default:
+        if (editPrefix) {
+          switch (action.type) {
+            case `${editPrefix}_${ActionCreator.REQUEST}`:
+              return Object.assign({}, state, {
+                isEditing: true,
+                fetchError: null
+              });
+
+            case `${editPrefix}_${ActionCreator.SUCCESS}`:
+              return Object.assign({}, state, {
+                isEditing: false,
+                fetchError: null
+              });
+
+            case `${editPrefix}_${ActionCreator.FAILURE}`:
+              return Object.assign({}, state, {
+                isEditing: false,
+                fetchError: action.error
+              });
+
+            default:
+              return state;
+          }
+        }
         return state;
     }
   };

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -16,12 +16,13 @@ import cdnServices from "./cdnServices";
 import searchServices from "./searchServices";
 import discoveryServices from "./discoveryServices";
 import registerLibrary, { RegisterLibraryState } from "./registerLibrary";
+import libraryRegistrations from "./libraryRegistrations";
 import { FetchEditState } from "./createFetchEditReducer";
 import {
   LibrariesData, CollectionsData, AdminAuthServicesData, IndividualAdminsData,
   PatronAuthServicesData, SitewideSettingsData, MetadataServicesData,
   AnalyticsServicesData, CDNServicesData, SearchServicesData,
-  DiscoveryServicesData
+  DiscoveryServicesData, LibraryRegistrationsData
 } from "../interfaces";
 
 
@@ -43,6 +44,7 @@ export interface State {
   searchServices: FetchEditState<SearchServicesData>;
   discoveryServices: FetchEditState<DiscoveryServicesData>;
   registerLibrary: RegisterLibraryState;
+  libraryRegistrations: FetchEditState<LibraryRegistrationsData>;
 }
 
 export default combineReducers<State>({
@@ -62,5 +64,6 @@ export default combineReducers<State>({
   cdnServices,
   searchServices,
   discoveryServices,
-  registerLibrary
+  registerLibrary,
+  libraryRegistrations
 });

--- a/src/reducers/libraryRegistrations.ts
+++ b/src/reducers/libraryRegistrations.ts
@@ -1,0 +1,5 @@
+import { LibraryRegistrationsData } from "../interfaces";
+import ActionCreator from "../actions";
+import createFetchEditReducer from "./createFetchEditReducer";
+
+export default createFetchEditReducer<LibraryRegistrationsData>(ActionCreator.LIBRARY_REGISTRATIONS);

--- a/src/stylesheets/discovery_service_edit_form.scss
+++ b/src/stylesheets/discovery_service_edit_form.scss
@@ -5,4 +5,9 @@
   button {
     margin-right: 10px;
   }
+
+  span {
+    padding: 10px;
+    margin: 0px 5px;
+  }
 }


### PR DESCRIPTION
This uses the status from https://github.com/NYPL-Simplified/circulation/pull/707.

The design is bad but the info is there now.