### PR TITLE
Added outstanding metadata to book edit form.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 
 node_js:
-  - "4.1"
+  - "7"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.0.51",
+  "version": "0.0.52",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",
@@ -23,15 +23,15 @@
     "bootstrap": "^3.3.6",
     "font-awesome": "^4.6.3",
     "isomorphic-fetch": "^2.2.1",
-    "opds-feed-parser": "0.0.13",
-    "opds-web-client": "^0.1.16",
+    "opds-feed-parser": "^0.0.14",
+    "opds-web-client": "^0.1.18",
     "qs": "^6.2.0",
     "react": "^15.4.0",
     "react-beautiful-dnd": "^2.3.1",
     "react-bootstrap": "0.29.4",
     "react-dom": "^15.4.0",
     "react-redux": "^5.0.6",
-    "react-router": "^2.4.1",
+    "react-router": "^3.2.0",
     "redux": "^3.7.2",
     "redux-thunk": "^2.1.0",
     "request": "^2.72.0"
@@ -55,7 +55,7 @@
     "style-loader": "^0.13.1",
     "ts-loader": "^0.8.2",
     "tslint": "^3.10.2",
-    "typescript": "2.1.1",
+    "typescript": "2.1.6",
     "typings": "^1.0.4",
     "url-loader": "^0.5.7",
     "webpack": "^1.13.1"

--- a/src/__tests__/editorAdapter-test.ts
+++ b/src/__tests__/editorAdapter-test.ts
@@ -38,7 +38,7 @@ describe("editorAdapter", () => {
         "$": {
           "schema:additionalType": { value: "medium" }
         },
-        "simplified:imprint": [{ "_": "imprint" }],
+        "bib:publisherImprint": [{ "_": "imprint" }],
         "schema:Rating": [{ "$": { "schema:ratingValue": { value: "5" }}}]
       }
     });

--- a/src/__tests__/editorAdapter-test.ts
+++ b/src/__tests__/editorAdapter-test.ts
@@ -1,0 +1,94 @@
+import { expect } from "chai";
+import { stub } from "sinon";
+
+import adapter from "../editorAdapter";
+import { OPDSEntry, Contributor, Series, Category, Summary } from "opds-feed-parser";
+
+describe("editorAdapter", () => {
+  it("adapts valid OPDS entry", () => {
+    let entry = new OPDSEntry({
+      id: "id",
+      updated: "updated",
+      title: "title",
+      authors: [new Contributor({ name: "name", uri: "uri", role: "role" })],
+      contributors: [new Contributor({ name: "name2", uri: "uri2", role: "role2" })],
+      series: new Series({ name: "series", position: 2 }),
+      categories: [
+        new Category({ term: "term", scheme: "scheme", label: "label" }),
+        new Category({ term: "13-16", scheme: "http://schema.org/typicalAgeRange", label: "age" }),
+        new Category({ term: "ya", scheme: "http://schema.org/audience", label: "ya" }),
+        new Category({ term: "fiction", scheme: "http://librarysimplified.org/terms/fiction/", label: "Fiction" })
+      ],
+      identifiers: [],
+      links: [
+        { href: "hide", rel: "http://librarysimplified.org/terms/rel/hide", type: "type", title: "title" },
+        { href: "restore", rel: "http://librarysimplified.org/terms/rel/restore", type: "type", title: "title" },
+        { href: "refresh", rel: "http://librarysimplified.org/terms/rel/refresh", type: "type", title: "title" },
+        { href: "edit", rel: "edit", type: "type", title: "title" },
+        { href: "issues", rel: "issues", type: "type", title: "title" }
+      ],
+      issued: "issued",
+      language: "language",
+      rights: "rights",
+      publisher: "publisher",
+      published: "published",
+      summary: new Summary({ content: "content", link: "link" }),
+      unparsed: {
+        "schema:alternativeHeadline": [{ "_": "subtitle" }],
+        "$": {
+          "schema:additionalType": { value: "medium" }
+        },
+        "simplified:imprint": [{ "_": "imprint" }],
+        "schema:Rating": [{ "$": { "schema:ratingValue": { value: "5" }}}]
+      }
+    });
+
+    let adapted = adapter(entry);
+    expect(adapted.title).to.equal("title");
+    expect(adapted.authors).to.deep.equal([{ name: "name", uri: "uri", role: "aut" }]);
+    expect(adapted.contributors).to.deep.equal(entry.contributors);
+    expect(adapted.subtitle).to.equal("subtitle");
+    expect(adapted.summary).to.equal("content");
+    expect(adapted.audience).to.equal("ya");
+    expect(adapted.targetAgeRange).to.deep.equal(["13", "16"]);
+    expect(adapted.fiction).to.equal(true);
+    expect(adapted.categories).to.deep.equal(["label", "age", "ya", "Fiction"]);
+    expect(adapted.hideLink).to.deep.equal(entry.links[0]);
+    expect(adapted.restoreLink).to.deep.equal(entry.links[1]);
+    expect(adapted.refreshLink).to.deep.equal(entry.links[2]);
+    expect(adapted.editLink).to.deep.equal(entry.links[3]);
+    expect(adapted.issuesLink).to.deep.equal(entry.links[4]);
+    expect(adapted.series).to.equal("series");
+    expect(adapted.seriesPosition).to.equal(2);
+    expect(adapted.medium).to.equal("medium");
+    expect(adapted.language).to.equal("language");
+    expect(adapted.publisher).to.equal("publisher");
+    expect(adapted.imprint).to.equal("imprint");
+    expect(adapted.issued).to.equal("issued");
+    expect(adapted.rating).to.equal("5");
+  });
+
+  it("doesn't crash when expected data is missing", () => {
+    let entry = new OPDSEntry({
+      id: "id",
+      updated: "updated",
+      title: "title",
+      authors: [],
+      contributors: [],
+      series: new Series({ name: "series", position: 2 }),
+      categories: [],
+      identifiers: [],
+      links: [],
+      issued: "issued",
+      language: "language",
+      rights: "rights",
+      publisher: "publisher",
+      published: "published",
+      summary: new Summary({ content: "content", link: "link" }),
+      unparsed: {}
+    });
+
+    let adapted = adapter(entry);
+    expect(adapted.title).to.equal("title");
+  });
+});

--- a/src/__tests__/editorAdapter-test.ts
+++ b/src/__tests__/editorAdapter-test.ts
@@ -39,7 +39,12 @@ describe("editorAdapter", () => {
           "schema:additionalType": { value: "medium" }
         },
         "bib:publisherImprint": [{ "_": "imprint" }],
-        "schema:Rating": [{ "$": { "schema:ratingValue": { value: "5" }}}]
+        "schema:Rating": [
+          { "$": { "schema:ratingValue": { value: "0.3" },
+                   "schema:additionalType": { value: "http://librarysimplified.org/terms/rel/quality" }}},
+          { "$": { "schema:ratingValue": { value: "4" },
+                   "schema:additionalType": { value: "http://schema.org/ratingValue" }}}
+        ]
       }
     });
 
@@ -65,7 +70,7 @@ describe("editorAdapter", () => {
     expect(adapted.publisher).to.equal("publisher");
     expect(adapted.imprint).to.equal("imprint");
     expect(adapted.issued).to.equal("issued");
-    expect(adapted.rating).to.equal("5");
+    expect(adapted.rating).to.equal("4");
   });
 
   it("doesn't crash when expected data is missing", () => {

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -7,7 +7,8 @@ import {
   MetadataServicesData, AnalyticsServicesData,
   CDNServicesData, SearchServicesData,
   DiscoveryServicesData, LibraryRegistrationsData,
-  CustomListsData, LanesData
+  CustomListsData, LanesData, RolesData, MediaData,
+  LanguagesData
 } from "./interfaces";
 import DataFetcher from "opds-web-client/lib/DataFetcher";
 import { RequestError, RequestRejector } from "opds-web-client/lib/DataFetcher";
@@ -18,6 +19,9 @@ import BaseActionCreator from "opds-web-client/lib/actions";
 export default class ActionCreator extends BaseActionCreator {
   static readonly EDIT_BOOK = "EDIT_BOOK";
   static readonly BOOK_ADMIN = "BOOK_ADMIN";
+  static readonly ROLES = "ROLES";
+  static readonly MEDIA = "MEDIA";
+  static readonly LANGUAGES = "LANGUAGES";
   static readonly COMPLAINTS = "COMPLAINTS";
   static readonly POST_COMPLAINT = "POST_COMPLAINT";
   static readonly RESOLVE_COMPLAINTS = "RESOLVE_COMPLAINTS";
@@ -242,6 +246,21 @@ export default class ActionCreator extends BaseActionCreator {
 
   editBook(url: string, data: FormData | null) {
     return this.postForm(ActionCreator.EDIT_BOOK, url, data).bind(this);
+  }
+
+  fetchRoles() {
+    let url = "/admin/roles";
+    return this.fetchJSON<RolesData>(ActionCreator.ROLES, url).bind(this);
+  }
+
+  fetchMedia() {
+    let url = "/admin/media";
+    return this.fetchJSON<MediaData>(ActionCreator.MEDIA, url).bind(this);
+  }
+
+  fetchLanguages() {
+    let url = "/admin/languages";
+    return this.fetchJSON<LanguagesData>(ActionCreator.LANGUAGES, url).bind(this);
   }
 
   fetchComplaints(url: string) {

--- a/src/components/Autocomplete.tsx
+++ b/src/components/Autocomplete.tsx
@@ -1,0 +1,36 @@
+import * as React from "react";
+import EditableInput from "./EditableInput";
+
+export interface AutocompleteProps {
+  autocompleteValues: string[];
+  disabled: boolean;
+  name: string;
+  label: string;
+  value?: string;
+}
+
+export default class Autocomplete extends React.Component<AutocompleteProps, void> {
+  render(): JSX.Element {
+    return (
+      <div>
+        <EditableInput
+          elementType="input"
+          type="text"
+          disabled={this.props.disabled}
+          name={this.props.name}
+          list={this.props.name + "-autocomplete-list"}
+          label={this.props.label}
+          value={this.props.value}
+          />
+        <datalist
+          id={this.props.name + "-autocomplete-list"}
+          >
+          { this.props.autocompleteValues.map(value =>
+              <option value={value} key={value}></option>
+            )
+          }
+        </datalist>
+      </div>
+    );
+  }
+}

--- a/src/components/BookDetailsEditor.tsx
+++ b/src/components/BookDetailsEditor.tsx
@@ -7,12 +7,15 @@ import editorAdapter from "../editorAdapter";
 import ButtonForm from "./ButtonForm";
 import BookEditForm from "./BookEditForm";
 import ErrorMessage from "./ErrorMessage";
-import { BookData } from "../interfaces";
+import { BookData, RolesData, MediaData, LanguagesData } from "../interfaces";
 import { FetchErrorData } from "opds-web-client/lib/interfaces";
 import { State } from "../reducers/index";
 
 export interface BookDetailsEditorStateProps {
   bookData?: BookData;
+  roles?: RolesData;
+  media?: MediaData;
+  languages?: LanguagesData;
   bookAdminUrl?: string;
   fetchError?: FetchErrorData;
   editError?: FetchErrorData;
@@ -20,8 +23,11 @@ export interface BookDetailsEditorStateProps {
 }
 
 export interface BookDetailsEditorDispatchProps {
-  fetchBook?: (url: string) => void;
-  editBook?: (url: string, data: FormData | null) => Promise<any>;
+  fetchBook: (url: string) => void;
+  fetchRoles: () => void;
+  fetchMedia: () => void;
+  fetchLanguages: () => void;
+  editBook: (url: string, data: FormData | null) => Promise<any>;
 }
 
 export interface BookDetailsEditorOwnProps {
@@ -94,6 +100,9 @@ export class BookDetailsEditor extends React.Component<BookDetailsEditorProps, v
             { this.props.bookData.editLink &&
               <BookEditForm
                 {...this.props.bookData}
+                roles={this.props.roles}
+                media={this.props.media}
+                languages={this.props.languages}
                 disabled={this.props.isFetching}
                 editBook={this.props.editBook}
                 refresh={this.refresh} />
@@ -111,6 +120,9 @@ export class BookDetailsEditor extends React.Component<BookDetailsEditorProps, v
     if (this.props.bookUrl) {
       let bookAdminUrl = this.props.bookUrl.replace("works", "admin/works");
       this.props.fetchBook(bookAdminUrl);
+      this.props.fetchRoles();
+      this.props.fetchMedia();
+      this.props.fetchLanguages();
     }
   }
 
@@ -147,8 +159,11 @@ function mapStateToProps(state, ownProps) {
   return {
     bookAdminUrl: state.editor.book.url,
     bookData: state.editor.book.data || ownProps.bookData,
-    isFetching: state.editor.book.isFetching,
-    fetchError: state.editor.book.fetchError,
+    roles: state.editor.roles.data,
+    media: state.editor.media.data,
+    languages: state.editor.languages.data,
+    isFetching: state.editor.book.isFetching || state.editor.roles.isFetching || state.editor.media.isFetching || state.editor.languages.isFetching,
+    fetchError: state.editor.book.fetchError || state.editor.roles.fetchError || state.editor.media.fetchError || state.editor.languages.fetchError,
     editError: state.editor.book.editError
   };
 }
@@ -158,7 +173,10 @@ function mapDispatchToProps(dispatch, ownProps) {
   let actions = new ActionCreator(fetcher, ownProps.csrfToken);
   return {
     editBook: (url, data) => dispatch(actions.editBook(url, data)),
-    fetchBook: (url: string) => dispatch(actions.fetchBookAdmin(url))
+    fetchBook: (url: string) => dispatch(actions.fetchBookAdmin(url)),
+    fetchRoles: () => dispatch(actions.fetchRoles()),
+    fetchMedia: () => dispatch(actions.fetchMedia()),
+    fetchLanguages: () => dispatch(actions.fetchLanguages())
   };
 }
 

--- a/src/components/BookEditForm.tsx
+++ b/src/components/BookEditForm.tsx
@@ -179,7 +179,7 @@ export default class BookEditForm extends React.Component<BookEditFormProps, Boo
           label="Rating (1-5, higher is better)"
           min={1}
           max={5}
-          value={this.props.rating && String(Math.round((this.props.rating * 4) + 1))}
+          value={this.props.rating && String(Math.round(this.props.rating))}
           />
         <EditableInput
           elementType="textarea"

--- a/src/components/BookEditForm.tsx
+++ b/src/components/BookEditForm.tsx
@@ -1,15 +1,33 @@
 import * as React from "react";
 import EditableInput from "./EditableInput";
-import { BookData } from "../interfaces";
+import { BookData, ContributorData, RolesData, MediaData, LanguagesData } from "../interfaces";
+import WithRemoveButton from "./WithRemoveButton";
+import Autocomplete from "./Autocomplete";
 
 export interface BookEditFormProps extends BookData {
+  roles: RolesData;
+  languages: LanguagesData;
+  media: MediaData;
   disabled: boolean;
   refresh: () => any;
   editBook: (url: string, data: FormData) => Promise<any>;
 }
 
+export interface BookEditFormState {
+  contributors?: ContributorData[];
+}
+
 /** Edit a book's metadata in the edit tab on the book details page. */
-export default class BookEditForm extends React.Component<BookEditFormProps, any> {
+export default class BookEditForm extends React.Component<BookEditFormProps, BookEditFormState> {
+  constructor(props) {
+    super(props);
+    this.state = {
+      contributors: (props.authors || []).concat(props.contributors || [])
+    };
+    this.addContributor = this.addContributor.bind(this);
+    this.removeContributor = this.removeContributor.bind(this);
+  }
+
   render(): JSX.Element {
     return (
       <form ref="form" onSubmit={this.save.bind(this)} className="edit-form">
@@ -30,6 +48,65 @@ export default class BookEditForm extends React.Component<BookEditFormProps, any
           value={this.props.subtitle}
           />
         <div className="form-group">
+          <label>Authors and Contributors</label>
+          { this.state.contributors.map(contributor =>
+              <WithRemoveButton
+                key={contributor.name}
+                disabled={this.props.disabled}
+                onRemove={() => this.removeContributor(contributor)}
+                >
+                <span className="contributor-form">
+                  <EditableInput
+                    elementType="select"
+                    disabled={this.props.disabled}
+                    name="contributor-role"
+                    value={this.getContributorRole(contributor)}
+                    >
+                    { this.props.roles && Object.values(this.props.roles).map(role =>
+                        <option value={role} key={role}>{role}</option>
+                      )
+                    }
+                  </EditableInput>
+                  <EditableInput
+                    elementType="input"
+                    type="text"
+                    disabled={this.props.disabled}
+                    name="contributor-name"
+                    value={contributor.name}
+                    />
+                </span>
+              </WithRemoveButton>
+            )
+          }
+          <span className="contributor-form">
+            <EditableInput
+              elementType="select"
+              disabled={this.props.disabled}
+              name="contributor-role"
+              value="Author"
+              ref="addContributorRole"
+              >
+              { this.props.roles && Object.values(this.props.roles).map(role =>
+                  <option value={role} key={role}>{role}</option>
+                )
+              }
+            </EditableInput>
+            <EditableInput
+              elementType="input"
+              type="text"
+              disabled={this.props.disabled}
+              name="contributor-name"
+              ref="addContributorName"
+              />
+            <button
+              type="button"
+              className="btn btn-default add-contributor"
+              disabled={this.props.disabled}
+              onClick={this.addContributor}
+              >Add</button>
+          </span>
+        </div>
+        <div className="form-group">
           <label>Series</label>
           <div className="form-inline">
             <EditableInput
@@ -47,10 +124,63 @@ export default class BookEditForm extends React.Component<BookEditFormProps, any
               disabled={this.props.disabled}
               name="series_position"
               placeholder="#"
-              value={this.props.seriesPosition}
+              value={this.props.seriesPosition && String(this.props.seriesPosition)}
               />
           </div>
         </div>
+        <EditableInput
+          elementType="select"
+          disabled={this.props.disabled}
+          name="medium"
+          label="Medium"
+          value={this.getMedium(this.props.medium)}
+          >
+          { this.props.media && Object.values(this.props.media).map(medium =>
+              <option value={medium} key={medium}>{medium}</option>
+            )
+          }
+        </EditableInput>
+        <Autocomplete
+          autocompleteValues={this.uniqueLanguageNames()}
+          disabled={this.props.disabled}
+          name="language"
+          label="Language"
+          value={this.props.languages && this.props.languages[this.props.language] && this.props.languages[this.props.language][0]}
+          />
+        <EditableInput
+          elementType="input"
+          type="text"
+          disabled={this.props.disabled}
+          name="publisher"
+          label="Publisher"
+          value={this.props.publisher}
+          />
+        <EditableInput
+          elementType="input"
+          type="text"
+          disabled={this.props.disabled}
+          name="imprint"
+          label="Imprint"
+          value={this.props.imprint}
+          />
+        <EditableInput
+          elementType="input"
+          type="date"
+          disabled={this.props.disabled}
+          name="issued"
+          label="Publication Date"
+          value={this.props.issued}
+          />
+        <EditableInput
+          elementType="input"
+          type="number"
+          disabled={this.props.disabled}
+          name="rating"
+          label="Rating (1-5, higher is better)"
+          min={1}
+          max={5}
+          value={this.props.rating && String(Math.round((this.props.rating * 4) + 1))}
+          />
         <EditableInput
           elementType="textarea"
           disabled={this.props.disabled}
@@ -66,6 +196,51 @@ export default class BookEditForm extends React.Component<BookEditFormProps, any
         </button>
       </form>
     );
+  }
+
+  uniqueLanguageNames() {
+    const languageNames = [];
+    for (let nameList of Object.values(this.props.languages || {})) {
+      for (let name of nameList) {
+        if (languageNames.indexOf(name) === -1) {
+          languageNames.push(name);
+        }
+      }
+    }
+    return languageNames;
+  }
+
+  getMedium(additionalTypeOrMedium) {
+    if (this.props.media) {
+      if (this.props.media[additionalTypeOrMedium]) {
+        return this.props.media[additionalTypeOrMedium];
+      }
+    }
+    return additionalTypeOrMedium;
+  }
+
+  getContributorRole(contributor) {
+    if (this.props.roles) {
+      if (this.props.roles[contributor.role]) {
+        return this.props.roles[contributor.role];
+      }
+    }
+    return contributor.role;
+  }
+
+  removeContributor(contributor) {
+    const remainingContributors = this.state.contributors.filter(stateContributor => {
+      return !(stateContributor.name === contributor.name && stateContributor.role === contributor.role);
+    });
+    this.setState({ contributors: remainingContributors });
+  }
+
+  addContributor() {
+    const name = (this.refs["addContributorName"] as any).getValue();
+    const role = (this.refs["addContributorRole"] as any).getValue();
+    this.setState({ contributors: this.state.contributors.concat({ role, name }) });
+    (this.refs["addContributorName"] as any).clear();
+    (this.refs["addContributorRole"] as any).clear();
   }
 
   save(event) {

--- a/src/components/BookEditForm.tsx
+++ b/src/components/BookEditForm.tsx
@@ -51,7 +51,7 @@ export default class BookEditForm extends React.Component<BookEditFormProps, Boo
           <label>Authors and Contributors</label>
           { this.state.contributors.map(contributor =>
               <WithRemoveButton
-                key={contributor.name}
+                key={contributor.name + contributor.role}
                 disabled={this.props.disabled}
                 onRemove={() => this.removeContributor(contributor)}
                 >

--- a/src/components/BookEditForm.tsx
+++ b/src/components/BookEditForm.tsx
@@ -124,7 +124,7 @@ export default class BookEditForm extends React.Component<BookEditFormProps, Boo
               disabled={this.props.disabled}
               name="series_position"
               placeholder="#"
-              value={this.props.seriesPosition && String(this.props.seriesPosition)}
+              value={this.props.seriesPosition !== undefined && this.props.seriesPosition !== null && String(this.props.seriesPosition)}
               />
           </div>
         </div>

--- a/src/components/EditableInput.tsx
+++ b/src/components/EditableInput.tsx
@@ -60,7 +60,10 @@ export default class EditableInput extends React.Component<EditableInputProps, E
       onChange: this.handleChange,
       style: this.props.style,
       placeholder: this.props.placeholder,
-      accept: this.props.accept
+      accept: this.props.accept,
+      list: this.props.list,
+      min: this.props.min,
+      max: this.props.max
     }, this.props.children);
   }
 

--- a/src/components/__tests__/Autocomplete-test.tsx
+++ b/src/components/__tests__/Autocomplete-test.tsx
@@ -1,0 +1,49 @@
+import { expect } from "chai";
+import { stub } from "sinon";
+
+import * as React from "react";
+import { shallow } from "enzyme";
+
+import Autocomplete from "../Autocomplete";
+import EditableInput from "../EditableInput";
+
+describe("Autocomplete", () => {
+  let wrapper;
+  let autocompleteValues = ["a", "b", "c"];
+
+  beforeEach(() => {
+    wrapper = shallow(
+      <Autocomplete
+        autocompleteValues={autocompleteValues}
+        disabled={false}
+        name="test"
+        label="Test"
+        value="b"
+        />
+    );
+  });
+
+  describe("rendering", () => {
+    it("shows input", () => {
+      let input = wrapper.find(EditableInput);
+      expect(input.length).to.equal(1);
+      expect(input.props().type).to.equal("text");
+      expect(input.props().disabled).to.equal(false);
+      expect(input.props().name).to.equal("test");
+      expect(input.props().label).to.equal("Test");
+      expect(input.props().value).to.equal("b");
+      expect(input.props().list).to.equal("test-autocomplete-list");
+    });
+
+    it("shows autocomplete list", () => {
+      let list = wrapper.find("datalist");
+      expect(list.length).to.equal(1);
+      expect(list.props().id).to.equal("test-autocomplete-list");
+      let options = list.find("option");
+      expect(options.length).to.equal(3);
+      expect(options.at(0).props().value).to.equal("a");
+      expect(options.at(1).props().value).to.equal("b");
+      expect(options.at(2).props().value).to.equal("c");
+    });
+  });
+});

--- a/src/components/__tests__/BookDetailsEditor-test.tsx
+++ b/src/components/__tests__/BookDetailsEditor-test.tsx
@@ -10,31 +10,49 @@ import BookEditForm from "../BookEditForm";
 import ErrorMessage from "../ErrorMessage";
 
 describe("BookDetailsEditor", () => {
-  it("loads admin book url on mount", () => {
-    let permalink = "works/1234";
-    let fetchBook = stub();
+  let fetchBook;
+  let fetchRoles;
+  let fetchLanguages;
+  let fetchMedia;
+  let editBook;
+  let dispatchProps;
 
+  beforeEach(() => {
+    fetchBook = stub();
+    fetchRoles = stub();
+    fetchLanguages = stub();
+    fetchMedia = stub();
+    editBook = stub();
+    dispatchProps = {
+      fetchBook, fetchRoles, fetchLanguages, fetchMedia, editBook
+    };
+  });
+
+  it("loads admin book url, roles, languages, and media on mount", () => {
+    let permalink = "works/1234";
     let wrapper = shallow(
       <BookDetailsEditor
         bookUrl={permalink}
-        fetchBook={fetchBook}
+        {...dispatchProps}
         csrfToken={"token"}
         />
     );
 
     expect(fetchBook.callCount).to.equal(1);
     expect(fetchBook.args[0][0]).to.equal("admin/works/1234");
+    expect(fetchRoles.callCount).to.equal(1);
+    expect(fetchLanguages.callCount).to.equal(1);
+    expect(fetchMedia.callCount).to.equal(1);
   });
 
   it("loads admin book url when given a new book url", () => {
     let permalink = "works/1234";
     let newPermalink = "works/5555";
-    let fetchBook = stub();
     let element = document.createElement("div");
     let wrapper = shallow(
       <BookDetailsEditor
         bookUrl={permalink}
-        fetchBook={fetchBook}
+        {...dispatchProps}
         csrfToken={"token"}
         />
     );
@@ -46,13 +64,12 @@ describe("BookDetailsEditor", () => {
   });
 
   it("shows title", () => {
-    let fetchBook = stub();
     let wrapper = shallow(
       <BookDetailsEditor
         bookData={{ title: "title" }}
         bookUrl="url"
         csrfToken="token"
-        fetchBook={fetchBook}
+        {...dispatchProps}
         />
     );
 
@@ -61,7 +78,6 @@ describe("BookDetailsEditor", () => {
   });
 
   it("shows button form for hide link", () => {
-    let fetchBook = stub();
     let hideLink = {
       href: "href", rel: "http://librarysimplified.org/terms/rel/hide"
     };
@@ -70,7 +86,7 @@ describe("BookDetailsEditor", () => {
         bookData={{ title: "title", hideLink: hideLink }}
         bookUrl="url"
         csrfToken="token"
-        fetchBook={fetchBook}
+        {...dispatchProps}
         />
     );
     let hide = (wrapper.instance() as any).hide;
@@ -81,7 +97,6 @@ describe("BookDetailsEditor", () => {
   });
 
   it("shows button form for restore link", () => {
-    let fetchBook = stub();
     let restoreLink = {
       href: "href", rel: "http://librarysimplified.org/terms/rel/restore"
     };
@@ -90,7 +105,7 @@ describe("BookDetailsEditor", () => {
         bookData={{ title: "title", restoreLink: restoreLink }}
         bookUrl="url"
         csrfToken="token"
-        fetchBook={fetchBook}
+        {...dispatchProps}
         />
     );
     let restore = (wrapper.instance() as any).restore;
@@ -101,7 +116,6 @@ describe("BookDetailsEditor", () => {
   });
 
   it("shows button form for refresh link", () => {
-    let fetchBook = stub();
     let refreshLink = {
       href: "href", rel: "http://librarysimplified/terms/rel/refresh"
     };
@@ -110,7 +124,7 @@ describe("BookDetailsEditor", () => {
         bookData={{ title: "title", refreshLink: refreshLink }}
         bookUrl="url"
         csrfToken="token"
-        fetchBook={fetchBook}
+        {...dispatchProps}
         />
     );
     let refresh = (wrapper.instance() as any).refreshMetadata;
@@ -121,7 +135,6 @@ describe("BookDetailsEditor", () => {
   });
 
   it("shows fetch error message", () => {
-    let fetchBook = stub();
     let fetchError = {
       status: 500,
       response: "response",
@@ -132,7 +145,7 @@ describe("BookDetailsEditor", () => {
         bookData={{ title: "title" }}
         bookUrl="url" csrfToken="token"
         fetchError={fetchError}
-        fetchBook={fetchBook}
+        {...dispatchProps}
         />
     );
 
@@ -143,7 +156,6 @@ describe("BookDetailsEditor", () => {
   });
 
   it("shows edit error message with form", () => {
-    let fetchBook = stub();
     let editError = {
       status: 500,
       response: "response",
@@ -158,7 +170,7 @@ describe("BookDetailsEditor", () => {
         bookUrl="url"
         csrfToken="token"
         editError={editError}
-        fetchBook={fetchBook}
+        {...dispatchProps}
         />
     );
 
@@ -166,5 +178,41 @@ describe("BookDetailsEditor", () => {
     expect(editForm.length).to.equal(1);
     let error = wrapper.find(ErrorMessage);
     expect(error.prop("error")).to.equal(editError);
+  });
+
+  it("shows book edit form", () => {
+    let roles = {
+      "aut": "Author",
+      "nar": "Narrator"
+    };
+    let languages = {
+      "eng": ["English"],
+      "spa": ["Spanish"]
+    };
+    let media = {
+      "http://schema.org/AudioObject": "Audio",
+      "http://schema.org/Book": "Book"
+    };
+    let editLink = {
+      href: "href", rel: "http://librarysimplified.org/terms/rel/edit"
+    };
+    let wrapper = shallow(
+      <BookDetailsEditor
+        bookData={{ title: "title", editLink }}
+        bookUrl="url"
+        csrfToken="token"
+        {...dispatchProps}
+        roles={roles}
+        languages={languages}
+        media={media}
+        />
+    );
+
+    let editForm = wrapper.find(BookEditForm);
+    expect(editForm.length).to.equal(1);
+    expect(editForm.prop("title")).to.equal("title");
+    expect(editForm.prop("roles")).to.equal(roles);
+    expect(editForm.prop("languages")).to.equal(languages);
+    expect(editForm.prop("media")).to.equal(media);
   });
 });

--- a/src/components/__tests__/BookEditForm-test.tsx
+++ b/src/components/__tests__/BookEditForm-test.tsx
@@ -42,7 +42,7 @@ describe("BookEditForm", () => {
     publisher: "publisher",
     imprint: "imprint",
     issued: "2017-04-03",
-    rating: 0.75,
+    rating: 4,
     editLink: {
       href: "href",
       rel: "edit"

--- a/src/components/__tests__/BookEditForm-test.tsx
+++ b/src/components/__tests__/BookEditForm-test.tsx
@@ -6,38 +6,67 @@ import { shallow, mount } from "enzyme";
 
 import BookEditForm from "../BookEditForm";
 import EditableInput from "../EditableInput";
-import { BookData } from "../../interfaces";
+import WithRemoveButton from "../WithRemoveButton";
+import Autocomplete from "../Autocomplete";
+import { BookData, RolesData, LanguagesData, MediaData } from "../../interfaces";
 
 describe("BookEditForm", () => {
+  let roles: RolesData = {
+    "aut": "Author",
+    "nar": "Narrator"
+  };
+
+  let languages: LanguagesData = {
+    "eng": ["English"],
+    "spa": ["Spanish"]
+  };
+
+  let media: MediaData = {
+    "http://schema.org/AudioObject": "Audio",
+    "http://schema.org/Book": "Book"
+  };
+
   let bookData: BookData = {
     title: "title",
     subtitle: "subtitle",
+    authors: [{ name: "An Author", role: "aut" }],
+    contributors: [{ name: "A Narrator", role: "nar" }, { name: "Another Narrator", role: "nar" }],
     fiction: true,
     audience: "Young Adult",
     targetAgeRange: ["12", "16"],
     summary: "summary",
     series: "series",
-    seriesPosition: "3",
+    seriesPosition: 3,
+    medium: "http://schema.org/AudioObject",
+    language: "eng",
+    publisher: "publisher",
+    imprint: "imprint",
+    issued: "2017-04-03",
+    rating: 0.75,
     editLink: {
       href: "href",
       rel: "edit"
     }
   };
 
+  let wrapper;
+  let editableInputByName = (name) => {
+    let inputs = wrapper.find(EditableInput);
+    return inputs.filterWhere(input => input.props().name === name);
+  };
+  let editableInputByValue = (value) => {
+    let inputs = wrapper.find(EditableInput);
+    return inputs.filterWhere(input => input.props().value === value);
+  };
+
   describe("rendering", () => {
-    let wrapper;
-    let editableInputByName = (name) => {
-      let inputs = wrapper.find(EditableInput);
-      return inputs.filterWhere(input => input.props().name === name);
-    };
-    let editableInputByValue = (value) => {
-      let inputs = wrapper.find(EditableInput);
-      return inputs.filterWhere(input => input.props().value === value);
-    };
     beforeEach(() => {
       wrapper = shallow(
         <BookEditForm
           {...bookData}
+          roles={roles}
+          languages={languages}
+          media={media}
           disabled={false}
           refresh={stub()}
           editBook={stub()}
@@ -57,6 +86,39 @@ describe("BookEditForm", () => {
       expect(input.props().value).to.equal("subtitle");
     });
 
+    it("shows authors and contributors", () => {
+      let contributorNames = editableInputByName("contributor-name");
+      let contributorRoles = editableInputByName("contributor-role");
+      expect(contributorNames.length).to.equal(4);
+      expect(contributorRoles.length).to.equal(4);
+      expect(contributorNames.at(0).props().value).to.equal("An Author");
+      expect(contributorRoles.at(0).props().value).to.equal("Author");
+      expect(contributorNames.at(1).props().value).to.equal("A Narrator");
+      expect(contributorRoles.at(1).props().value).to.equal("Narrator");
+      expect(contributorNames.at(2).props().value).to.equal("Another Narrator");
+      expect(contributorRoles.at(2).props().value).to.equal("Narrator");
+
+      // The last inputs are for adding a new contributor.
+      expect(contributorNames.at(3).props().value).to.be.undefined;
+      expect(contributorRoles.at(3).props().value).to.equal("Author");
+      let addButton = wrapper.find("button.add-contributor");
+      expect(addButton.length).to.equal(1);
+
+      // Existing authors and contributors are removable.
+      let removables = wrapper.find(WithRemoveButton);
+      expect(removables.length).to.equal(3);
+
+      // All roles inputs have the same options.
+      let roles = contributorRoles.at(1).find("option");
+      expect(roles.length).to.equal(2);
+      expect(roles.at(0).props().value).to.equal("Author");
+      expect(roles.at(1).props().value).to.equal("Narrator");
+      roles = contributorRoles.at(3).find("option");
+      expect(roles.length).to.equal(2);
+      expect(roles.at(0).props().value).to.equal("Author");
+      expect(roles.at(1).props().value).to.equal("Narrator");
+    });
+
     it("shows editable input with series", () => {
       let input = editableInputByName("series");
       expect(input.props().label).not.to.be.ok;
@@ -69,11 +131,128 @@ describe("BookEditForm", () => {
       expect(input.props().value).to.equal("3");
     });
 
+    it("shows editable input with medium", () => {
+      let input = editableInputByName("medium");
+      expect(input.props().label).to.equal("Medium");
+      expect(input.props().value).to.equal("Audio");
+    });
+
+    it("shows autocomplete with language", () => {
+      let autocomplete = wrapper.find(Autocomplete);
+      expect(autocomplete.props().name).to.equal("language");
+      expect(autocomplete.props().label).to.equal("Language");
+      expect(autocomplete.props().autocompleteValues).to.deep.equal(["English", "Spanish"]);
+      expect(autocomplete.props().value).to.equal("English");
+    });
+
+    it("shows editable input with publisher", () => {
+      let input = editableInputByName("publisher");
+      expect(input.props().label).to.equal("Publisher");
+      expect(input.props().value).to.equal("publisher");
+    });
+
+    it("shows editable input with imprint", () => {
+      let input = editableInputByName("imprint");
+      expect(input.props().label).to.equal("Imprint");
+      expect(input.props().value).to.equal("imprint");
+    });
+
+    it("shows editable input with publication date", () => {
+      let input = editableInputByName("issued");
+      expect(input.props().label).to.equal("Publication Date");
+      expect(input.props().value).to.equal("2017-04-03");
+    });
+
+    it("shows editbale input with rating", () => {
+      let input = editableInputByName("rating");
+      expect(input.props().label).to.contain("Rating");
+      expect(input.props().value).to.equal("4");
+    });
+
     it("shows editable textarea with summary", () => {
       let textarea = editableInputByName("summary");
       expect(textarea.prop("label")).to.equal("Summary");
       expect(textarea.prop("value")).to.equal("summary");
     });
+  });
+
+  it("removes a contributor", () => {
+    let editBook = stub();
+    wrapper = mount(
+      <BookEditForm
+        {...bookData}
+        roles={roles}
+        languages={languages}
+        media={media}
+        disabled={false}
+        refresh={stub()}
+        editBook={editBook}
+        />
+    );
+
+    let removables = wrapper.find(WithRemoveButton);
+    expect(removables.length).to.equal(3);
+    let firstNarrator = removables.at(1);
+    let onRemove = firstNarrator.prop("onRemove");
+    onRemove();
+
+    removables = wrapper.find(WithRemoveButton);
+    expect(removables.length).to.equal(2);
+
+    let contributorNames = editableInputByName("contributor-name");
+    let contributorRoles = editableInputByName("contributor-role");
+    expect(contributorNames.length).to.equal(3);
+    expect(contributorRoles.length).to.equal(3);
+    expect(contributorNames.at(0).props().value).to.equal("An Author");
+    expect(contributorRoles.at(0).props().value).to.equal("Author");
+    expect(contributorNames.at(1).props().value).to.equal("Another Narrator");
+    expect(contributorRoles.at(1).props().value).to.equal("Narrator");
+    expect(contributorNames.at(2).props().value).to.be.undefined;
+    expect(contributorRoles.at(2).props().value).to.equal("Author");
+  });
+
+  it("adds a contributor", () => {
+    let editBook = stub();
+    wrapper = mount(
+      <BookEditForm
+        {...bookData}
+        roles={roles}
+        languages={languages}
+        media={media}
+        disabled={false}
+        refresh={stub()}
+        editBook={editBook}
+        />
+    );
+
+    let contributorNames = editableInputByName("contributor-name");
+    let contributorRoles = editableInputByName("contributor-role");
+    expect(contributorNames.length).to.equal(4);
+    expect(contributorRoles.length).to.equal(4);
+
+    let addContributorName = contributorNames.at(3);
+    let addContributorRole = contributorRoles.at(3);
+    let addButton = wrapper.find("button.add-contributor");
+
+    addContributorName.get(0).setState({ value: "New Author" });
+    addContributorRole.get(0).setState({ value: "Author" });
+    addButton.simulate("click");
+
+    contributorNames = editableInputByName("contributor-name");
+    contributorRoles = editableInputByName("contributor-role");
+    expect(contributorNames.length).to.equal(5);
+    expect(contributorRoles.length).to.equal(5);
+
+    expect(contributorNames.at(0).props().value).to.equal("An Author");
+    expect(contributorRoles.at(0).props().value).to.equal("Author");
+    expect(contributorNames.at(1).props().value).to.equal("A Narrator");
+    expect(contributorRoles.at(1).props().value).to.equal("Narrator");
+    expect(contributorNames.at(2).props().value).to.equal("Another Narrator");
+    expect(contributorRoles.at(2).props().value).to.equal("Narrator");
+    expect(contributorNames.at(3).props().value).to.equal("New Author");
+    expect(contributorRoles.at(3).props().value).to.equal("Author");
+    expect(contributorNames.at(4).props().value).to.be.undefined;
+    expect(contributorRoles.at(4).props().value).to.equal("Author");
   });
 
   it("calls editBook on submit", () => {
@@ -84,7 +263,13 @@ describe("BookEditForm", () => {
         let elements = form.elements;
         for (let i = 0; i < elements.length; i++) {
           let element = elements[i];
-          this.data[element.name] = element.value;
+          if (!this.data[element.name]) {
+            this.data[element.name] = element.value;
+          } else if (typeof this.data[element.name] === "string") {
+            this.data[element.name] = [this.data[element.name], element.value];
+          } else {
+            this.data[element.name].push(element.value);
+          }
         }
       }
 
@@ -98,9 +283,12 @@ describe("BookEditForm", () => {
     let editBook = stub().returns(new Promise((resolve, reject) => {
       resolve();
     }));
-    let wrapper = mount(
+    wrapper = mount(
       <BookEditForm
         {...bookData}
+        roles={roles}
+        languages={languages}
+        media={media}
         disabled={false}
         refresh={stub()}
         editBook={editBook}
@@ -115,8 +303,20 @@ describe("BookEditForm", () => {
     expect(editBook.args[0][0]).to.equal("href");
     expect(editBook.args[0][1].get("title").value).to.equal(bookData.title);
     expect(editBook.args[0][1].get("subtitle").value).to.equal(bookData.subtitle);
+
+    // The last contributor field is the empty one for adding a new contributor.
+    // If the user had filled it in without clicking "Add", it would still be submitted.
+    expect(editBook.args[0][1].get("contributor-name").value).to.deep.equal(["An Author", "A Narrator", "Another Narrator", ""]);
+    expect(editBook.args[0][1].get("contributor-role").value).to.deep.equal(["Author", "Narrator", "Narrator", "Author"]);
+
     expect(editBook.args[0][1].get("series").value).to.equal(bookData.series);
-    expect(editBook.args[0][1].get("series_position").value).to.equal(bookData.seriesPosition);
+    expect(editBook.args[0][1].get("series_position").value).to.equal(String(bookData.seriesPosition));
+    expect(editBook.args[0][1].get("medium").value).to.equal("Audio");
+    expect(editBook.args[0][1].get("language").value).to.equal("English");
+    expect(editBook.args[0][1].get("publisher").value).to.equal(bookData.publisher);
+    expect(editBook.args[0][1].get("imprint").value).to.equal(bookData.imprint);
+    expect(editBook.args[0][1].get("issued").value).to.equal(bookData.issued);
+    expect(editBook.args[0][1].get("rating").value).to.equal("4");
     expect(editBook.args[0][1].get("summary").value).to.equal(bookData.summary);
   });
 
@@ -124,9 +324,12 @@ describe("BookEditForm", () => {
     let editBook = stub().returns(new Promise((resolve, reject) => {
       resolve();
     }));
-    let wrapper = mount(
+    wrapper = mount(
       <BookEditForm
         {...bookData}
+        roles={roles}
+        languages={languages}
+        media={media}
         disabled={false}
         refresh={done}
         editBook={editBook}
@@ -138,9 +341,12 @@ describe("BookEditForm", () => {
   });
 
   it("disables all inputs", () => {
-    let wrapper = shallow(
+    wrapper = shallow(
       <BookEditForm
         {...bookData}
+        roles={roles}
+        languages={languages}
+        media={media}
         disabled={true}
         refresh={stub()}
         editBook={stub()}
@@ -150,5 +356,7 @@ describe("BookEditForm", () => {
     inputs.forEach(input => {
       expect(input.prop("disabled")).to.equal(true);
     });
+    let autocomplete = wrapper.find(Autocomplete);
+    expect(autocomplete.prop("disabled")).to.equal(true);
   });
 });

--- a/src/editorAdapter.ts
+++ b/src/editorAdapter.ts
@@ -62,7 +62,7 @@ export default function adapter(data: OPDSEntry): BookData {
 
   let imprint;
   try {
-    imprint = data.unparsed["simplified:imprint"][0]["_"];
+    imprint = data.unparsed["bib:publisherImprint"][0]["_"];
   } catch (e) {
     imprint = null;
   }

--- a/src/editorAdapter.ts
+++ b/src/editorAdapter.ts
@@ -74,7 +74,13 @@ export default function adapter(data: OPDSEntry): BookData {
 
   let rating;
   try {
-    rating = data.unparsed["schema:Rating"][0]["$"]["schema:ratingValue"]["value"];
+    let ratings = data.unparsed["schema:Rating"];
+    for (let ratingTag of ratings) {
+      if (ratingTag["$"]["schema:additionalType"]["value"] === "http://schema.org/ratingValue") {
+        rating = ratingTag["$"]["schema:ratingValue"]["value"];
+        break;
+      }
+    }
   } catch (e) {
     rating = null;
   }

--- a/src/editorAdapter.ts
+++ b/src/editorAdapter.ts
@@ -53,25 +53,39 @@ export default function adapter(data: OPDSEntry): BookData {
     subtitle = null;
   };
 
-  let series;
+  let medium;
   try {
-    series = data.unparsed["schema:Series"][0]["$"]["name"]["value"];
+    medium = data.unparsed["$"]["schema:additionalType"]["value"];
   } catch (e) {
-    series = null;
+    medium = null;
   }
 
-  let seriesPosition;
+  let imprint;
   try {
-    seriesPosition = data.unparsed["schema:Series"][0]["$"]["schema:position"]["value"];
+    imprint = data.unparsed["simplified:imprint"][0]["_"];
   } catch (e) {
-    seriesPosition = null;
+    imprint = null;
+  }
+
+  let authors = [];
+  for (let author of data.authors) {
+    authors.push(Object.assign({}, author, { role: "aut" }));
+  }
+
+  let rating;
+  try {
+    rating = data.unparsed["schema:Rating"][0]["$"]["schema:ratingValue"]["value"];
+  } catch (e) {
+    rating = null;
   }
 
   return {
     title: data.title,
+    authors: authors,
+    contributors: data.contributors,
     subtitle: subtitle,
     summary: data.summary.content,
-    audience: audience.term,
+    audience: audience && audience.term,
     targetAgeRange: targetAgeRange,
     fiction: fiction,
     categories: categories,
@@ -80,7 +94,13 @@ export default function adapter(data: OPDSEntry): BookData {
     refreshLink: refreshLink,
     editLink: editLink,
     issuesLink: issuesLink,
-    series: series,
-    seriesPosition: seriesPosition
+    series: data.series && data.series.name,
+    seriesPosition: data.series && data.series.position,
+    medium: medium,
+    language: data.language,
+    publisher: data.publisher,
+    imprint: imprint,
+    issued: data.issued,
+    rating: rating
   };
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -11,12 +11,24 @@ export interface CategoryData {
   label: string;
 }
 
+export interface ContributorData {
+  name: string;
+  uri?: string;
+  role?: string;
+}
+
 export interface BookData {
   title: string;
+  authors?: ContributorData[];
+  contributors?: ContributorData[];
   subtitle?: string;
   fiction?: boolean;
   audience?: string;
   targetAgeRange?: string[];
+  medium?: string;
+  language?: string;
+  publisher?: string;
+  imprint?: string;
   summary?: string;
   hideLink?: LinkData;
   restoreLink?: LinkData;
@@ -25,7 +37,21 @@ export interface BookData {
   issuesLink?: LinkData;
   categories?: string[];
   series?: string;
-  seriesPosition?: string;
+  seriesPosition?: number;
+  issued?: string;
+  rating?: number;
+}
+
+export interface RolesData {
+  [key: string]: string;
+}
+
+export interface MediaData {
+  [key: string]: string;
+}
+
+export interface LanguagesData {
+  [key: string]: string[];
 }
 
 export interface BookLink {

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -21,6 +21,9 @@ import customLists from "./customLists";
 import lanes from "./lanes";
 import laneVisibility from "./laneVisibility";
 import resetLanes from "./resetLanes";
+import roles from "./roles";
+import media from "./media";
+import languages from "./languages";
 import collection, { CollectionState } from "opds-web-client/lib/reducers/collection";
 import { FetchEditState } from "./createFetchEditReducer";
 import {
@@ -28,7 +31,7 @@ import {
   PatronAuthServicesData, SitewideSettingsData, MetadataServicesData,
   AnalyticsServicesData, CDNServicesData, SearchServicesData,
   DiscoveryServicesData, LibraryRegistrationsData, CustomListsData,
-  LanesData
+  LanesData, RolesData, MediaData, LanguagesData
 } from "../interfaces";
 
 
@@ -56,6 +59,9 @@ export interface State {
   lanes: FetchEditState<LanesData>;
   laneVisibility: FetchEditState<void>;
   resetLanes: FetchEditState<void>;
+  roles: FetchEditState<RolesData>;
+  media: FetchEditState<MediaData>;
+  languages: FetchEditState<LanguagesData>;
 }
 
 export default combineReducers<State>({
@@ -81,5 +87,8 @@ export default combineReducers<State>({
   collection,
   lanes,
   laneVisibility,
-  resetLanes
+  resetLanes,
+  roles,
+  media,
+  languages
 });

--- a/src/reducers/languages.ts
+++ b/src/reducers/languages.ts
@@ -1,0 +1,5 @@
+import { LanguagesData } from "../interfaces";
+import ActionCreator from "../actions";
+import createFetchEditReducer from "./createFetchEditReducer";
+
+export default createFetchEditReducer<LanguagesData>(ActionCreator.LANGUAGES);

--- a/src/reducers/media.ts
+++ b/src/reducers/media.ts
@@ -1,0 +1,5 @@
+import { MediaData } from "../interfaces";
+import ActionCreator from "../actions";
+import createFetchEditReducer from "./createFetchEditReducer";
+
+export default createFetchEditReducer<MediaData>(ActionCreator.MEDIA);

--- a/src/reducers/roles.ts
+++ b/src/reducers/roles.ts
@@ -1,0 +1,5 @@
+import { RolesData } from "../interfaces";
+import ActionCreator from "../actions";
+import createFetchEditReducer from "./createFetchEditReducer";
+
+export default createFetchEditReducer<RolesData>(ActionCreator.ROLES);

--- a/src/stylesheets/edit_form.scss
+++ b/src/stylesheets/edit_form.scss
@@ -14,4 +14,22 @@
   textarea[name=summary] {
     height: 300px;
   }
+
+  .with-remove-button {
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-start;
+    align-items: baseline;
+  }
+
+  .contributor-form {
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-start;
+    align-items: baseline;
+
+    .form-group {
+      margin-right: 10px;
+    }
+  }
 }


### PR DESCRIPTION
This PR adds some outstanding metadata (authors, contributors, publisher, imprint, publication date, language, medium, and quality (sort of, staff can now put in a rating which affects quality)) to the book edit form. I think that covers everything librarians would need to edit.

For authors and contributors, name and role are editable, and role is a dropdown. Publisher and imprint are normal text fields. Publication date is a date picker. Language is a text field with autocomplete, which should work in most browsers except Safari. In Safari it's just a normal text field. Medium is a dropdown. Quality is a number from 1-5, although I'd like to come back to it and make it something nicer like stars sometime.

This depends on https://github.com/NYPL-Simplified/opds-feed-parser/pull/41 and https://github.com/NYPL-Simplified/opds-web-client/pull/214 and travis tests won't pass until those are merged and published.