### PR TITLE
Moved all CSRF tokens to header instead of form data, and cleaned up types.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.0.45",
+  "version": "0.0.46",
   "description": "Web Front-end for Library Simplified Circulation Manager",
   "repository": {
     "type": "git",

--- a/src/__tests__/actions-test.ts
+++ b/src/__tests__/actions-test.ts
@@ -35,7 +35,7 @@ class MockDataFetcher {
 };
 
 const fetcher = new MockDataFetcher() as any;
-const actions = new ActionCreator(fetcher);
+const actions = new ActionCreator(fetcher, "token");
 
 describe("actions", () => {
   describe("postForm", () => {
@@ -54,7 +54,7 @@ describe("actions", () => {
       }));
       fetch = fetchMock;
 
-      await actions.postForm(type, url, formData, "token")(dispatch);
+      await actions.postForm(type, url, formData)(dispatch);
       expect(dispatch.callCount).to.equal(3);
       expect(dispatch.args[0][0].type).to.equal(`${type}_${ActionCreator.REQUEST}`);
       expect(dispatch.args[1][0].type).to.equal(`${type}_${ActionCreator.SUCCESS}`);
@@ -79,7 +79,7 @@ describe("actions", () => {
       }));
       fetch = fetchMock;
 
-      await actions.postForm(type, url, formData, "token", "DELETE")(dispatch);
+      await actions.postForm(type, url, formData, "DELETE")(dispatch);
       expect(dispatch.callCount).to.equal(3);
       expect(fetchMock.callCount).to.equal(1);
       expect(fetchMock.args[0][0]).to.equal(url);
@@ -99,7 +99,7 @@ describe("actions", () => {
       fetch = fetchMock;
 
       try {
-        await actions.postForm(type, url, formData, "token")(dispatch);
+        await actions.postForm(type, url, formData)(dispatch);
         // shouldn't get here
         expect(false).to.equal(true);
       } catch (err) {
@@ -123,7 +123,7 @@ describe("actions", () => {
       fetch = fetchMock;
 
       try {
-        await actions.postForm(type, url, formData, "token")(dispatch);
+        await actions.postForm(type, url, formData)(dispatch);
         // shouldn't get here
         expect(false).to.equal(true);
       } catch (err) {
@@ -156,20 +156,6 @@ describe("actions", () => {
       expect(dispatch.callCount).to.equal(2);
       expect(dispatch.args[0][0].type).to.equal(`${type}_${ActionCreator.REQUEST}`);
       expect(dispatch.args[1][0].type).to.equal(`${type}_${ActionCreator.SUCCESS}`);
-      expect(fetchMock.callCount).to.equal(1);
-      expect(fetchMock.args[0][0]).to.equal(url);
-      expect(fetchMock.args[0][1].method).to.equal("POST");
-      expect(fetchMock.args[0][1].body).to.equal(JSON.stringify(jsonData));
-    });
-
-    it("includes CSRF token header if provided", async () => {
-      const dispatch = stub();
-      const fetchMock = stub().returns(new Promise<any>((resolve, reject) => {
-        resolve({ status: 200 });
-      }));
-      fetch = fetchMock;
-
-      await actions.postJSON<{ test: number }>(type, url, jsonData, "token")(dispatch);
       expect(fetchMock.callCount).to.equal(1);
       expect(fetchMock.args[0][0]).to.equal(url);
       expect(fetchMock.args[0][1].method).to.equal("POST");
@@ -260,7 +246,7 @@ describe("actions", () => {
       }));
       fetch = fetchMock;
 
-      await actions.editBook(editBookUrl, formData, "token")(dispatch);
+      await actions.editBook(editBookUrl, formData)(dispatch);
       expect(dispatch.callCount).to.equal(2);
       expect(dispatch.args[0][0].type).to.equal(ActionCreator.EDIT_BOOK_REQUEST);
       expect(dispatch.args[1][0].type).to.equal(ActionCreator.EDIT_BOOK_SUCCESS);
@@ -330,7 +316,7 @@ describe("actions", () => {
       }));
       fetch = fetchMock;
 
-      await actions.resolveComplaints(resolveComplaintsUrl, formData, "token")(dispatch);
+      await actions.resolveComplaints(resolveComplaintsUrl, formData)(dispatch);
       expect(dispatch.callCount).to.equal(2);
       expect(dispatch.args[0][0].type).to.equal(ActionCreator.RESOLVE_COMPLAINTS_REQUEST);
       expect(dispatch.args[1][0].type).to.equal(ActionCreator.RESOLVE_COMPLAINTS_SUCCESS);
@@ -376,7 +362,7 @@ describe("actions", () => {
       }));
       fetch = fetchMock;
 
-      await actions.editClassifications(editClassificationsUrl, formData, "token")(dispatch);
+      await actions.editClassifications(editClassificationsUrl, formData)(dispatch);
       expect(dispatch.callCount).to.equal(2);
       expect(dispatch.args[0][0].type).to.equal(ActionCreator.EDIT_CLASSIFICATIONS_REQUEST);
       expect(dispatch.args[1][0].type).to.equal(ActionCreator.EDIT_CLASSIFICATIONS_SUCCESS);
@@ -490,7 +476,7 @@ describe("actions", () => {
       }));
       fetch = fetchMock;
 
-      await actions.editLibrary(formData, "token")(dispatch);
+      await actions.editLibrary(formData)(dispatch);
       expect(dispatch.callCount).to.equal(2);
       expect(dispatch.args[0][0].type).to.equal(`${ActionCreator.EDIT_LIBRARY}_${ActionCreator.REQUEST}`);
       expect(dispatch.args[1][0].type).to.equal(`${ActionCreator.EDIT_LIBRARY}_${ActionCreator.SUCCESS}`);
@@ -535,7 +521,7 @@ describe("actions", () => {
       }));
       fetch = fetchMock;
 
-      await actions.editCollection(formData, "token")(dispatch);
+      await actions.editCollection(formData)(dispatch);
       expect(dispatch.callCount).to.equal(2);
       expect(dispatch.args[0][0].type).to.equal(`${ActionCreator.EDIT_COLLECTION}_${ActionCreator.REQUEST}`);
       expect(dispatch.args[1][0].type).to.equal(`${ActionCreator.EDIT_COLLECTION}_${ActionCreator.SUCCESS}`);
@@ -580,7 +566,7 @@ describe("actions", () => {
       }));
       fetch = fetchMock;
 
-      await actions.editAdminAuthService(formData, "token")(dispatch);
+      await actions.editAdminAuthService(formData)(dispatch);
       expect(dispatch.callCount).to.equal(2);
       expect(dispatch.args[0][0].type).to.equal(`${ActionCreator.EDIT_ADMIN_AUTH_SERVICE}_${ActionCreator.REQUEST}`);
       expect(dispatch.args[1][0].type).to.equal(`${ActionCreator.EDIT_ADMIN_AUTH_SERVICE}_${ActionCreator.SUCCESS}`);
@@ -625,7 +611,7 @@ describe("actions", () => {
       }));
       fetch = fetchMock;
 
-      await actions.editIndividualAdmin(formData, "token")(dispatch);
+      await actions.editIndividualAdmin(formData)(dispatch);
       expect(dispatch.callCount).to.equal(2);
       expect(dispatch.args[0][0].type).to.equal(`${ActionCreator.EDIT_INDIVIDUAL_ADMIN}_${ActionCreator.REQUEST}`);
       expect(dispatch.args[1][0].type).to.equal(`${ActionCreator.EDIT_INDIVIDUAL_ADMIN}_${ActionCreator.SUCCESS}`);

--- a/src/__tests__/actions-test.ts
+++ b/src/__tests__/actions-test.ts
@@ -42,7 +42,6 @@ describe("actions", () => {
     const type = "TEST";
     const url = "http://example.com/test";
     const formData = new (window as any).FormData();
-    formData.append("csrf_token", "token");
     formData.append("test", "test");
 
     it("dispatches request, success, and load", async () => {
@@ -55,7 +54,7 @@ describe("actions", () => {
       }));
       fetch = fetchMock;
 
-      await actions.postForm(type, url, formData)(dispatch);
+      await actions.postForm(type, url, formData, "token")(dispatch);
       expect(dispatch.callCount).to.equal(3);
       expect(dispatch.args[0][0].type).to.equal(`${type}_${ActionCreator.REQUEST}`);
       expect(dispatch.args[1][0].type).to.equal(`${type}_${ActionCreator.SUCCESS}`);
@@ -64,10 +63,13 @@ describe("actions", () => {
       expect(fetchMock.callCount).to.equal(1);
       expect(fetchMock.args[0][0]).to.equal(url);
       expect(fetchMock.args[0][1].method).to.equal("POST");
+      const expectedHeaders = new Headers();
+      expectedHeaders.append("X-CSRF-Token", "token");
+      expect(fetchMock.args[0][1].headers).to.deep.equal(expectedHeaders);
       expect(fetchMock.args[0][1].body).to.equal(formData);
     });
 
-    it("dispatches a DELETE request with a csrf token header", async () => {
+    it("dispatches a DELETE request", async () => {
       const dispatch = stub();
       const responseText = stub().returns(new Promise<string>((resolve) => {
         resolve("response");
@@ -97,7 +99,7 @@ describe("actions", () => {
       fetch = fetchMock;
 
       try {
-        await actions.postForm(type, url, formData)(dispatch);
+        await actions.postForm(type, url, formData, "token")(dispatch);
         // shouldn't get here
         expect(false).to.equal(true);
       } catch (err) {
@@ -121,7 +123,7 @@ describe("actions", () => {
       fetch = fetchMock;
 
       try {
-        await actions.postForm(type, url, formData)(dispatch);
+        await actions.postForm(type, url, formData, "token")(dispatch);
         // shouldn't get here
         expect(false).to.equal(true);
       } catch (err) {
@@ -157,6 +159,25 @@ describe("actions", () => {
       expect(fetchMock.callCount).to.equal(1);
       expect(fetchMock.args[0][0]).to.equal(url);
       expect(fetchMock.args[0][1].method).to.equal("POST");
+      expect(fetchMock.args[0][1].body).to.equal(JSON.stringify(jsonData));
+    });
+
+    it("includes CSRF token header if provided", async () => {
+      const dispatch = stub();
+      const fetchMock = stub().returns(new Promise<any>((resolve, reject) => {
+        resolve({ status: 200 });
+      }));
+      fetch = fetchMock;
+
+      await actions.postJSON<{ test: number }>(type, url, jsonData, "token")(dispatch);
+      expect(fetchMock.callCount).to.equal(1);
+      expect(fetchMock.args[0][0]).to.equal(url);
+      expect(fetchMock.args[0][1].method).to.equal("POST");
+      const expectedHeaders = new Headers();
+      expectedHeaders.append("Accept", "application/json");
+      expectedHeaders.append("Content-Type", "application/json");
+      expectedHeaders.append("X-CSRF-Token", "token");
+      expect(fetchMock.args[0][1].headers).to.deep.equal(expectedHeaders);
       expect(fetchMock.args[0][1].body).to.equal(JSON.stringify(jsonData));
     });
 
@@ -233,14 +254,13 @@ describe("actions", () => {
       const editBookUrl = "http://example.com/editBook";
       const dispatch = stub();
       const formData = new (window as any).FormData();
-      formData.append("csrf_token", "token");
       formData.append("title", "title");
       const fetchMock = stub().returns(new Promise<any>((resolve, reject) => {
         resolve({ status: 200 });
       }));
       fetch = fetchMock;
 
-      await actions.editBook(editBookUrl, formData)(dispatch);
+      await actions.editBook(editBookUrl, formData, "token")(dispatch);
       expect(dispatch.callCount).to.equal(2);
       expect(dispatch.args[0][0].type).to.equal(ActionCreator.EDIT_BOOK_REQUEST);
       expect(dispatch.args[1][0].type).to.equal(ActionCreator.EDIT_BOOK_SUCCESS);
@@ -304,14 +324,13 @@ describe("actions", () => {
       const resolveComplaintsUrl = "http://example.com/resolveComplaints";
       const dispatch = stub();
       const formData = new (window as any).FormData();
-      formData.append("csrf_token", "token");
       formData.append("type", "test type");
       const fetchMock = stub().returns(new Promise<any>((resolve, reject) => {
         resolve({ status: 200 });
       }));
       fetch = fetchMock;
 
-      await actions.resolveComplaints(resolveComplaintsUrl, formData)(dispatch);
+      await actions.resolveComplaints(resolveComplaintsUrl, formData, "token")(dispatch);
       expect(dispatch.callCount).to.equal(2);
       expect(dispatch.args[0][0].type).to.equal(ActionCreator.RESOLVE_COMPLAINTS_REQUEST);
       expect(dispatch.args[1][0].type).to.equal(ActionCreator.RESOLVE_COMPLAINTS_SUCCESS);
@@ -350,7 +369,6 @@ describe("actions", () => {
       const dispatch = stub();
       const formData = new (window as any).FormData();
       const newGenreTree = ["Drama", "Epic Fantasy", "Women Detectives"];
-      formData.append("csrf_token", "token");
       newGenreTree.forEach(genre => formData.append("genres", genre));
 
       const fetchMock = stub().returns(new Promise<any>((update, reject) => {
@@ -358,7 +376,7 @@ describe("actions", () => {
       }));
       fetch = fetchMock;
 
-      await actions.editClassifications(editClassificationsUrl, formData)(dispatch);
+      await actions.editClassifications(editClassificationsUrl, formData, "token")(dispatch);
       expect(dispatch.callCount).to.equal(2);
       expect(dispatch.args[0][0].type).to.equal(ActionCreator.EDIT_CLASSIFICATIONS_REQUEST);
       expect(dispatch.args[1][0].type).to.equal(ActionCreator.EDIT_CLASSIFICATIONS_SUCCESS);
@@ -465,7 +483,6 @@ describe("actions", () => {
       const editLibraryUrl = "/admin/libraries";
       const dispatch = stub();
       const formData = new (window as any).FormData();
-      formData.append("csrf_token", "token");
       formData.append("name", "new name");
 
       const fetchMock = stub().returns(new Promise<any>((update, reject) => {
@@ -473,7 +490,7 @@ describe("actions", () => {
       }));
       fetch = fetchMock;
 
-      await actions.editLibrary(formData)(dispatch);
+      await actions.editLibrary(formData, "token")(dispatch);
       expect(dispatch.callCount).to.equal(2);
       expect(dispatch.args[0][0].type).to.equal(`${ActionCreator.EDIT_LIBRARY}_${ActionCreator.REQUEST}`);
       expect(dispatch.args[1][0].type).to.equal(`${ActionCreator.EDIT_LIBRARY}_${ActionCreator.SUCCESS}`);
@@ -511,7 +528,6 @@ describe("actions", () => {
       const editCollectionUrl = "/admin/collections";
       const dispatch = stub();
       const formData = new (window as any).FormData();
-      formData.append("csrf_token", "token");
       formData.append("name", "new name");
 
       const fetchMock = stub().returns(new Promise<any>((update, reject) => {
@@ -519,7 +535,7 @@ describe("actions", () => {
       }));
       fetch = fetchMock;
 
-      await actions.editCollection(formData)(dispatch);
+      await actions.editCollection(formData, "token")(dispatch);
       expect(dispatch.callCount).to.equal(2);
       expect(dispatch.args[0][0].type).to.equal(`${ActionCreator.EDIT_COLLECTION}_${ActionCreator.REQUEST}`);
       expect(dispatch.args[1][0].type).to.equal(`${ActionCreator.EDIT_COLLECTION}_${ActionCreator.SUCCESS}`);
@@ -557,7 +573,6 @@ describe("actions", () => {
       const editAdminAuthServiceUrl = "/admin/admin_auth_services";
       const dispatch = stub();
       const formData = new (window as any).FormData();
-      formData.append("csrf_token", "token");
       formData.append("name", "new name");
 
       const fetchMock = stub().returns(new Promise<any>((update, reject) => {
@@ -565,7 +580,7 @@ describe("actions", () => {
       }));
       fetch = fetchMock;
 
-      await actions.editAdminAuthService(formData)(dispatch);
+      await actions.editAdminAuthService(formData, "token")(dispatch);
       expect(dispatch.callCount).to.equal(2);
       expect(dispatch.args[0][0].type).to.equal(`${ActionCreator.EDIT_ADMIN_AUTH_SERVICE}_${ActionCreator.REQUEST}`);
       expect(dispatch.args[1][0].type).to.equal(`${ActionCreator.EDIT_ADMIN_AUTH_SERVICE}_${ActionCreator.SUCCESS}`);
@@ -603,7 +618,6 @@ describe("actions", () => {
       const editIndividualAdminUrl = "/admin/individual_admins";
       const dispatch = stub();
       const formData = new (window as any).FormData();
-      formData.append("csrf_token", "token");
       formData.append("email", "email");
 
       const fetchMock = stub().returns(new Promise<any>((update, reject) => {
@@ -611,7 +625,7 @@ describe("actions", () => {
       }));
       fetch = fetchMock;
 
-      await actions.editIndividualAdmin(formData)(dispatch);
+      await actions.editIndividualAdmin(formData, "token")(dispatch);
       expect(dispatch.callCount).to.equal(2);
       expect(dispatch.args[0][0].type).to.equal(`${ActionCreator.EDIT_INDIVIDUAL_ADMIN}_${ActionCreator.REQUEST}`);
       expect(dispatch.args[1][0].type).to.equal(`${ActionCreator.EDIT_INDIVIDUAL_ADMIN}_${ActionCreator.SUCCESS}`);

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -97,20 +97,26 @@ export default class ActionCreator extends BaseActionCreator {
   static readonly STATS_FAILURE = "STATS_FAILURE";
   static readonly STATS_LOAD = "STATS_LOAD";
 
-  constructor(fetcher?: DataFetcher) {
+  csrfToken: string;
+
+  constructor(fetcher?: DataFetcher, csrfToken?: string) {
     fetcher = fetcher || new DataFetcher();
     super(fetcher);
+    csrfToken = csrfToken || null;
+    this.csrfToken = csrfToken;
   }
 
 
-  postForm(type: string, url: string, data: FormData | null, csrfToken: string, method?: string) {
+  postForm(type: string, url: string, data: FormData | null, method?: string) {
     let err: RequestError;
 
     return (dispatch => {
       return new Promise((resolve, reject: RequestRejector) => {
         dispatch(this.request(type));
         let headers = new Headers();
-        headers.append("X-CSRF-Token", csrfToken);
+        if (this.csrfToken) {
+          headers.append("X-CSRF-Token", this.csrfToken);
+        }
         fetch(url, {
           method: method || "POST",
           headers: headers,
@@ -157,15 +163,15 @@ export default class ActionCreator extends BaseActionCreator {
     }).bind(this);
   }
 
-  postJSON<T>(type: string, url: string, data: T, csrfToken?: string) {
+  postJSON<T>(type: string, url: string, data: T) {
     let err: RequestError;
 
     return (dispatch => {
       return new Promise((resolve, reject: RequestRejector) => {
         dispatch(this.request(type, url));
         let headers = new Headers();
-        if (csrfToken) {
-          headers.append("X-CSRF-Token", csrfToken);
+        if (this.csrfToken) {
+          headers.append("X-CSRF-Token", this.csrfToken);
         }
         headers.append("Accept", "application/json");
         headers.append("Content-Type", "application/json");
@@ -214,8 +220,8 @@ export default class ActionCreator extends BaseActionCreator {
     return this.fetchOPDS<BookData>(ActionCreator.BOOK_ADMIN, url).bind(this);
   }
 
-  editBook(url: string, data: FormData | null, csrfToken: string) {
-    return this.postForm(ActionCreator.EDIT_BOOK, url, data, csrfToken).bind(this);
+  editBook(url: string, data: FormData | null) {
+    return this.postForm(ActionCreator.EDIT_BOOK, url, data).bind(this);
   }
 
   fetchComplaints(url: string) {
@@ -226,16 +232,16 @@ export default class ActionCreator extends BaseActionCreator {
     return this.postJSON<{type: string}>(ActionCreator.POST_COMPLAINT, url, data).bind(this);
   }
 
-  resolveComplaints(url: string, data: FormData, csrfToken: string) {
-    return this.postForm(ActionCreator.RESOLVE_COMPLAINTS, url, data, csrfToken).bind(this);
+  resolveComplaints(url: string, data: FormData) {
+    return this.postForm(ActionCreator.RESOLVE_COMPLAINTS, url, data).bind(this);
   }
 
   fetchGenreTree(url: string) {
     return this.fetchJSON<GenreTree>(ActionCreator.GENRE_TREE, url).bind(this);
   }
 
-  editClassifications(url: string, data: FormData, csrfToken: string) {
-    return this.postForm(ActionCreator.EDIT_CLASSIFICATIONS, url, data, csrfToken).bind(this);
+  editClassifications(url: string, data: FormData) {
+    return this.postForm(ActionCreator.EDIT_CLASSIFICATIONS, url, data).bind(this);
   }
 
   fetchClassifications(url: string) {
@@ -257,9 +263,9 @@ export default class ActionCreator extends BaseActionCreator {
     return this.fetchJSON<LibrariesData>(ActionCreator.LIBRARIES, url).bind(this);
   }
 
-  editLibrary(data: FormData, csrfToken) {
+  editLibrary(data: FormData) {
     const url = "/admin/libraries";
-    return this.postForm(ActionCreator.EDIT_LIBRARY, url, data, csrfToken).bind(this);
+    return this.postForm(ActionCreator.EDIT_LIBRARY, url, data).bind(this);
   }
 
   fetchCollections() {
@@ -267,9 +273,9 @@ export default class ActionCreator extends BaseActionCreator {
     return this.fetchJSON<CollectionsData>(ActionCreator.COLLECTIONS, url).bind(this);
   }
 
-  editCollection(data: FormData, csrfToken: string) {
+  editCollection(data: FormData) {
     const url = "/admin/collections";
-    return this.postForm(ActionCreator.EDIT_COLLECTION, url, data, csrfToken).bind(this);
+    return this.postForm(ActionCreator.EDIT_COLLECTION, url, data).bind(this);
   }
 
   fetchAdminAuthServices() {
@@ -277,9 +283,9 @@ export default class ActionCreator extends BaseActionCreator {
     return this.fetchJSON<AdminAuthServicesData>(ActionCreator.ADMIN_AUTH_SERVICES, url).bind(this);
   }
 
-  editAdminAuthService(data: FormData, csrfToken: string) {
+  editAdminAuthService(data: FormData) {
     const url = "/admin/admin_auth_services";
-    return this.postForm(ActionCreator.EDIT_ADMIN_AUTH_SERVICE, url, data, csrfToken).bind(this);
+    return this.postForm(ActionCreator.EDIT_ADMIN_AUTH_SERVICE, url, data).bind(this);
   }
 
   fetchIndividualAdmins() {
@@ -287,9 +293,9 @@ export default class ActionCreator extends BaseActionCreator {
     return this.fetchJSON<IndividualAdminsData>(ActionCreator.INDIVIDUAL_ADMINS, url).bind(this);
   }
 
-  editIndividualAdmin(data: FormData, csrfToken: string) {
+  editIndividualAdmin(data: FormData) {
     const url = "/admin/individual_admins";
-    return this.postForm(ActionCreator.EDIT_INDIVIDUAL_ADMIN, url, data, csrfToken).bind(this);
+    return this.postForm(ActionCreator.EDIT_INDIVIDUAL_ADMIN, url, data).bind(this);
   }
 
   fetchPatronAuthServices() {
@@ -297,9 +303,9 @@ export default class ActionCreator extends BaseActionCreator {
     return this.fetchJSON<PatronAuthServicesData>(ActionCreator.PATRON_AUTH_SERVICES, url).bind(this);
   }
 
-  editPatronAuthService(data: FormData, csrfToken: string) {
+  editPatronAuthService(data: FormData) {
     const url = "/admin/patron_auth_services";
-    return this.postForm(ActionCreator.EDIT_PATRON_AUTH_SERVICE, url, data, csrfToken).bind(this);
+    return this.postForm(ActionCreator.EDIT_PATRON_AUTH_SERVICE, url, data).bind(this);
   }
 
   fetchSitewideSettings() {
@@ -307,9 +313,9 @@ export default class ActionCreator extends BaseActionCreator {
     return this.fetchJSON<SitewideSettingsData>(ActionCreator.SITEWIDE_SETTINGS, url).bind(this);
   }
 
-  editSitewideSetting(data: FormData, csrfToken: string) {
+  editSitewideSetting(data: FormData) {
     const url = "/admin/sitewide_settings";
-    return this.postForm(ActionCreator.EDIT_SITEWIDE_SETTING, url, data, csrfToken).bind(this);
+    return this.postForm(ActionCreator.EDIT_SITEWIDE_SETTING, url, data).bind(this);
   }
 
   fetchMetadataServices() {
@@ -317,9 +323,9 @@ export default class ActionCreator extends BaseActionCreator {
     return this.fetchJSON<MetadataServicesData>(ActionCreator.METADATA_SERVICES, url).bind(this);
   }
 
-  editMetadataService(data: FormData, csrfToken: string) {
+  editMetadataService(data: FormData) {
     const url = "/admin/metadata_services";
-    return this.postForm(ActionCreator.EDIT_METADATA_SERVICE, url, data, csrfToken).bind(this);
+    return this.postForm(ActionCreator.EDIT_METADATA_SERVICE, url, data).bind(this);
   }
 
   fetchAnalyticsServices() {
@@ -327,9 +333,9 @@ export default class ActionCreator extends BaseActionCreator {
     return this.fetchJSON<AnalyticsServicesData>(ActionCreator.ANALYTICS_SERVICES, url).bind(this);
   }
 
-  editAnalyticsService(data: FormData, csrfToken: string) {
+  editAnalyticsService(data: FormData) {
     const url = "/admin/analytics_services";
-    return this.postForm(ActionCreator.EDIT_ANALYTICS_SERVICE, url, data, csrfToken).bind(this);
+    return this.postForm(ActionCreator.EDIT_ANALYTICS_SERVICE, url, data).bind(this);
   }
 
   fetchCDNServices() {
@@ -337,9 +343,9 @@ export default class ActionCreator extends BaseActionCreator {
     return this.fetchJSON<CDNServicesData>(ActionCreator.CDN_SERVICES, url).bind(this);
   }
 
-  editCDNService(data: FormData, csrfToken: string) {
+  editCDNService(data: FormData) {
     const url = "/admin/cdn_services";
-    return this.postForm(ActionCreator.EDIT_CDN_SERVICE, url, data, csrfToken).bind(this);
+    return this.postForm(ActionCreator.EDIT_CDN_SERVICE, url, data).bind(this);
   }
 
   fetchSearchServices() {
@@ -347,9 +353,9 @@ export default class ActionCreator extends BaseActionCreator {
     return this.fetchJSON<SearchServicesData>(ActionCreator.SEARCH_SERVICES, url).bind(this);
   }
 
-  editSearchService(data: FormData, csrfToken: string) {
+  editSearchService(data: FormData) {
     const url = "/admin/search_services";
-    return this.postForm(ActionCreator.EDIT_SEARCH_SERVICE, url, data, csrfToken).bind(this);
+    return this.postForm(ActionCreator.EDIT_SEARCH_SERVICE, url, data).bind(this);
   }
 
   fetchDiscoveryServices() {
@@ -357,14 +363,14 @@ export default class ActionCreator extends BaseActionCreator {
     return this.fetchJSON<DiscoveryServicesData>(ActionCreator.DISCOVERY_SERVICES, url).bind(this);
   }
 
-  editDiscoveryService(data: FormData, csrfToken: string) {
+  editDiscoveryService(data: FormData) {
     const url = "/admin/discovery_services";
-    return this.postForm(ActionCreator.EDIT_DISCOVERY_SERVICE, url, data, csrfToken).bind(this);
+    return this.postForm(ActionCreator.EDIT_DISCOVERY_SERVICE, url, data).bind(this);
   }
 
-  registerLibrary(data: FormData, csrfToken: string) {
+  registerLibrary(data: FormData) {
     const url = "/admin/library_registrations";
-    return this.postForm(ActionCreator.REGISTER_LIBRARY, url, data, csrfToken).bind(this);
+    return this.postForm(ActionCreator.REGISTER_LIBRARY, url, data).bind(this);
   }
 
   fetchLibraryRegistrations() {
@@ -377,13 +383,13 @@ export default class ActionCreator extends BaseActionCreator {
     return this.fetchJSON<CustomListsData>(ActionCreator.CUSTOM_LISTS, url).bind(this);
   }
 
-  editCustomList(library: string, data: FormData, csrfToken: string) {
+  editCustomList(library: string, data: FormData) {
     const url = "/" + library + "/admin/custom_lists";
-    return this.postForm(ActionCreator.EDIT_CUSTOM_LIST, url, data, csrfToken).bind(this);
+    return this.postForm(ActionCreator.EDIT_CUSTOM_LIST, url, data).bind(this);
   }
 
-  deleteCustomList(library: string, listId: string, csrfToken: string) {
+  deleteCustomList(library: string, listId: string) {
     const url = "/" + library + "/admin/custom_list/" + listId;
-    return this.postForm(ActionCreator.DELETE_CUSTOM_LIST, url, null, csrfToken, "DELETE").bind(this);
+    return this.postForm(ActionCreator.DELETE_CUSTOM_LIST, url, null, "DELETE").bind(this);
   }
 }

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -102,16 +102,15 @@ export default class ActionCreator extends BaseActionCreator {
     super(fetcher);
   }
 
-  postForm(type: string, url: string, data: FormData | null, csrfToken?: string, method?: string) {
+
+  postForm(type: string, url: string, data: FormData | null, csrfToken: string, method?: string) {
     let err: RequestError;
 
     return (dispatch => {
       return new Promise((resolve, reject: RequestRejector) => {
         dispatch(this.request(type));
         let headers = new Headers();
-        if (csrfToken) {
-          headers.append("X-CSRF-Token", csrfToken);
-        }
+        headers.append("X-CSRF-Token", csrfToken);
         fetch(url, {
           method: method || "POST",
           headers: headers,
@@ -158,18 +157,21 @@ export default class ActionCreator extends BaseActionCreator {
     }).bind(this);
   }
 
-  postJSON<T>(type: string, url: string, data: T) {
+  postJSON<T>(type: string, url: string, data: T, csrfToken?: string) {
     let err: RequestError;
 
     return (dispatch => {
       return new Promise((resolve, reject: RequestRejector) => {
         dispatch(this.request(type, url));
+        let headers = new Headers();
+        if (csrfToken) {
+          headers.append("X-CSRF-Token", csrfToken);
+        }
+        headers.append("Accept", "application/json");
+        headers.append("Content-Type", "application/json");
         fetch(url, {
           method: "POST",
-          headers: {
-            "Accept": "application/json",
-            "Content-Type": "application/json"
-          },
+          headers: headers,
           body: JSON.stringify(data),
           credentials: "same-origin"
         }).then(response => {
@@ -212,8 +214,8 @@ export default class ActionCreator extends BaseActionCreator {
     return this.fetchOPDS<BookData>(ActionCreator.BOOK_ADMIN, url).bind(this);
   }
 
-  editBook(url: string, data: FormData) {
-    return this.postForm(ActionCreator.EDIT_BOOK, url, data).bind(this);
+  editBook(url: string, data: FormData | null, csrfToken: string) {
+    return this.postForm(ActionCreator.EDIT_BOOK, url, data, csrfToken).bind(this);
   }
 
   fetchComplaints(url: string) {
@@ -224,16 +226,16 @@ export default class ActionCreator extends BaseActionCreator {
     return this.postJSON<{type: string}>(ActionCreator.POST_COMPLAINT, url, data).bind(this);
   }
 
-  resolveComplaints(url: string, data: FormData) {
-    return this.postForm(ActionCreator.RESOLVE_COMPLAINTS, url, data).bind(this);
+  resolveComplaints(url: string, data: FormData, csrfToken: string) {
+    return this.postForm(ActionCreator.RESOLVE_COMPLAINTS, url, data, csrfToken).bind(this);
   }
 
   fetchGenreTree(url: string) {
     return this.fetchJSON<GenreTree>(ActionCreator.GENRE_TREE, url).bind(this);
   }
 
-  editClassifications(url: string, data: FormData) {
-    return this.postForm(ActionCreator.EDIT_CLASSIFICATIONS, url, data).bind(this);
+  editClassifications(url: string, data: FormData, csrfToken: string) {
+    return this.postForm(ActionCreator.EDIT_CLASSIFICATIONS, url, data, csrfToken).bind(this);
   }
 
   fetchClassifications(url: string) {
@@ -255,9 +257,9 @@ export default class ActionCreator extends BaseActionCreator {
     return this.fetchJSON<LibrariesData>(ActionCreator.LIBRARIES, url).bind(this);
   }
 
-  editLibrary(data: FormData) {
+  editLibrary(data: FormData, csrfToken) {
     const url = "/admin/libraries";
-    return this.postForm(ActionCreator.EDIT_LIBRARY, url, data).bind(this);
+    return this.postForm(ActionCreator.EDIT_LIBRARY, url, data, csrfToken).bind(this);
   }
 
   fetchCollections() {
@@ -265,9 +267,9 @@ export default class ActionCreator extends BaseActionCreator {
     return this.fetchJSON<CollectionsData>(ActionCreator.COLLECTIONS, url).bind(this);
   }
 
-  editCollection(data: FormData) {
+  editCollection(data: FormData, csrfToken: string) {
     const url = "/admin/collections";
-    return this.postForm(ActionCreator.EDIT_COLLECTION, url, data).bind(this);
+    return this.postForm(ActionCreator.EDIT_COLLECTION, url, data, csrfToken).bind(this);
   }
 
   fetchAdminAuthServices() {
@@ -275,9 +277,9 @@ export default class ActionCreator extends BaseActionCreator {
     return this.fetchJSON<AdminAuthServicesData>(ActionCreator.ADMIN_AUTH_SERVICES, url).bind(this);
   }
 
-  editAdminAuthService(data: FormData) {
+  editAdminAuthService(data: FormData, csrfToken: string) {
     const url = "/admin/admin_auth_services";
-    return this.postForm(ActionCreator.EDIT_ADMIN_AUTH_SERVICE, url, data).bind(this);
+    return this.postForm(ActionCreator.EDIT_ADMIN_AUTH_SERVICE, url, data, csrfToken).bind(this);
   }
 
   fetchIndividualAdmins() {
@@ -285,9 +287,9 @@ export default class ActionCreator extends BaseActionCreator {
     return this.fetchJSON<IndividualAdminsData>(ActionCreator.INDIVIDUAL_ADMINS, url).bind(this);
   }
 
-  editIndividualAdmin(data: FormData) {
+  editIndividualAdmin(data: FormData, csrfToken: string) {
     const url = "/admin/individual_admins";
-    return this.postForm(ActionCreator.EDIT_INDIVIDUAL_ADMIN, url, data).bind(this);
+    return this.postForm(ActionCreator.EDIT_INDIVIDUAL_ADMIN, url, data, csrfToken).bind(this);
   }
 
   fetchPatronAuthServices() {
@@ -295,9 +297,9 @@ export default class ActionCreator extends BaseActionCreator {
     return this.fetchJSON<PatronAuthServicesData>(ActionCreator.PATRON_AUTH_SERVICES, url).bind(this);
   }
 
-  editPatronAuthService(data: FormData) {
+  editPatronAuthService(data: FormData, csrfToken: string) {
     const url = "/admin/patron_auth_services";
-    return this.postForm(ActionCreator.EDIT_PATRON_AUTH_SERVICE, url, data).bind(this);
+    return this.postForm(ActionCreator.EDIT_PATRON_AUTH_SERVICE, url, data, csrfToken).bind(this);
   }
 
   fetchSitewideSettings() {
@@ -305,9 +307,9 @@ export default class ActionCreator extends BaseActionCreator {
     return this.fetchJSON<SitewideSettingsData>(ActionCreator.SITEWIDE_SETTINGS, url).bind(this);
   }
 
-  editSitewideSetting(data: FormData) {
+  editSitewideSetting(data: FormData, csrfToken: string) {
     const url = "/admin/sitewide_settings";
-    return this.postForm(ActionCreator.EDIT_SITEWIDE_SETTING, url, data).bind(this);
+    return this.postForm(ActionCreator.EDIT_SITEWIDE_SETTING, url, data, csrfToken).bind(this);
   }
 
   fetchMetadataServices() {
@@ -315,9 +317,9 @@ export default class ActionCreator extends BaseActionCreator {
     return this.fetchJSON<MetadataServicesData>(ActionCreator.METADATA_SERVICES, url).bind(this);
   }
 
-  editMetadataService(data: FormData) {
+  editMetadataService(data: FormData, csrfToken: string) {
     const url = "/admin/metadata_services";
-    return this.postForm(ActionCreator.EDIT_METADATA_SERVICE, url, data).bind(this);
+    return this.postForm(ActionCreator.EDIT_METADATA_SERVICE, url, data, csrfToken).bind(this);
   }
 
   fetchAnalyticsServices() {
@@ -325,9 +327,9 @@ export default class ActionCreator extends BaseActionCreator {
     return this.fetchJSON<AnalyticsServicesData>(ActionCreator.ANALYTICS_SERVICES, url).bind(this);
   }
 
-  editAnalyticsService(data: FormData) {
+  editAnalyticsService(data: FormData, csrfToken: string) {
     const url = "/admin/analytics_services";
-    return this.postForm(ActionCreator.EDIT_ANALYTICS_SERVICE, url, data).bind(this);
+    return this.postForm(ActionCreator.EDIT_ANALYTICS_SERVICE, url, data, csrfToken).bind(this);
   }
 
   fetchCDNServices() {
@@ -335,9 +337,9 @@ export default class ActionCreator extends BaseActionCreator {
     return this.fetchJSON<CDNServicesData>(ActionCreator.CDN_SERVICES, url).bind(this);
   }
 
-  editCDNService(data: FormData) {
+  editCDNService(data: FormData, csrfToken: string) {
     const url = "/admin/cdn_services";
-    return this.postForm(ActionCreator.EDIT_CDN_SERVICE, url, data).bind(this);
+    return this.postForm(ActionCreator.EDIT_CDN_SERVICE, url, data, csrfToken).bind(this);
   }
 
   fetchSearchServices() {
@@ -345,9 +347,9 @@ export default class ActionCreator extends BaseActionCreator {
     return this.fetchJSON<SearchServicesData>(ActionCreator.SEARCH_SERVICES, url).bind(this);
   }
 
-  editSearchService(data: FormData) {
+  editSearchService(data: FormData, csrfToken: string) {
     const url = "/admin/search_services";
-    return this.postForm(ActionCreator.EDIT_SEARCH_SERVICE, url, data).bind(this);
+    return this.postForm(ActionCreator.EDIT_SEARCH_SERVICE, url, data, csrfToken).bind(this);
   }
 
   fetchDiscoveryServices() {
@@ -355,14 +357,14 @@ export default class ActionCreator extends BaseActionCreator {
     return this.fetchJSON<DiscoveryServicesData>(ActionCreator.DISCOVERY_SERVICES, url).bind(this);
   }
 
-  editDiscoveryService(data: FormData) {
+  editDiscoveryService(data: FormData, csrfToken: string) {
     const url = "/admin/discovery_services";
-    return this.postForm(ActionCreator.EDIT_DISCOVERY_SERVICE, url, data).bind(this);
+    return this.postForm(ActionCreator.EDIT_DISCOVERY_SERVICE, url, data, csrfToken).bind(this);
   }
 
-  registerLibrary(data: FormData) {
+  registerLibrary(data: FormData, csrfToken: string) {
     const url = "/admin/library_registrations";
-    return this.postForm(ActionCreator.REGISTER_LIBRARY, url, data).bind(this);
+    return this.postForm(ActionCreator.REGISTER_LIBRARY, url, data, csrfToken).bind(this);
   }
 
   fetchLibraryRegistrations() {
@@ -375,7 +377,7 @@ export default class ActionCreator extends BaseActionCreator {
     return this.fetchJSON<CustomListsData>(ActionCreator.CUSTOM_LISTS, url).bind(this);
   }
 
-  editCustomList(library: string, data: FormData, csrfToken) {
+  editCustomList(library: string, data: FormData, csrfToken: string) {
     const url = "/" + library + "/admin/custom_lists";
     return this.postForm(ActionCreator.EDIT_CUSTOM_LIST, url, data, csrfToken).bind(this);
   }

--- a/src/components/AdminAuthServices.tsx
+++ b/src/components/AdminAuthServices.tsx
@@ -23,10 +23,10 @@ function mapStateToProps(state, ownProps) {
 }
 
 function mapDispatchToProps(dispatch, ownProps) {
-  let actions = new ActionCreator();
+  let actions = new ActionCreator(null, ownProps.csrfToken);
   return {
     fetchData: () => dispatch(actions.fetchAdminAuthServices()),
-    editItem: (data: FormData) => dispatch(actions.editAdminAuthService(data, ownProps.csrfToken))
+    editItem: (data: FormData) => dispatch(actions.editAdminAuthService(data))
   };
 }
 

--- a/src/components/AdminAuthServices.tsx
+++ b/src/components/AdminAuthServices.tsx
@@ -1,4 +1,4 @@
-import EditableConfigList from "./EditableConfigList";
+import EditableConfigList, { EditableConfigListStateProps, EditableConfigListDispatchProps, EditableConfigListOwnProps } from "./EditableConfigList";
 import { connect } from "react-redux";
 import ActionCreator from "../actions";
 import { AdminAuthServicesData, AdminAuthServiceData } from "../interfaces";
@@ -22,15 +22,15 @@ function mapStateToProps(state, ownProps) {
   };
 }
 
-function mapDispatchToProps(dispatch) {
+function mapDispatchToProps(dispatch, ownProps) {
   let actions = new ActionCreator();
   return {
     fetchData: () => dispatch(actions.fetchAdminAuthServices()),
-    editItem: (data: FormData) => dispatch(actions.editAdminAuthService(data))
+    editItem: (data: FormData) => dispatch(actions.editAdminAuthService(data, ownProps.csrfToken))
   };
 }
 
-const ConnectedAdminAuthServices = connect<any, any, any>(
+const ConnectedAdminAuthServices = connect<EditableConfigListStateProps<AdminAuthServicesData>, EditableConfigListDispatchProps<AdminAuthServicesData>, EditableConfigListOwnProps>(
   mapStateToProps,
   mapDispatchToProps
 )(AdminAuthServices);

--- a/src/components/AnalyticsServices.tsx
+++ b/src/components/AnalyticsServices.tsx
@@ -35,10 +35,10 @@ function mapStateToProps(state, ownProps) {
 }
 
 function mapDispatchToProps(dispatch, ownProps) {
-  let actions = new ActionCreator();
+  let actions = new ActionCreator(null, ownProps.csrfToken);
   return {
     fetchData: () => dispatch(actions.fetchAnalyticsServices()),
-    editItem: (data: FormData) => dispatch(actions.editAnalyticsService(data, ownProps.csrfToken))
+    editItem: (data: FormData) => dispatch(actions.editAnalyticsService(data))
   };
 }
 

--- a/src/components/AnalyticsServices.tsx
+++ b/src/components/AnalyticsServices.tsx
@@ -1,4 +1,4 @@
-import EditableConfigList from "./EditableConfigList";
+import EditableConfigList, { EditableConfigListStateProps, EditableConfigListDispatchProps, EditableConfigListOwnProps } from "./EditableConfigList";
 import { connect } from "react-redux";
 import ActionCreator from "../actions";
 import { AnalyticsServicesData, AnalyticsServiceData } from "../interfaces";
@@ -34,15 +34,15 @@ function mapStateToProps(state, ownProps) {
   };
 }
 
-function mapDispatchToProps(dispatch) {
+function mapDispatchToProps(dispatch, ownProps) {
   let actions = new ActionCreator();
   return {
     fetchData: () => dispatch(actions.fetchAnalyticsServices()),
-    editItem: (data: FormData) => dispatch(actions.editAnalyticsService(data))
+    editItem: (data: FormData) => dispatch(actions.editAnalyticsService(data, ownProps.csrfToken))
   };
 }
 
-const ConnectedAnalyticsServices = connect<any, any, any>(
+const ConnectedAnalyticsServices = connect<EditableConfigListStateProps<AnalyticsServicesData>, EditableConfigListDispatchProps<AnalyticsServicesData>, EditableConfigListOwnProps>(
   mapStateToProps,
   mapDispatchToProps
 )(AnalyticsServices);

--- a/src/components/BookEditForm.tsx
+++ b/src/components/BookEditForm.tsx
@@ -3,7 +3,6 @@ import EditableInput from "./EditableInput";
 import { BookData } from "../interfaces";
 
 export interface BookEditFormProps extends BookData {
-  csrfToken: string;
   disabled: boolean;
   refresh: () => any;
   editBook: (url: string, data: FormData) => Promise<any>;
@@ -13,11 +12,6 @@ export default class BookEditForm extends React.Component<BookEditFormProps, any
   render(): JSX.Element {
     return (
       <form ref="form" onSubmit={this.save.bind(this)} className="edit-form">
-        <input
-          type="hidden"
-          name="csrf_token"
-          value={this.props.csrfToken}
-          />
         <EditableInput
           elementType="input"
           type="text"

--- a/src/components/CDNServices.tsx
+++ b/src/components/CDNServices.tsx
@@ -1,4 +1,4 @@
-import EditableConfigList from "./EditableConfigList";
+import EditableConfigList, { EditableConfigListStateProps, EditableConfigListDispatchProps, EditableConfigListOwnProps } from "./EditableConfigList";
 import { connect } from "react-redux";
 import ActionCreator from "../actions";
 import { CDNServicesData, CDNServiceData } from "../interfaces";
@@ -26,15 +26,15 @@ function mapStateToProps(state, ownProps) {
   };
 }
 
-function mapDispatchToProps(dispatch) {
+function mapDispatchToProps(dispatch, ownProps) {
   let actions = new ActionCreator();
   return {
     fetchData: () => dispatch(actions.fetchCDNServices()),
-    editItem: (data: FormData) => dispatch(actions.editCDNService(data))
+    editItem: (data: FormData) => dispatch(actions.editCDNService(data, ownProps.csrfToken))
   };
 }
 
-const ConnectedCDNServices = connect<any, any, any>(
+const ConnectedCDNServices = connect<EditableConfigListStateProps<CDNServicesData>, EditableConfigListDispatchProps<CDNServicesData>, EditableConfigListOwnProps>(
   mapStateToProps,
   mapDispatchToProps
 )(CDNServices);

--- a/src/components/CDNServices.tsx
+++ b/src/components/CDNServices.tsx
@@ -27,10 +27,10 @@ function mapStateToProps(state, ownProps) {
 }
 
 function mapDispatchToProps(dispatch, ownProps) {
-  let actions = new ActionCreator();
+  let actions = new ActionCreator(null, ownProps.csrfToken);
   return {
     fetchData: () => dispatch(actions.fetchCDNServices()),
-    editItem: (data: FormData) => dispatch(actions.editCDNService(data, ownProps.csrfToken))
+    editItem: (data: FormData) => dispatch(actions.editCDNService(data))
   };
 }
 

--- a/src/components/CirculationEvents.tsx
+++ b/src/components/CirculationEvents.tsx
@@ -10,16 +10,28 @@ import { CirculationEventData } from "../interfaces";
 import { FetchErrorData } from "opds-web-client/lib/interfaces";
 import { State } from "../reducers/index";
 
-export interface CirculationEventsProps {
-  store?: Store<State>;
+export interface CirculationEventsStateProps {
   events?: CirculationEventData[];
   fetchError?: FetchErrorData;
-  fetchCirculationEvents?: () => Promise<any>;
-  wait?: number;
   isLoaded?: boolean;
 }
 
-export class CirculationEvents extends React.Component<CirculationEventsProps, any> {
+export interface CirculationEventsDispatchProps {
+  fetchCirculationEvents?: () => Promise<any>;
+}
+
+export interface CirculationEventsOwnProps {
+  store?: Store<State>;
+  wait?: number;
+}
+
+export interface CirculationEventsProps extends CirculationEventsStateProps, CirculationEventsDispatchProps, CirculationEventsOwnProps {}
+
+export interface CirculationEventsState {
+  showDownloadForm: boolean;
+}
+
+export class CirculationEvents extends React.Component<CirculationEventsProps, CirculationEventsState> {
   timer: any;
   context: { showCircEventsDownload: boolean };
   _isMounted: boolean;
@@ -150,7 +162,7 @@ function mapDispatchToProps(dispatch) {
   };
 }
 
-const ConnectedCirculationEvents = connect<any, any, any>(
+const ConnectedCirculationEvents = connect<CirculationEventsStateProps, CirculationEventsDispatchProps, CirculationEventsOwnProps>(
   mapStateToProps,
   mapDispatchToProps
 )(CirculationEvents);

--- a/src/components/CirculationEventsDownloadForm.tsx
+++ b/src/components/CirculationEventsDownloadForm.tsx
@@ -7,7 +7,7 @@ export interface CirculationEventsDownloadFormProps extends React.Props<Circulat
   hide: () => void;
 }
 
-export default class CirculationEventsDownloadForm extends React.Component<CirculationEventsDownloadFormProps, any> {
+export default class CirculationEventsDownloadForm extends React.Component<CirculationEventsDownloadFormProps, void> {
   constructor(props) {
     super(props);
     this.download = this.download.bind(this);

--- a/src/components/Classifications.tsx
+++ b/src/components/Classifications.tsx
@@ -128,12 +128,12 @@ function mapStateToProps(state, ownProps) {
 
 function mapDispatchToProps(dispatch, ownProps) {
   let fetcher = new DataFetcher({ adapter: editorAdapter });
-  let actions = new ActionCreator(fetcher);
+  let actions = new ActionCreator(fetcher, ownProps.csrfToken);
   return {
     fetchBook: (url: string) => dispatch(actions.fetchBookAdmin(url)),
     fetchGenreTree: (url: string) => dispatch(actions.fetchGenreTree(url)),
     fetchClassifications: (url: string) => dispatch(actions.fetchClassifications(url)),
-    editClassifications: (url: string, data: FormData) => dispatch(actions.editClassifications(url, data, ownProps.csrfToken))
+    editClassifications: (url: string, data: FormData) => dispatch(actions.editClassifications(url, data))
   };
 }
 

--- a/src/components/Classifications.tsx
+++ b/src/components/Classifications.tsx
@@ -11,21 +11,16 @@ import { BookData, Audience, Fiction, GenreTree, ClassificationData } from "../i
 import { FetchErrorData } from "opds-web-client/lib/interfaces";
 import { State } from "../reducers/index";
 
-export interface ClassificationsProps {
-  // from parent
-  store: Store<State>;
-  bookUrl: string;
-  book: BookData;
-  csrfToken: string;
-  refreshCatalog: () => Promise<any>;
-
+export interface ClassificationsStateProps {
   // from store
   bookAdminUrl?: string;
   genreTree?: GenreTree;
   classifications?: ClassificationData[];
   fetchError?: FetchErrorData;
   isFetching?: boolean;
+}
 
+export interface ClassificationsDispatchProps {
   // from actions
   fetchBook?: (url: string) => Promise<any>;
   fetchGenreTree?: (url: string) => Promise<any>;
@@ -33,7 +28,18 @@ export interface ClassificationsProps {
   editClassifications?: (url: string, data: FormData) => Promise<any>;
 }
 
-export class Classifications extends React.Component<ClassificationsProps, any> {
+export interface ClassificationsOwnProps {
+  // from parent
+  store: Store<State>;
+  csrfToken: string;
+  bookUrl: string;
+  book: BookData;
+  refreshCatalog: () => Promise<any>;
+}
+
+export interface ClassificationsProps extends ClassificationsStateProps, ClassificationsDispatchProps, ClassificationsOwnProps {};
+
+export class Classifications extends React.Component<ClassificationsProps, void> {
   constructor(props) {
     super(props);
     this.refresh = this.refresh.bind(this);
@@ -68,7 +74,6 @@ export class Classifications extends React.Component<ClassificationsProps, any> 
             book={this.props.book}
             genreTree={this.props.genreTree}
             disabled={this.props.isFetching}
-            csrfToken={this.props.csrfToken}
             editClassifications={this.editClassifications}
             />
         }
@@ -121,18 +126,18 @@ function mapStateToProps(state, ownProps) {
   };
 }
 
-function mapDispatchToProps(dispatch) {
+function mapDispatchToProps(dispatch, ownProps) {
   let fetcher = new DataFetcher({ adapter: editorAdapter });
   let actions = new ActionCreator(fetcher);
   return {
     fetchBook: (url: string) => dispatch(actions.fetchBookAdmin(url)),
     fetchGenreTree: (url: string) => dispatch(actions.fetchGenreTree(url)),
     fetchClassifications: (url: string) => dispatch(actions.fetchClassifications(url)),
-    editClassifications: (url: string, data: FormData) => dispatch(actions.editClassifications(url, data))
+    editClassifications: (url: string, data: FormData) => dispatch(actions.editClassifications(url, data, ownProps.csrfToken))
   };
 }
 
-const ConnectedClassifications = connect<any, any, any>(
+const ConnectedClassifications = connect<ClassificationsStateProps, ClassificationsDispatchProps, ClassificationsOwnProps>(
   mapStateToProps,
   mapDispatchToProps
 )(Classifications);

--- a/src/components/ClassificationsForm.tsx
+++ b/src/components/ClassificationsForm.tsx
@@ -9,7 +9,6 @@ import { BookData, GenreTree } from "../interfaces";
 export interface ClassificationsFormProps {
   book: BookData;
   genreTree: GenreTree;
-  csrfToken: string;
   editClassifications: (data: FormData) => Promise<any>;
   disabled?: boolean;
 }
@@ -257,7 +256,6 @@ export default class ClassificationsForm extends React.Component<Classifications
 
   submit() {
     let data = new (window as any).FormData();
-    data.append("csrf_token", this.props.csrfToken);
     data.append("audience", this.state.audience);
     if (this.shouldShowTargetAge()) {
       data.append("target_age_min", (this.refs as any).targetAgeMin.getValue());

--- a/src/components/ClassificationsTable.tsx
+++ b/src/components/ClassificationsTable.tsx
@@ -5,7 +5,7 @@ export interface ClassificationsTableProps {
   classifications: ClassificationData[];
 }
 
-export default class ClassificationsTable extends React.Component<ClassificationsTableProps, any> {
+export default class ClassificationsTable extends React.Component<ClassificationsTableProps, void> {
   render(): JSX.Element {
     return (
       <div className="classifications-table">

--- a/src/components/Collections.tsx
+++ b/src/components/Collections.tsx
@@ -1,4 +1,4 @@
-import EditableConfigList from "./EditableConfigList";
+import EditableConfigList, { EditableConfigListStateProps, EditableConfigListDispatchProps, EditableConfigListOwnProps } from "./EditableConfigList";
 import { connect } from "react-redux";
 import ActionCreator from "../actions";
 import { CollectionsData, CollectionData, LibraryData } from "../interfaces";
@@ -25,15 +25,15 @@ function mapStateToProps(state, ownProps) {
   };
 }
 
-function mapDispatchToProps(dispatch) {
+function mapDispatchToProps(dispatch, ownProps) {
   let actions = new ActionCreator();
   return {
     fetchData: () => dispatch(actions.fetchCollections()),
-    editItem: (data: FormData) => dispatch(actions.editCollection(data))
+    editItem: (data: FormData) => dispatch(actions.editCollection(data, ownProps.csrfToken))
   };
 }
 
-const ConnectedCollections = connect<any, any, any>(
+const ConnectedCollections = connect<EditableConfigListStateProps<CollectionsData>, EditableConfigListDispatchProps<CollectionsData>, EditableConfigListOwnProps>(
   mapStateToProps,
   mapDispatchToProps,
 )(Collections);

--- a/src/components/Collections.tsx
+++ b/src/components/Collections.tsx
@@ -26,10 +26,10 @@ function mapStateToProps(state, ownProps) {
 }
 
 function mapDispatchToProps(dispatch, ownProps) {
-  let actions = new ActionCreator();
+  let actions = new ActionCreator(null, ownProps.csrfToken);
   return {
     fetchData: () => dispatch(actions.fetchCollections()),
-    editItem: (data: FormData) => dispatch(actions.editCollection(data, ownProps.csrfToken))
+    editItem: (data: FormData) => dispatch(actions.editCollection(data))
   };
 }
 

--- a/src/components/Complaints.tsx
+++ b/src/components/Complaints.tsx
@@ -154,11 +154,11 @@ function mapStateToProps(state, ownProps) {
 
 function mapDispatchToProps(dispatch, ownProps) {
   let fetcher = new DataFetcher();
-  let actions = new ActionCreator(fetcher);
+  let actions = new ActionCreator(fetcher, ownProps.csrfToken);
   return {
     fetchComplaints: (url) => dispatch(actions.fetchComplaints(url)),
     postComplaint: (url, data) => dispatch(actions.postComplaint(url, data)),
-    resolveComplaints: (url, data) => dispatch(actions.resolveComplaints(url, data, ownProps.csrfToken))
+    resolveComplaints: (url, data) => dispatch(actions.resolveComplaints(url, data))
   };
 }
 

--- a/src/components/Complaints.tsx
+++ b/src/components/Complaints.tsx
@@ -10,21 +10,29 @@ import { BookData, PostComplaint } from "../interfaces";
 import { FetchErrorData } from "opds-web-client/lib/interfaces";
 import { State } from "../reducers/index";
 
-export interface ComplaintsProps {
-  bookUrl: string;
-  book: BookData;
+export interface ComplaintsStateProps {
   complaints?: any;
   fetchError?: FetchErrorData;
-  store?: Store<State>;
-  csrfToken: string;
+  isFetching?: boolean;
+}
+
+export interface ComplaintsDispatchProps {
   fetchComplaints?: (url: string) => Promise<any>;
   postComplaint?: PostComplaint;
   resolveComplaints?: (url: string, data: FormData) => Promise<any>;
-  isFetching?: boolean;
+}
+
+export interface ComplaintsOwnProps {
+  bookUrl: string;
+  book: BookData;
+  store?: Store<State>;
+  csrfToken: string;
   refreshCatalog: () => Promise<any>;
 }
 
-export class Complaints extends React.Component<ComplaintsProps, any> {
+export interface ComplaintsProps extends ComplaintsStateProps, ComplaintsDispatchProps, ComplaintsOwnProps {};
+
+export class Complaints extends React.Component<ComplaintsProps, void> {
   constructor(props) {
     super(props);
     this.resolve = this.resolve.bind(this);
@@ -130,7 +138,6 @@ export class Complaints extends React.Component<ComplaintsProps, any> {
     if (window.confirm("Are you sure you want to resolve all complaints of this type?")) {
       let url = this.resolveComplaintsUrl();
       let data = new (window as any).FormData();
-      data.append("csrf_token", this.props.csrfToken);
       data.append("type", type);
       return this.props.resolveComplaints(url, data).then(this.refresh);
     }
@@ -145,17 +152,17 @@ function mapStateToProps(state, ownProps) {
   };
 }
 
-function mapDispatchToProps(dispatch) {
+function mapDispatchToProps(dispatch, ownProps) {
   let fetcher = new DataFetcher();
   let actions = new ActionCreator(fetcher);
   return {
     fetchComplaints: (url) => dispatch(actions.fetchComplaints(url)),
     postComplaint: (url, data) => dispatch(actions.postComplaint(url, data)),
-    resolveComplaints: (url, data) => dispatch(actions.resolveComplaints(url, data))
+    resolveComplaints: (url, data) => dispatch(actions.resolveComplaints(url, data, ownProps.csrfToken))
   };
 }
 
-const ConnectedComplaints = connect<any, any, any>(
+const ConnectedComplaints = connect<ComplaintsStateProps, ComplaintsDispatchProps, ComplaintsOwnProps>(
   mapStateToProps,
   mapDispatchToProps
 )(Complaints);

--- a/src/components/ContextProvider.tsx
+++ b/src/components/ContextProvider.tsx
@@ -10,7 +10,7 @@ export interface ContextProviderProps extends React.Props<any> {
   settingUp?: boolean;
 }
 
-export default class ContextProvider extends React.Component<ContextProviderProps, any> {
+export default class ContextProvider extends React.Component<ContextProviderProps, void> {
   store: Store<State>;
   pathFor: PathFor;
 

--- a/src/components/CustomListEditor.tsx
+++ b/src/components/CustomListEditor.tsx
@@ -7,7 +7,6 @@ import XCloseIcon from "./icons/XCloseIcon";
 import SearchIcon from "./icons/SearchIcon";
 
 export interface CustomListEditorProps extends React.Props<CustomListEditor> {
-  csrfToken: string;
   library: string;
   list?: CustomListData;
   editedIdentifier?: string;

--- a/src/components/CustomLists.tsx
+++ b/src/components/CustomLists.tsx
@@ -247,11 +247,11 @@ function mapStateToProps(state, ownProps) {
 
 function mapDispatchToProps(dispatch, ownProps) {
   let fetcher = new DataFetcher({ adapter });
-  let actions = new ActionCreator(fetcher);
+  let actions = new ActionCreator(fetcher, ownProps.csrfToken);
   return {
     fetchCustomLists: () => dispatch(actions.fetchCustomLists(ownProps.library)),
-    editCustomList: (data: FormData) => dispatch(actions.editCustomList(ownProps.library, data, ownProps.csrfToken)),
-    deleteCustomList: (listId: string) => dispatch(actions.deleteCustomList(ownProps.library, listId, ownProps.csrfToken)),
+    editCustomList: (data: FormData) => dispatch(actions.editCustomList(ownProps.library, data)),
+    deleteCustomList: (listId: string) => dispatch(actions.deleteCustomList(ownProps.library, listId)),
     search: (url: string) => dispatch(actions.fetchCollection(url)),
     loadMoreSearchResults: (url: string) => dispatch(actions.fetchPage(url))
   };

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -9,7 +9,7 @@ export interface DashboardContext {
   editorStore: Store<State>;
 }
 
-export default class Dashboard extends React.Component<any, any> {
+export default class Dashboard extends React.Component<void, void> {
   context: DashboardContext;
 
   static contextTypes: React.ValidationMap<DashboardContext> = {

--- a/src/components/DiscoveryServices.tsx
+++ b/src/components/DiscoveryServices.tsx
@@ -71,11 +71,11 @@ function mapStateToProps(state, ownProps) {
 }
 
 function mapDispatchToProps(dispatch, ownProps) {
-  let actions = new ActionCreator();
+  let actions = new ActionCreator(null, ownProps.csrfToken);
   return {
     fetchData: () => dispatch(actions.fetchDiscoveryServices()),
-    editItem: (data: FormData) => dispatch(actions.editDiscoveryService(data, ownProps.csrfToken)),
-    registerLibrary: (data: FormData) => dispatch(actions.registerLibrary(data, ownProps.csrfToken)),
+    editItem: (data: FormData) => dispatch(actions.editDiscoveryService(data)),
+    registerLibrary: (data: FormData) => dispatch(actions.registerLibrary(data)),
     fetchLibraryRegistrations: () => dispatch(actions.fetchLibraryRegistrations())
   };
 }

--- a/src/components/DiscoveryServices.tsx
+++ b/src/components/DiscoveryServices.tsx
@@ -1,15 +1,20 @@
 import * as React from "react";
-import { GenericEditableConfigList, EditableConfigListProps } from "./EditableConfigList";
+import { GenericEditableConfigList, EditableConfigListStateProps, EditableConfigListDispatchProps, EditableConfigListOwnProps } from "./EditableConfigList";
 import { connect } from "react-redux";
 import ActionCreator from "../actions";
 import { DiscoveryServicesData, DiscoveryServiceData, LibraryData, LibraryRegistrationsData } from "../interfaces";
 import DiscoveryServiceEditForm from "./DiscoveryServiceEditForm";
 
-export interface DiscoveryServicesProps extends EditableConfigListProps<DiscoveryServicesData> {
-  registerLibrary: (library: LibraryData) => Promise<void>;
-  fetchLibraryRegistrations?: () => Promise<LibraryRegistrationsData>;
+export interface DiscoveryServicesStateProps extends EditableConfigListStateProps<DiscoveryServicesData> {
   isFetchingLibraryRegistrations?: boolean;
 }
+
+export interface DiscoveryServicesDispatchProps extends EditableConfigListDispatchProps<DiscoveryServicesData> {
+  registerLibrary: (data: FormData) => Promise<void>;
+  fetchLibraryRegistrations?: () => Promise<LibraryRegistrationsData>;
+}
+
+export interface DiscoveryServicesProps extends DiscoveryServicesStateProps, DiscoveryServicesDispatchProps, EditableConfigListOwnProps {};
 
 export class DiscoveryServices extends GenericEditableConfigList<DiscoveryServicesData, DiscoveryServiceData, DiscoveryServicesProps> {
   EditForm = DiscoveryServiceEditForm;
@@ -28,7 +33,6 @@ export class DiscoveryServices extends GenericEditableConfigList<DiscoveryServic
       registerLibrary: (library: LibraryData) => {
         if (this.itemToEdit()) {
           const data = new (window as any).FormData();
-          data.append("csrf_token", this.props.csrfToken);
           data.append("library_short_name", library.short_name);
           data.append("integration_id", this.itemToEdit().id);
           this.props.registerLibrary(data).then(() => {
@@ -66,17 +70,17 @@ function mapStateToProps(state, ownProps) {
   };
 }
 
-function mapDispatchToProps(dispatch) {
+function mapDispatchToProps(dispatch, ownProps) {
   let actions = new ActionCreator();
   return {
     fetchData: () => dispatch(actions.fetchDiscoveryServices()),
-    editItem: (data: FormData) => dispatch(actions.editDiscoveryService(data)),
-    registerLibrary: (data: FormData) => dispatch(actions.registerLibrary(data)),
+    editItem: (data: FormData) => dispatch(actions.editDiscoveryService(data, ownProps.csrfToken)),
+    registerLibrary: (data: FormData) => dispatch(actions.registerLibrary(data, ownProps.csrfToken)),
     fetchLibraryRegistrations: () => dispatch(actions.fetchLibraryRegistrations())
   };
 }
 
-const ConnectedDiscoveryServices = connect<any, any, any>(
+const ConnectedDiscoveryServices = connect<DiscoveryServicesStateProps, DiscoveryServicesDispatchProps, EditableConfigListOwnProps>(
   mapStateToProps,
   mapDispatchToProps
 )(DiscoveryServices);

--- a/src/components/EditableConfigList.tsx
+++ b/src/components/EditableConfigList.tsx
@@ -5,22 +5,29 @@ import { State } from "../reducers/index";
 import LoadingIndicator from "opds-web-client/lib/components/LoadingIndicator";
 import ErrorMessage from "./ErrorMessage";
 
-export interface EditableConfigListProps<T> {
-  store?: Store<State>;
+export interface EditableConfigListStateProps<T> {
   data?: T;
   fetchError?: FetchErrorData;
+  isFetching?: boolean;
+}
+
+export interface EditableConfigListDispatchProps<T> {
   fetchData?: () => Promise<T>;
   editItem?: (data: FormData) => Promise<void>;
-  isFetching?: boolean;
+}
+
+export interface EditableConfigListOwnProps {
+  store?: Store<State>;
   csrfToken: string;
   editOrCreate?: string;
   identifier?: string;
 }
 
+export interface EditableConfigListProps<T> extends EditableConfigListStateProps<T>, EditableConfigListDispatchProps<T>, EditableConfigListOwnProps {}
+
 export interface EditFormProps<T, U> {
   item?: U;
   data: T;
-  csrfToken: string;
   disabled: boolean;
   editItem: (data: FormData) => Promise<void>;
   urlBase: string;
@@ -80,7 +87,6 @@ export abstract class GenericEditableConfigList<T, U, V extends EditableConfigLi
             <h2>Create a new {this.itemTypeName}</h2>
             <EditForm
               data={this.props.data}
-              csrfToken={this.props.csrfToken}
               disabled={this.props.isFetching}
               editItem={this.editItem}
               urlBase={this.urlBase}
@@ -95,7 +101,6 @@ export abstract class GenericEditableConfigList<T, U, V extends EditableConfigLi
             <EditForm
               item={this.itemToEdit()}
               data={this.props.data}
-              csrfToken={this.props.csrfToken}
               disabled={this.props.isFetching}
               editItem={this.editItem}
               urlBase={this.urlBase}

--- a/src/components/EditableInput.tsx
+++ b/src/components/EditableInput.tsx
@@ -7,7 +7,12 @@ export interface EditableInputProps extends React.HTMLProps<EditableInput> {
   onChange?: () => any;
 }
 
-export default class EditableInput extends React.Component<EditableInputProps, any> {
+export interface EditableInputState {
+  value: string;
+  checked: boolean;
+}
+
+export default class EditableInput extends React.Component<EditableInputProps, EditableInputState> {
   constructor(props) {
     super(props);
     this.state = {
@@ -55,29 +60,27 @@ export default class EditableInput extends React.Component<EditableInputProps, a
   }
 
   componentWillReceiveProps(props) {
+    let value = this.state.value;
+    let checked = this.state.checked;
     if (props.value !== this.props.value) {
-      this.setState({
-        value: props.value || ""
-      });
+      value = props.value || "";
     }
     if (props.checked !== this.props.checked) {
-      this.setState({
-        checked: props.checked || false
-      });
+      checked = props.checked || false;
     }
+    this.setState({ value, checked });
   }
 
   handleChange() {
     if (!this.props.readOnly && (!this.props.onChange || this.props.onChange() !== false)) {
+      let value = this.state.value;
+      let checked = this.state.checked;
       if (this.props.type === "checkbox") {
-        this.setState({
-          checked: !this.state.checked
-        });
+        checked = !this.state.checked;
       } else {
-        this.setState({
-          value: this.getValue()
-        });
+        value = this.getValue();
       }
+      this.setState({ value, checked });
     }
   }
 

--- a/src/components/EditableRadio.tsx
+++ b/src/components/EditableRadio.tsx
@@ -8,7 +8,11 @@ export interface EditableRadioProps extends React.HTMLProps<EditableRadio> {
   checked: boolean;
 }
 
-export default class EditableRadio extends React.Component<EditableRadioProps, any> {
+export interface EditableRadioState {
+  checked: boolean;
+}
+
+export default class EditableRadio extends React.Component<EditableRadioProps, EditableRadioState> {
   constructor(props) {
     super(props);
     this.state = {

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -154,9 +154,9 @@ function mapStateToProps(state, ownProps) {
 
 function mapDispatchToProps(dispatch, ownProps) {
   let fetcher = new DataFetcher({ adapter: editorAdapter });
-  let actions = new ActionCreator(fetcher);
+  let actions = new ActionCreator(fetcher, ownProps.csrfToken);
   return {
-    editBook: (url, data) => dispatch(actions.editBook(url, data, ownProps.csrfToken)),
+    editBook: (url, data) => dispatch(actions.editBook(url, data)),
     fetchBook: (url: string) => dispatch(actions.fetchBookAdmin(url))
   };
 }

--- a/src/components/ErrorMessage.tsx
+++ b/src/components/ErrorMessage.tsx
@@ -7,7 +7,7 @@ export interface ErrorMessageProps {
   tryAgain?: () => any;
 }
 
-export default class ErrorMessage extends React.Component<ErrorMessageProps, any> {
+export default class ErrorMessage extends React.Component<ErrorMessageProps, void> {
   render(): JSX.Element {
     let status = this.props.error.status;
 

--- a/src/components/GenreForm.tsx
+++ b/src/components/GenreForm.tsx
@@ -8,7 +8,12 @@ export interface GenreFormProps {
   disabled?: boolean;
 }
 
-export default class GenreForm extends React.Component<GenreFormProps, any> {
+export interface GenreFormState {
+  genre: string | null;
+  subgenre: string | null;
+}
+
+export default class GenreForm extends React.Component<GenreFormProps, GenreFormState> {
   constructor(props) {
     super(props);
     this.state = {
@@ -91,11 +96,11 @@ export default class GenreForm extends React.Component<GenreFormProps, any> {
   }
 
   handleGenreSelect(event) {
-    this.setState({ genre: event.target.value });
+    this.setState({ genre: event.target.value, subgenre: null });
   }
 
   handleSubgenreSelect(event) {
-    this.setState({ subgenre: event.target.value });
+    this.setState({ genre: this.state.genre, subgenre: event.target.value });
   }
 
   resetForm() {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -11,12 +11,21 @@ import { Link } from "react-router";
 import { Navbar, Nav, NavItem } from "react-bootstrap";
 import { Router } from "opds-web-client/lib/interfaces";
 
-export interface HeaderProps extends React.Props<Header> {
+export interface HeaderStateProps {
   libraries?: LibraryData[];
+}
+
+export interface HeaderDispatchProps {
   fetchLibraries?: () => Promise<LibrariesData>;
 }
 
-export class Header extends React.Component<HeaderProps, any> {
+export interface HeaderOwnProps {
+  store?: Store<State>;
+}
+
+export interface HeaderProps extends React.Props<Header>, HeaderStateProps, HeaderDispatchProps, HeaderOwnProps {}
+
+export class Header extends React.Component<HeaderProps, void> {
   context: { library: () => string, router: Router };
 
   static contextTypes = {
@@ -125,14 +134,14 @@ function mapDispatchToProps(dispatch) {
   };
 }
 
-const ConnectedHeader = connect<any, any, any>(
+const ConnectedHeader = connect<HeaderStateProps, HeaderDispatchProps, HeaderOwnProps>(
   mapStateToProps,
   mapDispatchToProps,
 )(Header);
 
 /** HeaderWithStore is a wrapper component to pass the store as a prop to the
     ConnectedHeader, since it's not in the regular place in the context. */
-export default class HeaderWithStore extends React.Component<any, any> {
+export default class HeaderWithStore extends React.Component<void, void> {
   context: { editorStore: Store<State> };
 
   static contextTypes = {

--- a/src/components/IndividualAdminEditForm.tsx
+++ b/src/components/IndividualAdminEditForm.tsx
@@ -5,7 +5,6 @@ import { IndividualAdminsData, IndividualAdminData } from "../interfaces";
 export interface IndividualAdminEditFormProps {
   data: IndividualAdminsData;
   item?: IndividualAdminData;
-  csrfToken: string;
   disabled: boolean;
   editItem: (data: FormData) => Promise<void>;
   urlBase: string;
@@ -31,11 +30,6 @@ export default class IndividualAdminEditForm extends React.Component<IndividualA
   render(): JSX.Element {
     return (
       <form ref="form" onSubmit={this.save} className="edit-form">
-        <input
-          type="hidden"
-          name="csrf_token"
-          value={this.props.csrfToken}
-          />
         <EditableInput
           elementType="input"
           type="text"

--- a/src/components/IndividualAdmins.tsx
+++ b/src/components/IndividualAdmins.tsx
@@ -22,10 +22,10 @@ function mapStateToProps(state, ownProps) {
 }
 
 function mapDispatchToProps(dispatch, ownProps) {
-  let actions = new ActionCreator();
+  let actions = new ActionCreator(null, ownProps.csrfToken);
   return {
     fetchData: () => dispatch(actions.fetchIndividualAdmins()),
-    editItem: (data: FormData) => dispatch(actions.editIndividualAdmin(data, ownProps.csrfToken))
+    editItem: (data: FormData) => dispatch(actions.editIndividualAdmin(data))
   };
 }
 

--- a/src/components/IndividualAdmins.tsx
+++ b/src/components/IndividualAdmins.tsx
@@ -1,4 +1,4 @@
-import EditableConfigList from "./EditableConfigList";
+import EditableConfigList, { EditableConfigListStateProps, EditableConfigListDispatchProps, EditableConfigListOwnProps } from "./EditableConfigList";
 import { connect } from "react-redux";
 import ActionCreator from "../actions";
 import { IndividualAdminsData, IndividualAdminData } from "../interfaces";
@@ -21,15 +21,15 @@ function mapStateToProps(state, ownProps) {
   };
 }
 
-function mapDispatchToProps(dispatch) {
+function mapDispatchToProps(dispatch, ownProps) {
   let actions = new ActionCreator();
   return {
     fetchData: () => dispatch(actions.fetchIndividualAdmins()),
-    editItem: (data: FormData) => dispatch(actions.editIndividualAdmin(data))
+    editItem: (data: FormData) => dispatch(actions.editIndividualAdmin(data, ownProps.csrfToken))
   };
 }
 
-const ConnectedIndividualAdmins = connect<any, any, any>(
+const ConnectedIndividualAdmins = connect<EditableConfigListStateProps<IndividualAdminsData>, EditableConfigListDispatchProps<IndividualAdminsData>, EditableConfigListOwnProps>(
   mapStateToProps,
   mapDispatchToProps
 )(IndividualAdmins);

--- a/src/components/Libraries.tsx
+++ b/src/components/Libraries.tsx
@@ -26,10 +26,10 @@ function mapStateToProps(state, ownProps) {
 }
 
 function mapDispatchToProps(dispatch, ownProps) {
-  let actions = new ActionCreator();
+  let actions = new ActionCreator(null, ownProps.csrfToken);
   return {
     fetchData: () => dispatch(actions.fetchLibraries()),
-    editItem: (data: FormData) => dispatch(actions.editLibrary(data, ownProps.csrfToken))
+    editItem: (data: FormData) => dispatch(actions.editLibrary(data))
   };
 }
 

--- a/src/components/Libraries.tsx
+++ b/src/components/Libraries.tsx
@@ -1,4 +1,4 @@
-import EditableConfigList from "./EditableConfigList";
+import EditableConfigList, { EditableConfigListStateProps, EditableConfigListDispatchProps, EditableConfigListOwnProps } from "./EditableConfigList";
 import { connect } from "react-redux";
 import ActionCreator from "../actions";
 import { LibrariesData, LibraryData } from "../interfaces";
@@ -25,15 +25,15 @@ function mapStateToProps(state, ownProps) {
   };
 }
 
-function mapDispatchToProps(dispatch) {
+function mapDispatchToProps(dispatch, ownProps) {
   let actions = new ActionCreator();
   return {
     fetchData: () => dispatch(actions.fetchLibraries()),
-    editItem: (data: FormData) => dispatch(actions.editLibrary(data))
+    editItem: (data: FormData) => dispatch(actions.editLibrary(data, ownProps.csrfToken))
   };
 }
 
-const ConnectedLibraries = connect<any, any, any>(
+const ConnectedLibraries = connect<EditableConfigListStateProps<LibrariesData>, EditableConfigListDispatchProps<LibrariesData>, EditableConfigListOwnProps>(
   mapStateToProps,
   mapDispatchToProps
 )(Libraries);

--- a/src/components/LibraryEditForm.tsx
+++ b/src/components/LibraryEditForm.tsx
@@ -6,7 +6,6 @@ import { LibrariesData, LibraryData } from "../interfaces";
 export interface LibraryEditFormProps {
   data: LibrariesData;
   item?: LibraryData;
-  csrfToken: string;
   disabled: boolean;
   editItem: (data: FormData) => Promise<void>;
   urlBase: string;
@@ -17,11 +16,6 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
   render(): JSX.Element {
     return (
       <form ref="form" onSubmit={this.save.bind(this)} className="edit-form">
-        <input
-          type="hidden"
-          name="csrf_token"
-          value={this.props.csrfToken}
-          />
         <input
           type="hidden"
           name="uuid"

--- a/src/components/MetadataServices.tsx
+++ b/src/components/MetadataServices.tsx
@@ -35,10 +35,10 @@ function mapStateToProps(state, ownProps) {
 }
 
 function mapDispatchToProps(dispatch, ownProps) {
-  let actions = new ActionCreator();
+  let actions = new ActionCreator(null, ownProps.csrfToken);
   return {
     fetchData: () => dispatch(actions.fetchMetadataServices()),
-    editItem: (data: FormData) => dispatch(actions.editMetadataService(data, ownProps.csrfToken))
+    editItem: (data: FormData) => dispatch(actions.editMetadataService(data))
   };
 }
 

--- a/src/components/MetadataServices.tsx
+++ b/src/components/MetadataServices.tsx
@@ -1,4 +1,4 @@
-import EditableConfigList from "./EditableConfigList";
+import EditableConfigList, { EditableConfigListStateProps, EditableConfigListDispatchProps, EditableConfigListOwnProps } from "./EditableConfigList";
 import { connect } from "react-redux";
 import ActionCreator from "../actions";
 import { MetadataServicesData, MetadataServiceData } from "../interfaces";
@@ -34,15 +34,15 @@ function mapStateToProps(state, ownProps) {
   };
 }
 
-function mapDispatchToProps(dispatch) {
+function mapDispatchToProps(dispatch, ownProps) {
   let actions = new ActionCreator();
   return {
     fetchData: () => dispatch(actions.fetchMetadataServices()),
-    editItem: (data: FormData) => dispatch(actions.editMetadataService(data))
+    editItem: (data: FormData) => dispatch(actions.editMetadataService(data, ownProps.csrfToken))
   };
 }
 
-const ConnectedMetadataServices = connect<any, any, any>(
+const ConnectedMetadataServices = connect<EditableConfigListStateProps<MetadataServicesData>, EditableConfigListDispatchProps<MetadataServicesData>, EditableConfigListOwnProps>(
   mapStateToProps,
   mapDispatchToProps
 )(MetadataServices);

--- a/src/components/PatronAuthServices.tsx
+++ b/src/components/PatronAuthServices.tsx
@@ -35,10 +35,10 @@ function mapStateToProps(state, ownProps) {
 }
 
 function mapDispatchToProps(dispatch, ownProps) {
-  let actions = new ActionCreator();
+  let actions = new ActionCreator(null, ownProps.csrfToken);
   return {
     fetchData: () => dispatch(actions.fetchPatronAuthServices()),
-    editItem: (data: FormData) => dispatch(actions.editPatronAuthService(data, ownProps.csrfToken))
+    editItem: (data: FormData) => dispatch(actions.editPatronAuthService(data))
   };
 }
 

--- a/src/components/PatronAuthServices.tsx
+++ b/src/components/PatronAuthServices.tsx
@@ -1,4 +1,4 @@
-import EditableConfigList from "./EditableConfigList";
+import EditableConfigList, { EditableConfigListStateProps, EditableConfigListDispatchProps, EditableConfigListOwnProps } from "./EditableConfigList";
 import { connect } from "react-redux";
 import ActionCreator from "../actions";
 import { PatronAuthServicesData, PatronAuthServiceData } from "../interfaces";
@@ -34,15 +34,15 @@ function mapStateToProps(state, ownProps) {
   };
 }
 
-function mapDispatchToProps(dispatch) {
+function mapDispatchToProps(dispatch, ownProps) {
   let actions = new ActionCreator();
   return {
     fetchData: () => dispatch(actions.fetchPatronAuthServices()),
-    editItem: (data: FormData) => dispatch(actions.editPatronAuthService(data))
+    editItem: (data: FormData) => dispatch(actions.editPatronAuthService(data, ownProps.csrfToken))
   };
 }
 
-const ConnectedPatronAuthServices = connect<any, any, any>(
+const ConnectedPatronAuthServices = connect<EditableConfigListStateProps<PatronAuthServicesData>, EditableConfigListDispatchProps<PatronAuthServicesData>, EditableConfigListOwnProps>(
   mapStateToProps,
   mapDispatchToProps
 )(PatronAuthServices);

--- a/src/components/SearchServices.tsx
+++ b/src/components/SearchServices.tsx
@@ -24,10 +24,10 @@ function mapStateToProps(state, ownProps) {
 }
 
 function mapDispatchToProps(dispatch, ownProps) {
-  let actions = new ActionCreator();
+  let actions = new ActionCreator(null, ownProps.csrfToken);
   return {
     fetchData: () => dispatch(actions.fetchSearchServices()),
-    editItem: (data: FormData) => dispatch(actions.editSearchService(data, ownProps.csrfToken))
+    editItem: (data: FormData) => dispatch(actions.editSearchService(data))
   };
 }
 

--- a/src/components/SearchServices.tsx
+++ b/src/components/SearchServices.tsx
@@ -1,4 +1,4 @@
-import EditableConfigList from "./EditableConfigList";
+import EditableConfigList, { EditableConfigListStateProps, EditableConfigListDispatchProps, EditableConfigListOwnProps } from "./EditableConfigList";
 import { connect } from "react-redux";
 import ActionCreator from "../actions";
 import { SearchServicesData, SearchServiceData } from "../interfaces";
@@ -23,15 +23,15 @@ function mapStateToProps(state, ownProps) {
   };
 }
 
-function mapDispatchToProps(dispatch) {
+function mapDispatchToProps(dispatch, ownProps) {
   let actions = new ActionCreator();
   return {
     fetchData: () => dispatch(actions.fetchSearchServices()),
-    editItem: (data: FormData) => dispatch(actions.editSearchService(data))
+    editItem: (data: FormData) => dispatch(actions.editSearchService(data, ownProps.csrfToken))
   };
 }
 
-const ConnectedSearchServices = connect<any, any, any>(
+const ConnectedSearchServices = connect<EditableConfigListStateProps<SearchServicesData>, EditableConfigListDispatchProps<SearchServicesData>, EditableConfigListOwnProps>(
   mapStateToProps,
   mapDispatchToProps
 )(SearchServices);

--- a/src/components/ServiceEditForm.tsx
+++ b/src/components/ServiceEditForm.tsx
@@ -9,7 +9,6 @@ import { EditFormProps } from "./EditableConfigList";
 export interface ServiceEditFormProps<T> {
   data: T;
   item?: ServiceData;
-  csrfToken: string;
   disabled: boolean;
   editItem: (data: FormData) => Promise<void>;
   urlBase: string;
@@ -51,11 +50,6 @@ export default class ServiceEditForm<T extends ServicesData> extends React.Compo
   render(): JSX.Element {
     return (
       <form ref="form" onSubmit={this.save} className="edit-form">
-        <input
-          type="hidden"
-          name="csrf_token"
-          value={this.props.csrfToken}
-          />
         { this.props.item && this.props.item.id &&
           <input
             type="hidden"
@@ -418,7 +412,7 @@ export default class ServiceEditForm<T extends ServicesData> extends React.Compo
       (this.refs[setting.key] as any).clear();
     }
     const libraries = this.state.libraries.concat(newLibrary);
-    const newState = Object.assign({}, this.state, { libraries });
+    const newState = Object.assign({}, this.state, { libraries, selectedLibrary: null });
     this.setState(newState);
   }
 

--- a/src/components/SitewideSettingEditForm.tsx
+++ b/src/components/SitewideSettingEditForm.tsx
@@ -5,7 +5,6 @@ import { SitewideSettingsData, SitewideSettingData } from "../interfaces";
 export interface SitewideSettingEditFormProps {
   data: SitewideSettingsData;
   item?: SitewideSettingData;
-  csrfToken: string;
   disabled: boolean;
   editItem: (data: FormData) => Promise<void>;
   urlBase: string;
@@ -23,11 +22,6 @@ export default class SitewideSettingEditForm extends React.Component<SitewideSet
       <div>
         { this.availableSettings().length > 0 &&
           <form ref="form" onSubmit={this.save} className="edit-form">
-            <input
-              type="hidden"
-              name="csrf_token"
-              value={this.props.csrfToken}
-              />
             <EditableInput
               elementType="select"
               disabled={this.props.disabled}

--- a/src/components/SitewideSettings.tsx
+++ b/src/components/SitewideSettings.tsx
@@ -31,10 +31,10 @@ function mapStateToProps(state, ownProps) {
 }
 
 function mapDispatchToProps(dispatch, ownProps) {
-  let actions = new ActionCreator();
+  let actions = new ActionCreator(null, ownProps.csrfToken);
   return {
     fetchData: () => dispatch(actions.fetchSitewideSettings()),
-    editItem: (data: FormData) => dispatch(actions.editSitewideSetting(data, ownProps.csrfToken))
+    editItem: (data: FormData) => dispatch(actions.editSitewideSetting(data))
   };
 }
 

--- a/src/components/SitewideSettings.tsx
+++ b/src/components/SitewideSettings.tsx
@@ -1,4 +1,4 @@
-import EditableConfigList from "./EditableConfigList";
+import EditableConfigList, { EditableConfigListStateProps, EditableConfigListDispatchProps, EditableConfigListOwnProps } from "./EditableConfigList";
 import { connect } from "react-redux";
 import ActionCreator from "../actions";
 import { SitewideSettingsData, SitewideSettingData } from "../interfaces";
@@ -30,15 +30,15 @@ function mapStateToProps(state, ownProps) {
   };
 }
 
-function mapDispatchToProps(dispatch) {
+function mapDispatchToProps(dispatch, ownProps) {
   let actions = new ActionCreator();
   return {
     fetchData: () => dispatch(actions.fetchSitewideSettings()),
-    editItem: (data: FormData) => dispatch(actions.editSitewideSetting(data))
+    editItem: (data: FormData) => dispatch(actions.editSitewideSetting(data, ownProps.csrfToken))
   };
 }
 
-const ConnectedSitewideSettings = connect<any, any, any>(
+const ConnectedSitewideSettings = connect<EditableConfigListStateProps<SitewideSettingsData>, EditableConfigListDispatchProps<SitewideSettingsData>, EditableConfigListOwnProps>(
   mapStateToProps,
   mapDispatchToProps
 )(SitewideSettings);

--- a/src/components/Stats.tsx
+++ b/src/components/Stats.tsx
@@ -8,15 +8,23 @@ import { State } from "../reducers/index";
 import LoadingIndicator from "opds-web-client/lib/components/LoadingIndicator";
 import ErrorMessage from "./ErrorMessage";
 
-export interface StatsProps {
-  store?: Store<State>;
+export interface StatsStateProps {
   stats?: StatsData;
   fetchError?: FetchErrorData;
-  fetchStats?: () => Promise<any>;
   isLoaded?: boolean;
 }
 
-export class Stats extends React.Component<StatsProps, any> {
+export interface StatsDispatchProps {
+  fetchStats?: () => Promise<any>;
+}
+
+export interface StatsOwnProps {
+  store?: Store<State>;
+}
+
+export interface StatsProps extends StatsStateProps, StatsDispatchProps, StatsOwnProps {}
+
+export class Stats extends React.Component<StatsProps, void> {
 
   render(): JSX.Element {
     let patronCounts = [
@@ -123,7 +131,7 @@ function mapDispatchToProps(dispatch) {
   };
 }
 
-const ConnectedStats = connect<any, any, any>(
+const ConnectedStats = connect<StatsStateProps, StatsDispatchProps, StatsOwnProps>(
   mapStateToProps,
   mapDispatchToProps
 )(Stats);

--- a/src/components/__tests__/BookEditForm-test.tsx
+++ b/src/components/__tests__/BookEditForm-test.tsx
@@ -38,7 +38,6 @@ describe("BookEditForm", () => {
       wrapper = shallow(
         <BookEditForm
           {...bookData}
-          csrfToken=""
           disabled={false}
           refresh={stub()}
           editBook={stub()}
@@ -102,7 +101,6 @@ describe("BookEditForm", () => {
     let wrapper = mount(
       <BookEditForm
         {...bookData}
-        csrfToken="token"
         disabled={false}
         refresh={stub()}
         editBook={editBook}
@@ -115,7 +113,6 @@ describe("BookEditForm", () => {
 
     expect(editBook.callCount).to.equal(1);
     expect(editBook.args[0][0]).to.equal("href");
-    expect(editBook.args[0][1].get("csrf_token").value).to.equal("token");
     expect(editBook.args[0][1].get("title").value).to.equal(bookData.title);
     expect(editBook.args[0][1].get("subtitle").value).to.equal(bookData.subtitle);
     expect(editBook.args[0][1].get("series").value).to.equal(bookData.series);
@@ -130,7 +127,6 @@ describe("BookEditForm", () => {
     let wrapper = mount(
       <BookEditForm
         {...bookData}
-        csrfToken=""
         disabled={false}
         refresh={done}
         editBook={editBook}
@@ -145,7 +141,6 @@ describe("BookEditForm", () => {
     let wrapper = shallow(
       <BookEditForm
         {...bookData}
-        csrfToken=""
         disabled={true}
         refresh={stub()}
         editBook={stub()}

--- a/src/components/__tests__/Classifications-test.tsx
+++ b/src/components/__tests__/Classifications-test.tsx
@@ -79,7 +79,6 @@ describe("Classifications", () => {
       let form = wrapper.find(ClassificationsForm);
       expect(form.props().book).to.equal(bookData);
       expect(form.props().genreTree).to.equal(genreData);
-      expect(form.props().csrfToken).to.equal("token");
       expect(form.props().editClassifications).to.equal(instance.editClassifications);
     });
 

--- a/src/components/__tests__/ClassificationsForm-test.tsx
+++ b/src/components/__tests__/ClassificationsForm-test.tsx
@@ -41,7 +41,6 @@ describe("ClassificationsForm", () => {
         <ClassificationsForm
           book={bookData}
           genreTree={genreData}
-          csrfToken="token"
           editClassifications={editClassifications}
           />
       );
@@ -132,7 +131,6 @@ describe("ClassificationsForm", () => {
         <ClassificationsForm
           book={bookData}
           genreTree={genreData}
-          csrfToken="token"
           editClassifications={editClassifications}
           />
       );

--- a/src/components/__tests__/CustomListEditor-test.tsx
+++ b/src/components/__tests__/CustomListEditor-test.tsx
@@ -38,7 +38,6 @@ describe("CustomListEditor", () => {
     loadMoreSearchResults = stub();
     wrapper = shallow(
       <CustomListEditor
-        csrfToken="token"
         library="library"
         list={listData}
         searchResults={searchResults}
@@ -75,7 +74,6 @@ describe("CustomListEditor", () => {
   it("saves list", () => {
     wrapper = mount(
       <CustomListEditor
-        csrfToken="token"
         library="library"
         list={listData}
         searchResults={searchResults}
@@ -110,7 +108,6 @@ describe("CustomListEditor", () => {
 
     wrapper = mount(
       <CustomListEditor
-        csrfToken="token"
         library="library"
         searchResults={searchResults}
         editCustomList={editCustomList}
@@ -147,7 +144,6 @@ describe("CustomListEditor", () => {
 
     wrapper = mount(
       <CustomListEditor
-        csrfToken="token"
         library="library"
         list={listData}
         searchResults={searchResults}
@@ -176,7 +172,6 @@ describe("CustomListEditor", () => {
 
     wrapper = mount(
       <CustomListEditor
-        csrfToken="token"
         library="library"
         list={listData}
         searchResults={searchResults}
@@ -206,7 +201,6 @@ describe("CustomListEditor", () => {
   it("searches", () => {
     wrapper = mount(
       <CustomListEditor
-        csrfToken="token"
         library="library"
         list={listData}
         searchResults={searchResults}

--- a/src/components/__tests__/CustomLists-test.tsx
+++ b/src/components/__tests__/CustomLists-test.tsx
@@ -238,9 +238,7 @@ describe("CustomLists", () => {
     deleteButton.simulate("click");
 
     expect(deleteCustomList.callCount).to.equal(1);
-    expect(deleteCustomList.args[0][0]).to.equal("library");
-    expect(deleteCustomList.args[0][1]).to.equal("1");
-    expect(deleteCustomList.args[0][2]).to.equal("token");
+    expect(deleteCustomList.args[0][0]).to.equal("1");
 
     confirmStub.restore();
   });
@@ -249,9 +247,7 @@ describe("CustomLists", () => {
     const testData = new (window as any).FormData();
     (wrapper.instance() as CustomLists).editCustomList(testData);
     expect(editCustomList.callCount).to.equal(1);
-    expect(editCustomList.args[0][0]).to.equal("library");
-    expect(editCustomList.args[0][1]).to.equal(testData);
-    expect(editCustomList.args[0][2]).to.equal("token");
+    expect(editCustomList.args[0][0]).to.equal(testData);
   });
 
   it("renders create form", async () => {
@@ -261,7 +257,6 @@ describe("CustomLists", () => {
     wrapper.setProps({ editOrCreate: "create" });
     editor = wrapper.find(CustomListEditor);
     expect(editor.length).to.equal(1);
-    expect(editor.props().csrfToken).to.equal("token");
     expect(editor.props().library).to.equal("library");
     expect(editor.props().search).to.equal(search);
     expect(editor.props().loadMoreSearchResults).to.equal(loadMoreSearchResults);
@@ -273,9 +268,7 @@ describe("CustomLists", () => {
     let editCustomListProp = editor.props().editCustomList;
     await editCustomListProp();
     expect(editCustomList.callCount).to.equal(1);
-    expect(editCustomList.args[0][0]).to.equal("library");
     expect(fetchCustomLists.callCount).to.equal(2);
-    expect(fetchCustomLists.args[1][0]).to.equal("library");
 
     wrapper.setProps({ editedIdentifier: "5" });
     editor = wrapper.find(CustomListEditor);
@@ -290,7 +283,6 @@ describe("CustomLists", () => {
     editor = wrapper.find(CustomListEditor);
     expect(editor.length).to.equal(1);
     expect(editor.props().list).to.deep.equal(listsData[1]);
-    expect(editor.props().csrfToken).to.equal("token");
     expect(editor.props().library).to.equal("library");
     expect(editor.props().search).to.equal(search);
     expect(editor.props().loadMoreSearchResults).to.equal(loadMoreSearchResults);

--- a/src/components/__tests__/DiscoveryServiceEditForm-test.tsx
+++ b/src/components/__tests__/DiscoveryServiceEditForm-test.tsx
@@ -45,7 +45,6 @@ describe("DiscoveryServiceEditForm", () => {
       registerLibrary = stub();
       wrapper = shallow(
         <DiscoveryServiceEditForm
-          csrfToken="token"
           disabled={false}
           data={servicesData}
           editItem={editService}
@@ -80,7 +79,6 @@ describe("DiscoveryServiceEditForm", () => {
       registerLibrary = stub();
       wrapper = shallow(
         <DiscoveryServiceEditForm
-          csrfToken="token"
           disabled={false}
           data={servicesData}
           item={serviceData}

--- a/src/components/__tests__/DiscoveryServices-test.tsx
+++ b/src/components/__tests__/DiscoveryServices-test.tsx
@@ -35,7 +35,6 @@ describe("DiscoveryServices", () => {
 
     expect(registerLibrary.callCount).to.equal(1);
     const formData = registerLibrary.args[0][0];
-    expect(formData.get("csrf_token")).to.equal("token");
     expect(formData.get("library_short_name")).to.equal("nypl");
     expect(formData.get("integration_id")).to.equal("2");
 

--- a/src/components/__tests__/EditableConfigList-test.tsx
+++ b/src/components/__tests__/EditableConfigList-test.tsx
@@ -136,7 +136,6 @@ describe("EditableConfigList", () => {
     expect(form.length).to.equal(1);
     expect(form.props().data).to.deep.equal(thingsData);
     expect(form.props().item).to.be.undefined;
-    expect(form.props().csrfToken).to.equal("token");
     expect(form.props().disabled).to.equal(false);
     expect(form.props().listDataKey).to.equal("things");
   });
@@ -147,7 +146,6 @@ describe("EditableConfigList", () => {
     expect(form.length).to.equal(1);
     expect(form.props().data).to.deep.equal(thingsData);
     expect(form.props().item).to.equal(thingData);
-    expect(form.props().csrfToken).to.equal("token");
     expect(form.props().disabled).to.equal(false);
     expect(form.props().listDataKey).to.equal("things");
   });

--- a/src/components/__tests__/IndividualAdminEditForm-test.tsx
+++ b/src/components/__tests__/IndividualAdminEditForm-test.tsx
@@ -29,18 +29,12 @@ describe("IndividualAdminEditForm", () => {
       wrapper = shallow(
         <IndividualAdminEditForm
           data={{ individualAdmins: [adminData] }}
-          csrfToken="token"
           disabled={false}
           editItem={editIndividualAdmin}
           urlBase="url base"
           listDataKey="admins"
           />
       );
-    });
-
-    it("renders hidden csrf token", () => {
-      let input = wrapper.find("input[name=\"csrf_token\"]");
-      expect(input.props().value).to.equal("token");
     });
 
     it("renders email", () => {
@@ -69,7 +63,6 @@ describe("IndividualAdminEditForm", () => {
       wrapper = mount(
         <IndividualAdminEditForm
           data={{ individualAdmins: [adminData] }}
-          csrfToken="token"
           disabled={false}
           editItem={editIndividualAdmin}
           urlBase="url base"
@@ -90,7 +83,6 @@ describe("IndividualAdminEditForm", () => {
 
       expect(editIndividualAdmin.callCount).to.equal(1);
       let formData = editIndividualAdmin.args[0][0];
-      expect(formData.get("csrf_token")).to.equal("token");
       expect(formData.get("email")).to.equal("test@nypl.org");
       expect(formData.get("password")).to.equal("newPassword");
     });

--- a/src/components/__tests__/LibraryEditForm-test.tsx
+++ b/src/components/__tests__/LibraryEditForm-test.tsx
@@ -47,18 +47,12 @@ describe("LibraryEditForm", () => {
       wrapper = shallow(
         <LibraryEditForm
           data={{ libraries: [libraryData], settings: settingFields }}
-          csrfToken="token"
           disabled={false}
           editItem={editLibrary}
           urlBase="url base"
           listDataKey="libraries"
           />
       );
-    });
-
-    it("renders hidden csrf token", () => {
-      let input = wrapper.find("input[name=\"csrf_token\"]");
-      expect(input.props().value).to.equal("token");
     });
 
     it("renders hidden uuid", () => {
@@ -110,7 +104,6 @@ describe("LibraryEditForm", () => {
       wrapper = mount(
         <LibraryEditForm
           data={{ libraries: [libraryData], settings: settingFields }}
-          csrfToken="token"
           disabled={false}
           editItem={editLibrary}
           urlBase="url base"
@@ -127,7 +120,6 @@ describe("LibraryEditForm", () => {
 
       expect(editLibrary.callCount).to.equal(1);
       let formData = editLibrary.args[0][0];
-      expect(formData.get("csrf_token")).to.equal("token");
       expect(formData.get("uuid")).to.equal("uuid");
       expect(formData.get("name")).to.equal("name");
       expect(formData.get("short_name")).to.equal("short_name");

--- a/src/components/__tests__/ServiceEditForm-test.tsx
+++ b/src/components/__tests__/ServiceEditForm-test.tsx
@@ -110,7 +110,6 @@ describe("ServiceEditForm", () => {
 
       wrapper = shallow(
         <TestServiceEditForm
-          csrfToken="token"
           disabled={false}
           data={servicesData}
           editItem={editService}
@@ -118,11 +117,6 @@ describe("ServiceEditForm", () => {
           listDataKey="services"
           />
       );
-    });
-
-    it("renders hidden csrf token", () => {
-      let input = wrapper.find("input[name=\"csrf_token\"]");
-      expect(input.props().value).to.equal("token");
     });
 
     it("renders hidden id", () => {
@@ -148,7 +142,6 @@ describe("ServiceEditForm", () => {
 
       wrapper = shallow(
         <TestServiceEditForm
-          csrfToken="token"
           disabled={false}
           data={servicesData}
           editItem={editService}
@@ -180,7 +173,6 @@ describe("ServiceEditForm", () => {
 
       wrapper = shallow(
         <TestServiceEditForm
-          csrfToken="token"
           disabled={false}
           data={servicesData}
           editItem={editService}
@@ -210,7 +202,6 @@ describe("ServiceEditForm", () => {
       const newService = Object.assign({}, serviceData, { protocol: "protocol 3" });
       wrapper = shallow(
         <TestServiceEditForm
-          csrfToken="token"
           disabled={false}
           data={servicesData}
           item={newService}
@@ -230,7 +221,6 @@ describe("ServiceEditForm", () => {
       let servicesDataWithParent = Object.assign({}, servicesData, { services: [parentService, childService] });
       wrapper = shallow(
         <TestServiceEditForm
-          csrfToken="token"
           disabled={false}
           data={servicesDataWithParent}
           item={childService}
@@ -251,7 +241,6 @@ describe("ServiceEditForm", () => {
       childService.parent_id = parentService.id;
       wrapper = shallow(
         <TestServiceEditForm
-          csrfToken="token"
           disabled={false}
           data={servicesDataWithParent}
           item={childService}
@@ -275,7 +264,6 @@ describe("ServiceEditForm", () => {
       let servicesDataWithParent = Object.assign({}, servicesData, { services: [parentService, childService] });
       wrapper = shallow(
         <TestServiceEditForm
-          csrfToken="token"
           disabled={false}
           data={servicesDataWithParent}
           item={childService}
@@ -301,7 +289,6 @@ describe("ServiceEditForm", () => {
       childService.parent_id = parentService.id;
       wrapper = shallow(
         <TestServiceEditForm
-          csrfToken="token"
           disabled={false}
           data={servicesDataWithParent}
           item={childService}
@@ -332,7 +319,6 @@ describe("ServiceEditForm", () => {
 
       wrapper = shallow(
         <TestServiceEditForm
-          csrfToken="token"
           disabled={false}
           data={servicesDataSitewide}
           editItem={editService}
@@ -348,7 +334,6 @@ describe("ServiceEditForm", () => {
       });
       wrapper = shallow(
         <TestServiceEditForm
-          csrfToken="token"
           disabled={false}
           data={servicesDataSitewide}
           editItem={editService}
@@ -367,7 +352,6 @@ describe("ServiceEditForm", () => {
 
       wrapper = mount(
         <TestServiceEditForm
-          csrfToken="token"
           disabled={false}
           data={servicesData}
           editItem={editService}
@@ -391,7 +375,6 @@ describe("ServiceEditForm", () => {
 
       wrapper = shallow(
         <TestServiceEditForm
-          csrfToken="token"
           disabled={false}
           data={servicesData}
           editItem={editService}
@@ -412,7 +395,6 @@ describe("ServiceEditForm", () => {
 
       wrapper = shallow(
         <TestServiceEditForm
-          csrfToken="token"
           disabled={false}
           data={servicesDataSitewide}
           editItem={editService}
@@ -428,7 +410,6 @@ describe("ServiceEditForm", () => {
       });
       wrapper = shallow(
         <TestServiceEditForm
-          csrfToken="token"
           disabled={false}
           data={servicesDataSitewide}
           editItem={editService}
@@ -458,7 +439,6 @@ describe("ServiceEditForm", () => {
 
       wrapper = shallow(
         <TestServiceEditForm
-          csrfToken="token"
           disabled={false}
           data={servicesData}
           editItem={editService}
@@ -482,7 +462,6 @@ describe("ServiceEditForm", () => {
       editService = stub().returns(new Promise<void>(resolve => resolve()));
       wrapper = mount(
         <TestServiceEditForm
-          csrfToken="token"
           disabled={false}
           data={servicesData}
           editItem={editService}
@@ -554,7 +533,6 @@ describe("ServiceEditForm", () => {
       let servicesDataWithParent = Object.assign({}, servicesData, { services: [parentService], protocols: [parentProtocol] });
       wrapper = mount(
         <TestServiceEditForm
-          csrfToken="token"
           disabled={false}
           data={servicesDataWithParent}
           editItem={editService}
@@ -653,7 +631,6 @@ describe("ServiceEditForm", () => {
     it("removes a library", () => {
       wrapper = mount(
         <TestServiceEditForm
-          csrfToken="token"
           disabled={false}
           data={servicesData}
           editItem={editService}
@@ -676,7 +653,6 @@ describe("ServiceEditForm", () => {
     it("edits a library", () => {
       wrapper = mount(
         <TestServiceEditForm
-          csrfToken="token"
           disabled={false}
           data={servicesData}
           editItem={editService}
@@ -741,7 +717,6 @@ describe("ServiceEditForm", () => {
 
       expect(editService.callCount).to.equal(1);
       let formData = editService.args[0][0];
-      expect(formData.get("csrf_token")).to.equal("token");
       expect(formData.get("id")).to.equal("2");
       expect(formData.get("protocol")).to.equal("protocol 1");
       expect(formData.get("text_setting")).to.equal("text setting");

--- a/src/components/__tests__/SitewideSettingEditForm-test.tsx
+++ b/src/components/__tests__/SitewideSettingEditForm-test.tsx
@@ -38,7 +38,6 @@ describe("SitewideSettingEditForm", () => {
       wrapper = shallow(
         <SitewideSettingEditForm
           data={settingsData}
-          csrfToken="token"
           disabled={false}
           editItem={editSitewideSetting}
           urlBase="url base"
@@ -55,7 +54,6 @@ describe("SitewideSettingEditForm", () => {
       wrapper = shallow(
         <SitewideSettingEditForm
           data={data}
-          csrfToken="token"
           disabled={false}
           editItem={editSitewideSetting}
           urlBase="url base"
@@ -67,11 +65,6 @@ describe("SitewideSettingEditForm", () => {
 
       let input = wrapper.find("input[name=\"csrf_token\"]");
       expect(input.length).to.equal(0);
-    });
-
-    it("renders hidden csrf token", () => {
-      let input = wrapper.find("input[name=\"csrf_token\"]");
-      expect(input.props().value).to.equal("token");
     });
 
     it("renders key", () => {
@@ -107,7 +100,6 @@ describe("SitewideSettingEditForm", () => {
       wrapper = mount(
         <SitewideSettingEditForm
           data={settingsData}
-          csrfToken="token"
           disabled={false}
           editItem={editSitewideSetting}
           urlBase="url base"
@@ -124,7 +116,6 @@ describe("SitewideSettingEditForm", () => {
 
       expect(editSitewideSetting.callCount).to.equal(1);
       let formData = editSitewideSetting.args[0][0];
-      expect(formData.get("csrf_token")).to.equal("token");
       expect(formData.get("key")).to.equal("test_key");
       expect(formData.get("value")).to.equal("value");
     });


### PR DESCRIPTION
The goal of this branch was to make the CSRF token handling consistent across requests - all requests will use the "X-CSRF-Token" header instead of putting the token in form data.

The CSRF token now has to be an argument to all the actions, but it no longer needs to be passed down through as many of the components.

As part of this I also cleaned up some missing types that were previously `any`, mostly those used with Redux's `connect` function. This lets Typescript ensure I didn't mess up the arguments in all the `mapDispatchToProps` functions, which don't have their own tests and are now responsible for putting CSRF tokens in the action calls.