### PR TITLE
Fixed bug where adding an item to a list didn't clear out the add input.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.0.49",
+  "version": "0.0.50",
   "description": "Web Front-end for Library Simplified Circulation Manager",
   "repository": {
     "type": "git",

--- a/src/components/EditableInput.tsx
+++ b/src/components/EditableInput.tsx
@@ -62,13 +62,18 @@ export default class EditableInput extends React.Component<EditableInputProps, E
   componentWillReceiveProps(props) {
     let value = this.state.value;
     let checked = this.state.checked;
+    let changed = false;
     if (props.value !== this.props.value) {
       value = props.value || "";
+      changed = true;
     }
     if (props.checked !== this.props.checked) {
       checked = props.checked || false;
+      changed = true;
     }
-    this.setState({ value, checked });
+    if (changed) {
+      this.setState({ value, checked });
+    }
   }
 
   handleChange() {


### PR DESCRIPTION
This fixes a bug where adding an item to a list would add the item, but also leave the text in the add input, so when you saved you ended up with two copies of the item.

This bug was related to React's `setState` method. When you clicked "add", I was calling `EditableInput.clear` to set the input's state to `""`, but React doesn't update the state immediately. Some other code was accessing the state before it changed, and calling `setState` again with the old value.

I fixed the bug by changing that code to not `setState` unless there's a new prop that actually affects the state. In the case of adding a list item, there's not.

Unfortunately I couldn't reproduce this bug in tests. I think enzyme updates the state immediately.