### PR TITLE
Go to the edit page for a config item after creating it.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.0.46",
+  "version": "0.0.47",
   "description": "Web Front-end for Library Simplified Circulation Manager",
   "repository": {
     "type": "git",

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -128,9 +128,11 @@ export default class ActionCreator extends BaseActionCreator {
             if (response.text) {
               response.text().then(text => {
                 dispatch(this.load<string>(type, text));
+                resolve(response);
               });
+            } else {
+              resolve(response);
             }
-            resolve(response);
           } else {
             response.json().then(data => {
               err = {

--- a/src/components/AdminAuthServices.tsx
+++ b/src/components/AdminAuthServices.tsx
@@ -17,6 +17,7 @@ export class AdminAuthServices extends EditableConfigList<AdminAuthServicesData,
 function mapStateToProps(state, ownProps) {
   return {
     data: state.editor.adminAuthServices && state.editor.adminAuthServices.data,
+    editedIdentifier: state.editor.adminAuthServices && state.editor.adminAuthServices.editedIdentifier,
     fetchError: state.editor.adminAuthServices.fetchError,
     isFetching: state.editor.adminAuthServices.isFetching || state.editor.adminAuthServices.isEditing
   };

--- a/src/components/AnalyticsServices.tsx
+++ b/src/components/AnalyticsServices.tsx
@@ -29,6 +29,7 @@ function mapStateToProps(state, ownProps) {
   }
   return {
     data: data,
+    editedIdentifier: state.editor.analyticsServices && state.editor.analyticsServices.editedIdentifier,
     fetchError: state.editor.analyticsServices.fetchError,
     isFetching: state.editor.analyticsServices.isFetching || state.editor.analyticsServices.isEditing
   };

--- a/src/components/CDNServices.tsx
+++ b/src/components/CDNServices.tsx
@@ -21,6 +21,7 @@ function mapStateToProps(state, ownProps) {
   const data = Object.assign({}, state.editor.cdnServices && state.editor.cdnServices.data || {});
   return {
     data: data,
+    editedIdentifier: state.editor.cdnServices && state.editor.cdnServices.editedIdentifier,
     fetchError: state.editor.cdnServices.fetchError,
     isFetching: state.editor.cdnServices.isFetching || state.editor.cdnServices.isEditing
   };

--- a/src/components/Collections.tsx
+++ b/src/components/Collections.tsx
@@ -20,6 +20,7 @@ function mapStateToProps(state, ownProps) {
   }
   return {
     data: data,
+    editedIdentifier: state.editor.collections && state.editor.collections.editedIdentifier,
     fetchError: state.editor.collections.fetchError,
     isFetching: state.editor.collections.isFetching || state.editor.collections.isEditing
   };

--- a/src/components/DiscoveryServices.tsx
+++ b/src/components/DiscoveryServices.tsx
@@ -64,6 +64,7 @@ function mapStateToProps(state, ownProps) {
   }
   return {
     data: data,
+    editedIdentifier: state.editor.discoveryServices && state.editor.discoveryServices.editedIdentifier,
     fetchError: state.editor.discoveryServices.fetchError || (state.editor.registerLibrary && state.editor.registerLibrary.fetchError),
     isFetching: state.editor.discoveryServices.isFetching || state.editor.discoveryServices.isEditing || (state.editor.registerLibrary && state.editor.registerLibrary.isFetching),
     isFetchingLibraryRegistrations: state.editor.libraryRegistrations && state.editor.libraryRegistrations.isFetching

--- a/src/components/EditableConfigList.tsx
+++ b/src/components/EditableConfigList.tsx
@@ -9,6 +9,7 @@ export interface EditableConfigListStateProps<T> {
   data?: T;
   fetchError?: FetchErrorData;
   isFetching?: boolean;
+  editedIdentifier?: string;
 }
 
 export interface EditableConfigListDispatchProps<T> {
@@ -32,6 +33,7 @@ export interface EditFormProps<T, U> {
   editItem: (data: FormData) => Promise<void>;
   urlBase: string;
   listDataKey: string;
+  editedIdentifier?: string;
 }
 
 export abstract class GenericEditableConfigList<T, U, V extends EditableConfigListProps<T>> extends React.Component<V, void> {
@@ -91,6 +93,7 @@ export abstract class GenericEditableConfigList<T, U, V extends EditableConfigLi
               editItem={this.editItem}
               urlBase={this.urlBase}
               listDataKey={this.listDataKey}
+              editedIdentifier={this.props.editedIdentifier}
               />
           </div>
         }
@@ -105,6 +108,7 @@ export abstract class GenericEditableConfigList<T, U, V extends EditableConfigLi
               editItem={this.editItem}
               urlBase={this.urlBase}
               listDataKey={this.listDataKey}
+              editedIdentifier={this.props.editedIdentifier}
               />
           </div>
         }

--- a/src/components/IndividualAdminEditForm.tsx
+++ b/src/components/IndividualAdminEditForm.tsx
@@ -9,6 +9,7 @@ export interface IndividualAdminEditFormProps {
   editItem: (data: FormData) => Promise<void>;
   urlBase: string;
   listDataKey: string;
+  editedIdentifier?: string;
 }
 
 export interface IndividualAdminEditFormContext {
@@ -67,8 +68,8 @@ export default class IndividualAdminEditForm extends React.Component<IndividualA
       }
 
       // If a new admin was created, go to its edit page.
-      if (!this.props.item && data.get("email")) {
-        window.location.href = "/admin/web/config/individualAdmins/edit/" + data.get("email");
+      if (!this.props.item && this.props.editedIdentifier) {
+        window.location.href = this.props.urlBase + "edit/" + this.props.editedIdentifier;
       }
     });
   }

--- a/src/components/IndividualAdmins.tsx
+++ b/src/components/IndividualAdmins.tsx
@@ -16,6 +16,7 @@ export class IndividualAdmins extends EditableConfigList<IndividualAdminsData, I
 function mapStateToProps(state, ownProps) {
   return {
     data: state.editor.individualAdmins && state.editor.individualAdmins.data,
+    editedIdentifier: state.editor.individualAdmins && state.editor.individualAdmins.editedIdentifier,
     fetchError: state.editor.individualAdmins.fetchError,
     isFetching: state.editor.individualAdmins.isFetching || state.editor.individualAdmins.isEditing
   };

--- a/src/components/Libraries.tsx
+++ b/src/components/Libraries.tsx
@@ -20,6 +20,7 @@ export class Libraries extends EditableConfigList<LibrariesData, LibraryData> {
 function mapStateToProps(state, ownProps) {
   return {
     data: state.editor.libraries && state.editor.libraries.data,
+    editedIdentifier: state.editor.libraries && state.editor.libraries.editedIdentifier,
     fetchError: state.editor.libraries.fetchError,
     isFetching: state.editor.libraries.isFetching || state.editor.libraries.isEditing
   };

--- a/src/components/LibraryEditForm.tsx
+++ b/src/components/LibraryEditForm.tsx
@@ -10,6 +10,7 @@ export interface LibraryEditFormProps {
   editItem: (data: FormData) => Promise<void>;
   urlBase: string;
   listDataKey: string;
+  editedIdentifier?: string;
 }
 
 export default class LibraryEditForm extends React.Component<LibraryEditFormProps, void> {
@@ -62,9 +63,9 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
 
     const data = new (window as any).FormData(this.refs["form"] as any);
     this.props.editItem(data).then(() => {
-      // If a new library was created, go back to the list of libraries.
-      if (!this.props.item) {
-        window.location.href = this.props.urlBase;
+      // If a new library was created, go to the new library's edit page.
+      if (!this.props.item && this.props.editedIdentifier) {
+        window.location.href = this.props.urlBase + "edit/" + this.props.editedIdentifier;
       }
     });
   }

--- a/src/components/MetadataServices.tsx
+++ b/src/components/MetadataServices.tsx
@@ -29,6 +29,7 @@ function mapStateToProps(state, ownProps) {
   }
   return {
     data: data,
+    editedIdentifier: state.editor.metadataServices && state.editor.metadataServices.editedIdentifier,
     fetchError: state.editor.metadataServices.fetchError,
     isFetching: state.editor.metadataServices.isFetching || state.editor.metadataServices.isEditing
   };

--- a/src/components/PatronAuthServices.tsx
+++ b/src/components/PatronAuthServices.tsx
@@ -29,6 +29,7 @@ function mapStateToProps(state, ownProps) {
   }
   return {
     data: data,
+    editedIdentifier: state.editor.patronAuthServices && state.editor.patronAuthServices.editedIdentifier,
     fetchError: state.editor.patronAuthServices.fetchError,
     isFetching: state.editor.patronAuthServices.isFetching || state.editor.patronAuthServices.isEditing
   };

--- a/src/components/SearchServices.tsx
+++ b/src/components/SearchServices.tsx
@@ -18,6 +18,7 @@ function mapStateToProps(state, ownProps) {
   const data = Object.assign({}, state.editor.searchServices && state.editor.searchServices.data || {});
   return {
     data: data,
+    editedIdentifier: state.editor.searchServices && state.editor.searchServices.editedIdentifier,
     fetchError: state.editor.searchServices.fetchError,
     isFetching: state.editor.searchServices.isFetching || state.editor.searchServices.isEditing
   };

--- a/src/components/ServiceEditForm.tsx
+++ b/src/components/ServiceEditForm.tsx
@@ -13,6 +13,7 @@ export interface ServiceEditFormProps<T> {
   editItem: (data: FormData) => Promise<void>;
   urlBase: string;
   listDataKey: string;
+  editedIdentifier?: string;
 }
 
 export interface ServiceEditFormState {
@@ -422,9 +423,9 @@ export default class ServiceEditForm<T extends ServicesData> extends React.Compo
     const data = new (window as any).FormData(this.refs["form"] as any);
     data.append("libraries", JSON.stringify(this.state.libraries));
     this.props.editItem(data).then(() => {
-      // If a new service was created, go back to the list of services.
-      if (!this.props.item) {
-        window.location.href = this.props.urlBase;
+      // If a new service was created, go to its edit page.
+      if (!this.props.item && this.props.editedIdentifier) {
+        window.location.href = this.props.urlBase + "edit/" + this.props.editedIdentifier;
       }
     });
   }

--- a/src/components/SitewideSettings.tsx
+++ b/src/components/SitewideSettings.tsx
@@ -25,6 +25,7 @@ export class SitewideSettings extends EditableConfigList<SitewideSettingsData, S
 function mapStateToProps(state, ownProps) {
   return {
     data: state.editor.sitewideSettings && state.editor.sitewideSettings.data,
+    editedIdentifier: state.editor.sitewideSettings && state.editor.sitewideSettings.editedIdentifier,
     fetchError: state.editor.sitewideSettings.fetchError,
     isFetching: state.editor.sitewideSettings.isFetching || state.editor.sitewideSettings.isEditing
   };

--- a/src/components/__tests__/IndividualAdminEditForm-test.tsx
+++ b/src/components/__tests__/IndividualAdminEditForm-test.tsx
@@ -71,20 +71,36 @@ describe("IndividualAdminEditForm", () => {
       );
     });
 
-    it("submits data", () => {
-      wrapper.setProps({ item: adminData });
-      let input = wrapper.find("input[name='password']");
-      let inputElement = input.get(0);
-      inputElement.value = "newPassword";
-      input.simulate("change");
+    it("submits data", async () => {
+      // Set window.location.href to be writable, jsdom doesn't normally allow changing it but browsers do.
+      // Start on the create page.
+      Object.defineProperty(window.location, "href", { writable: true, value: "url base/create" });
+
+      let emailInput = wrapper.find("input[name='email']");
+      let emailInputElement = emailInput.get(0);
+      emailInputElement.value = "newEmail";
+      emailInput.simulate("change");
+      let pwInput = wrapper.find("input[name='password']");
+      let pwInputElement = pwInput.get(0);
+      pwInputElement.value = "newPassword";
+      pwInput.simulate("change");
 
       let form = wrapper.find("form");
       form.simulate("submit");
 
       expect(editIndividualAdmin.callCount).to.equal(1);
       let formData = editIndividualAdmin.args[0][0];
-      expect(formData.get("email")).to.equal("test@nypl.org");
+      expect(formData.get("email")).to.equal("newEmail");
       expect(formData.get("password")).to.equal("newPassword");
+
+      wrapper.setProps({ editedIdentifier: "newEmail" });
+      // Let the call stack clear so the callback after editItem will run.
+      const pause = (): Promise<void> => {
+          return new Promise<void>(resolve => setTimeout(resolve, 0));
+      };
+      await pause();
+      expect(window.location.href).to.contain("edit");
+      expect(window.location.href).to.contain("newEmail");
     });
   });
 });

--- a/src/components/__tests__/LibraryEditForm-test.tsx
+++ b/src/components/__tests__/LibraryEditForm-test.tsx
@@ -126,5 +126,25 @@ describe("LibraryEditForm", () => {
       expect(formData.get("privacy-policy")).to.equal("http://privacy");
       expect(formData.get("copyright")).to.equal("http://copyright");
     });
+
+    it("navigates to edit form after creating a new library", async () => {
+      // Set window.location.href to be writable, jsdom doesn't normally allow changing it but browsers do.
+      // Start on the create page.
+      Object.defineProperty(window.location, "href", { writable: true, value: "url base/create" });
+
+      let form = wrapper.find("form");
+      form.simulate("submit");
+
+      expect(editLibrary.callCount).to.equal(1);
+
+      wrapper.setProps({ editedIdentifier: "5" });
+      // Let the call stack clear so the callback after editItem will run.
+      const pause = (): Promise<void> => {
+          return new Promise<void>(resolve => setTimeout(resolve, 0));
+      };
+      await pause();
+      expect(window.location.href).to.contain("edit");
+      expect(window.location.href).to.contain("5");
+    });
   });
 });

--- a/src/components/__tests__/ServiceEditForm-test.tsx
+++ b/src/components/__tests__/ServiceEditForm-test.tsx
@@ -723,5 +723,25 @@ describe("ServiceEditForm", () => {
       expect(formData.get("select_setting")).to.equal("option2");
       expect(formData.get("libraries")).to.equal(JSON.stringify(serviceData.libraries));
     });
+
+    it("navigates to edit form after creating a new service", async () => {
+      // Set window.location.href to be writable, jsdom doesn't normally allow changing it but browsers do.
+      // Start on the create page.
+      Object.defineProperty(window.location, "href", { writable: true, value: "/services/create" });
+
+      let form = wrapper.find("form");
+      form.simulate("submit");
+
+      expect(editService.callCount).to.equal(1);
+
+      wrapper.setProps({ editedIdentifier: "5" });
+      // Let the call stack clear so the callback after editItem will run.
+      const pause = (): Promise<void> => {
+          return new Promise<void>(resolve => setTimeout(resolve, 0));
+      };
+      await pause();
+      expect(window.location.href).to.contain("edit");
+      expect(window.location.href).to.contain("5");
+    });
   });
 });


### PR DESCRIPTION
This branch brings some of the work I did for custom lists over to the config section. When you create a new config item, you end up on the edit page for the new item instead of back on the list of that type of item.