### PR TITLE
Added tab on book details page for managing a book's list membership.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.0.52",
+  "version": "0.0.53",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -28,6 +28,8 @@ export default class ActionCreator extends BaseActionCreator {
   static readonly GENRE_TREE = "GENRE_TREE";
   static readonly CLASSIFICATIONS = "CLASSIFICATIONS";
   static readonly EDIT_CLASSIFICATIONS = "EDIT_CLASSIFICATIONS";
+  static readonly CUSTOM_LISTS_FOR_BOOK = "CUSTOM_LISTS_FOR_BOOK";
+  static readonly EDIT_CUSTOM_LISTS_FOR_BOOK = "EDIT_CUSTOM_LISTS_FOR_BOOK";
   static readonly CIRCULATION_EVENTS = "CIRCULATION_EVENTS";
   static readonly STATS = "STATS";
   static readonly LIBRARIES = "LIBRARIES";
@@ -285,6 +287,14 @@ export default class ActionCreator extends BaseActionCreator {
 
   fetchClassifications(url: string) {
     return this.fetchJSON<{ classifications: ClassificationData[] }>(ActionCreator.CLASSIFICATIONS, url).bind(this);
+  }
+
+  fetchCustomListsForBook(url: string) {
+    return this.fetchJSON<CustomListsData>(ActionCreator.CUSTOM_LISTS_FOR_BOOK, url).bind(this);
+  }
+
+  editCustomListsForBook(url: string, data: FormData) {
+    return this.postForm(ActionCreator.EDIT_CUSTOM_LISTS_FOR_BOOK, url, data).bind(this);
   }
 
   fetchCirculationEvents() {

--- a/src/components/Autocomplete.tsx
+++ b/src/components/Autocomplete.tsx
@@ -21,6 +21,7 @@ export default class Autocomplete extends React.Component<AutocompleteProps, voi
           list={this.props.name + "-autocomplete-list"}
           label={this.props.label}
           value={this.props.value}
+          ref="input"
           />
         <datalist
           id={this.props.name + "-autocomplete-list"}
@@ -32,5 +33,9 @@ export default class Autocomplete extends React.Component<AutocompleteProps, voi
         </datalist>
       </div>
     );
+  }
+
+  getValue() {
+    return (this.refs["input"] as any).getValue();
   }
 }

--- a/src/components/BookDetailsContainer.tsx
+++ b/src/components/BookDetailsContainer.tsx
@@ -9,6 +9,7 @@ export interface BookDetailsContainerContext {
   csrfToken: string;
   tab: string;
   editorStore: Store<State>;
+  library: (collectionUrl: string, bookUrl: string) => string;
 }
 
 /** Wrapper for `BookDetailsTabContainer` that extracts parameters from its context
@@ -20,7 +21,8 @@ export default class BookDetailsContainer extends React.Component<BookDetailsCon
   static contextTypes = {
     csrfToken: React.PropTypes.string.isRequired,
     tab: React.PropTypes.string,
-    editorStore: React.PropTypes.object.isRequired
+    editorStore: React.PropTypes.object.isRequired,
+    library: React.PropTypes.func.isRequired
   };
 
   render(): JSX.Element {
@@ -31,6 +33,7 @@ export default class BookDetailsContainer extends React.Component<BookDetailsCon
           collectionUrl={this.props.collectionUrl}
           refreshCatalog={this.props.refreshCatalog}
           tab={this.context.tab}
+          library={this.context.library}
           store={this.context.editorStore}
           csrfToken={this.context.csrfToken}>
           { this.props.children }

--- a/src/components/BookDetailsTabContainer.tsx
+++ b/src/components/BookDetailsTabContainer.tsx
@@ -6,6 +6,7 @@ import { connect } from "react-redux";
 import BookDetailsEditor from "./BookDetailsEditor";
 import Classifications from "./Classifications";
 import Complaints from "./Complaints";
+import CustomListsForBook from "./CustomListsForBook";
 import { BookData } from "../interfaces";
 import { TabContainer, TabContainerProps } from "./TabContainer";
 
@@ -16,6 +17,7 @@ export interface BookDetailsTabContainerProps extends TabContainerProps {
   refreshCatalog: () => Promise<any>;
   complaintsCount?: number;
   clearBook?: () => void;
+  library: (collectionUrl, bookUrl) => string;
 }
 
 /** Wraps the book details component from OPDSWebClient with additional tabs
@@ -63,6 +65,16 @@ export class BookDetailsTabContainer extends TabContainer<BookDetailsTabContaine
           bookUrl={this.props.bookUrl}
           book={this.props.bookData}
           refreshCatalog={this.props.refreshCatalog}
+          />
+      ),
+      lists: (
+        <CustomListsForBook
+          store={this.props.store}
+          csrfToken={this.props.csrfToken}
+          bookUrl={this.props.bookUrl}
+          book={this.props.bookData}
+          refreshCatalog={this.props.refreshCatalog}
+          library={this.props.library(this.props.collectionUrl, this.props.bookUrl)}
           />
       )
     };

--- a/src/components/CustomListsForBook.tsx
+++ b/src/components/CustomListsForBook.tsx
@@ -1,0 +1,202 @@
+import * as React from "react";
+import { Store } from "redux";
+import { connect } from "react-redux";
+import DataFetcher from "opds-web-client/lib/DataFetcher";
+import ActionCreator from "../actions";
+import ErrorMessage from "./ErrorMessage";
+import WithRemoveButton from "./WithRemoveButton";
+import Autocomplete from "./Autocomplete";
+import {
+  BookData, CustomListData, CustomListsData
+} from "../interfaces";
+import { FetchErrorData } from "opds-web-client/lib/interfaces";
+import { State } from "../reducers/index";
+
+export interface CustomListsForBookStateProps {
+  allCustomLists?: CustomListData[];
+  customListsForBook?: CustomListData[];
+  fetchError?: FetchErrorData;
+  isFetching?: boolean;
+}
+
+export interface CustomListsForBookDispatchProps {
+  fetchAllCustomLists?: () => Promise<CustomListsData>;
+  fetchCustomListsForBook?: (url: string) => Promise<CustomListsData>;
+  editCustomListsForBook?: (url: string, data: FormData) => Promise<void>;
+}
+
+export interface CustomListsForBookOwnProps {
+  bookUrl: string;
+  book: BookData;
+  library: string;
+  store?: Store<State>;
+  csrfToken: string;
+  refreshCatalog: () => Promise<any>;
+}
+
+export interface CustomListsForBookProps extends CustomListsForBookStateProps, CustomListsForBookDispatchProps, CustomListsForBookOwnProps {};
+
+export interface CustomListsForBookState {
+  customLists: CustomListData[];
+}
+
+/** Tab on the book details page that shows custom lists a book is on and lets
+    an admin add the book to lists or remove the book from lists. */
+export class CustomListsForBook extends React.Component<CustomListsForBookProps, CustomListsForBookState> {
+  constructor(props) {
+    super(props);
+    this.state = {
+      customLists: this.props.customListsForBook || []
+    };
+    this.refresh = this.refresh.bind(this);
+    this.addList = this.addList.bind(this);
+  }
+
+  render(): JSX.Element {
+    return (
+      <div>
+        { this.props.book &&
+          <h2>{this.props.book.title}</h2>
+        }
+        <h3>Lists</h3>
+        { this.props.fetchError &&
+          <ErrorMessage error={this.props.fetchError} tryAgain={this.refresh} />
+        }
+
+        { this.state.customLists && this.state.customLists.map(list =>
+            <WithRemoveButton
+              key={list.id}
+              disabled={this.props.isFetching}
+              onRemove={() => this.removeList(list) }
+              >
+              <h4>
+                { list.id ?
+                  <a href={"/admin/web/lists/" + this.props.library + "/edit/" + list.id}>
+                    {list.name}
+                  </a> :
+                  list.name
+                }
+              </h4>
+            </WithRemoveButton>
+          )
+        }
+
+        { this.availableLists().length > 0 &&
+          <div>
+            <Autocomplete
+              autocompleteValues={this.availableLists().map(list => list.name)}
+              disabled={this.props.isFetching}
+              name="list"
+              label="Add a list"
+              value=""
+              ref="addList"
+              />
+            <button
+              className="btn btn-default"
+              onClick={this.addList}
+              >Add</button>
+          </div>
+        }
+      </div>
+    );
+  }
+
+  availableLists(): CustomListData[] {
+    const availableLists = [];
+    for (const list of (this.props.allCustomLists || [])) {
+      let inStateLists = false;
+      for (const stateList of this.state.customLists) {
+        if (stateList.id === list.id) {
+          inStateLists = true;
+          break;
+        }
+      }
+      if (!inStateLists) {
+        availableLists.push(list);
+      }
+    }
+    return availableLists;
+  }
+
+  addList() {
+    const lists = this.state.customLists.slice(0);
+    const newListName = (this.refs["addList"] as Autocomplete).getValue();
+    const newList: CustomListData = { name : newListName };
+    for (const list of this.props.allCustomLists) {
+      if (list.name === newListName) {
+        newList.id = list.id;
+        break;
+      }
+    }
+    lists.push(newList);
+    this.setState({ customLists: lists });
+    this.save(lists);
+  }
+
+  removeList(list: CustomListData) {
+    const newLists = [];
+    for (const stateList of this.state.customLists) {
+      if (stateList.id !== list.id) {
+        newLists.push(stateList);
+      }
+    }
+    this.setState({ customLists: newLists });
+    this.save(newLists);
+  }
+
+  componentWillMount() {
+    if (this.props.bookUrl) {
+      this.props.fetchCustomListsForBook(this.listsUrl());
+      this.props.fetchAllCustomLists();
+    }
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if ((this.props.bookUrl !== nextProps.bookUrl) || (!this.props.customListsForBook && nextProps.customListsForBook)) {
+      this.setState({ customLists: nextProps.customListsForBook });
+    }
+  }
+
+  listsUrl() {
+    return this.props.bookUrl.replace("works", "admin/works") + "/lists";
+  }
+
+  refresh() {
+    this.props.fetchAllCustomLists();
+    this.props.fetchCustomListsForBook(this.listsUrl());
+    this.props.refreshCatalog();
+  }
+
+  save(lists: CustomListData[]) {
+    let url = this.listsUrl();
+    let data = new (window as any).FormData();
+    data.append("lists", JSON.stringify(lists));
+    return this.props.editCustomListsForBook(url, data).then(this.refresh);
+  }
+}
+
+function mapStateToProps(state, ownProps) {
+  return {
+    allCustomLists: state.editor.customLists.data && state.editor.customLists.data.custom_lists,
+    customListsForBook: state.editor.customListsForBook.data && state.editor.customListsForBook.data.custom_lists,
+    isFetching: state.editor.customListsForBook.isFetching,
+    fetchError: state.editor.customListsForBook.fetchError
+  };
+}
+
+function mapDispatchToProps(dispatch, ownProps) {
+  let fetcher = new DataFetcher();
+  let actions = new ActionCreator(fetcher, ownProps.csrfToken);
+  return {
+    fetchAllCustomLists: () => dispatch(actions.fetchCustomLists(ownProps.library)),
+    fetchCustomListsForBook: (url) => dispatch(actions.fetchCustomListsForBook(url)),
+    editCustomListsForBook: (url, data) => dispatch(actions.editCustomListsForBook(url, data))
+  };
+}
+
+const ConnectedCustomListsForBook = connect<CustomListsForBookStateProps, CustomListsForBookDispatchProps, CustomListsForBookOwnProps>(
+  mapStateToProps,
+  mapDispatchToProps
+)(CustomListsForBook);
+
+export default ConnectedCustomListsForBook;

--- a/src/components/__tests__/Autocomplete-test.tsx
+++ b/src/components/__tests__/Autocomplete-test.tsx
@@ -2,7 +2,7 @@ import { expect } from "chai";
 import { stub } from "sinon";
 
 import * as React from "react";
-import { shallow } from "enzyme";
+import { shallow, mount } from "enzyme";
 
 import Autocomplete from "../Autocomplete";
 import EditableInput from "../EditableInput";
@@ -44,6 +44,23 @@ describe("Autocomplete", () => {
       expect(options.at(0).props().value).to.equal("a");
       expect(options.at(1).props().value).to.equal("b");
       expect(options.at(2).props().value).to.equal("c");
+    });
+  });
+
+  describe("behavior", () => {
+    it("returns value", () => {
+      wrapper = mount(
+        <Autocomplete
+          autocompleteValues={autocompleteValues}
+          disabled={false}
+          name="test"
+          label="Test"
+          value="b"
+          />
+      );
+      let getValueStub = stub(EditableInput.prototype, "getValue").returns("test value");
+      expect((wrapper.instance() as Autocomplete).getValue()).to.equal("test value");
+      getValueStub.restore();
     });
   });
 });

--- a/src/components/__tests__/BookDetailsContainer-test.tsx
+++ b/src/components/__tests__/BookDetailsContainer-test.tsx
@@ -24,7 +24,8 @@ describe("BookDetailsContainer", () => {
     context = {
       editorStore: store,
       tab: "tab",
-      csrfToken: "token"
+      csrfToken: "token",
+      library: stub()
     };
     refreshCatalog = stub();
 
@@ -46,6 +47,7 @@ describe("BookDetailsContainer", () => {
     expect(tabContainer.props().bookUrl).to.equal("book url");
     expect(tabContainer.props().collectionUrl).to.equal("collection url");
     expect(tabContainer.props().tab).to.equal("tab");
+    expect(tabContainer.props().library).to.equal(context.library);
     expect(tabContainer.props().csrfToken).to.equal("token");
     expect(tabContainer.props().refreshCatalog).to.equal(refreshCatalog);
     expect(tabContainer.props().store).to.equal(store);

--- a/src/components/__tests__/BookDetailsTabContainer-test.tsx
+++ b/src/components/__tests__/BookDetailsTabContainer-test.tsx
@@ -9,6 +9,7 @@ import { BookDetailsTabContainer } from "../BookDetailsTabContainer";
 import BookDetailsEditor from "../BookDetailsEditor";
 import Classifications from "../Classifications";
 import Complaints from "../Complaints";
+import CustomListsForBook from "../CustomListsForBook";
 import { mockRouterContext } from "./routing";
 
 
@@ -30,6 +31,7 @@ describe("BookDetailsTabContainer", () => {
         csrfToken="token"
         refreshCatalog={stub()}
         store={store}
+        library={(a,b) => "library"}
         >
         <div className="bookDetails">Moby Dick</div>
       </BookDetailsTabContainer>,
@@ -65,6 +67,12 @@ describe("BookDetailsTabContainer", () => {
   it("shows Complaints", () => {
     let complaints = wrapper.find(Complaints);
     expect(complaints.props().bookUrl).to.equal("book url");
+  });
+
+  it("shows lists", () => {
+    let lists = wrapper.find(CustomListsForBook);
+    expect(lists.props().bookUrl).to.equal("book url");
+    expect(lists.props().library).to.equal("library");
   });
 
   it("uses router to navigate when tab is clicked", () => {

--- a/src/components/__tests__/CustomListsForBook-test.tsx
+++ b/src/components/__tests__/CustomListsForBook-test.tsx
@@ -1,0 +1,201 @@
+import { expect } from "chai";
+import { stub } from "sinon";
+
+import * as React from "react";
+import { shallow, mount } from "enzyme";
+import { CustomListsForBook } from "../CustomListsForBook";
+import ErrorMessage from "../ErrorMessage";
+import WithRemoveButton from "../WithRemoveButton";
+import Autocomplete from "../Autocomplete";
+
+describe("CustomListsForBook", () => {
+  let wrapper;
+  let fetchAllCustomLists;
+  let fetchCustomListsForBook;
+  let editCustomListsForBook;
+  let refreshCatalog;
+  let bookData = {
+    title: "test title"
+  };
+  let allCustomLists = [
+    { id: "1", name: "list 1"},
+    { id: "2", name: "list 2"},
+    { id: "3", name: "list 3"}
+  ];
+  let customListsForBook = [
+    { id: "2", name: "list 2"}
+  ];
+
+  beforeEach(() => {
+    fetchAllCustomLists = stub();
+    fetchCustomListsForBook = stub();
+    editCustomListsForBook = stub().returns(new Promise<void>(resolve => resolve()));
+    refreshCatalog = stub();
+    wrapper = shallow(
+      <CustomListsForBook
+        csrfToken="token"
+        book={bookData}
+        bookUrl="works/book url"
+        library="library"
+        allCustomLists={allCustomLists}
+        customListsForBook={customListsForBook}
+        fetchAllCustomLists={fetchAllCustomLists}
+        fetchCustomListsForBook={fetchCustomListsForBook}
+        editCustomListsForBook={editCustomListsForBook}
+        refreshCatalog={refreshCatalog}
+        />
+    );
+  });
+
+  describe("rendering", () => {
+    it("shows error message", () => {
+      let error = wrapper.find(ErrorMessage);
+      expect(error.length).to.equal(0);
+
+      wrapper.setProps({ fetchError: { error: "error" }});
+      error = wrapper.find(ErrorMessage);
+      expect(error.length).to.equal(1);
+    });
+
+    it("shows book title", () => {
+      let title = wrapper.find("h2");
+      expect(title.text()).to.equal("test title");
+    });
+
+    it("shows current lists", () => {
+      let removable = wrapper.find(WithRemoveButton);
+      expect(removable.length).to.equal(1);
+
+      let link = wrapper.find("a");
+      expect(link.length).to.equal(1);
+      expect(link.props().href).to.equal("/admin/web/lists/library/edit/2");
+      expect(link.text()).to.equal("list 2");
+    });
+
+    it("shows available lists", () => {
+      let autocomplete = wrapper.find(Autocomplete);
+      expect(autocomplete.length).to.equal(1);
+      let availableLists = autocomplete.props().autocompleteValues;
+      expect(availableLists).to.deep.equal(["list 1", "list 3"]);
+
+      let button = wrapper.find("button");
+      expect(button.length).to.equal(1);
+      expect(button.text()).to.contain("Add");
+    });
+
+    it("disables while fetching", () => {
+      wrapper.setProps({ isFetching: true });
+      let removable = wrapper.find(WithRemoveButton);
+      expect(removable.props().disabled).to.equal(true);
+      let autocomplete = wrapper.find(Autocomplete);
+      expect(autocomplete.props().disabled).to.equal(true);
+    });
+  });
+
+  describe("behavior", () => {
+    it("fetches lists on mount", () => {
+      expect(refreshCatalog.callCount).to.equal(0);
+      expect(fetchAllCustomLists.callCount).to.equal(1);
+      expect(fetchCustomListsForBook.callCount).to.equal(1);
+      expect(fetchCustomListsForBook.args[0][0]).to.equal("admin/works/book url/lists");
+    });
+
+    it("adds a list", () => {
+      let autocompleteStub = stub(Autocomplete.prototype, "getValue");
+
+      wrapper = mount(
+        <CustomListsForBook
+          csrfToken="token"
+          book={bookData}
+          bookUrl="works/book url"
+          library="library"
+          allCustomLists={allCustomLists}
+          customListsForBook={customListsForBook}
+          fetchAllCustomLists={fetchAllCustomLists}
+          fetchCustomListsForBook={fetchCustomListsForBook}
+          editCustomListsForBook={editCustomListsForBook}
+          refreshCatalog={refreshCatalog}
+          />
+      );
+      // Add one of the existing lists.
+      autocompleteStub.returns("list 1");
+      let addButton = wrapper.find("button");
+      addButton.simulate("click");
+
+      let removables = wrapper.find(WithRemoveButton);
+      expect(removables.length).to.equal(2);
+
+      let links = wrapper.find("h4 a");
+      expect(links.length).to.equal(2);
+      expect(links.at(0).props().href).to.equal("/admin/web/lists/library/edit/2");
+      expect(links.at(0).text()).to.equal("list 2");
+      expect(links.at(1).props().href).to.equal("/admin/web/lists/library/edit/1");
+      expect(links.at(1).text()).to.equal("list 1");
+
+      expect(editCustomListsForBook.callCount).to.equal(1);
+      expect(editCustomListsForBook.args[0][0]).to.equal("admin/works/book url/lists");
+      let formData = editCustomListsForBook.args[0][1];
+      expect(JSON.parse(formData.get("lists"))).to.deep.equal([allCustomLists[1], allCustomLists[0]]);
+
+      // Also add a new list.
+      autocompleteStub.returns("new list");
+      addButton.simulate("click");
+
+      removables = wrapper.find(WithRemoveButton);
+      expect(removables.length).to.equal(3);
+
+      // The new list doesn't get a link since it doesn't have its own page yet.
+      links = wrapper.find("h4 a");
+      expect(links.length).to.equal(2);
+      expect(links.at(0).props().href).to.equal("/admin/web/lists/library/edit/2");
+      expect(links.at(0).text()).to.equal("list 2");
+      expect(links.at(1).props().href).to.equal("/admin/web/lists/library/edit/1");
+      expect(links.at(1).text()).to.equal("list 1");
+
+      // But it's still in the list.
+      let listNames = wrapper.find("h4");
+      expect(listNames.length).to.equal(3);
+      expect(listNames.at(2).text()).to.equal("new list");
+
+      expect(editCustomListsForBook.callCount).to.equal(2);
+      expect(editCustomListsForBook.args[1][0]).to.equal("admin/works/book url/lists");
+      formData = editCustomListsForBook.args[1][1];
+      expect(JSON.parse(formData.get("lists"))).to.deep.equal(
+        [allCustomLists[1], allCustomLists[0], { name: "new list" }]);
+
+      autocompleteStub.restore();
+    });
+
+    it("removes a list", () => {
+      wrapper = mount(
+        <CustomListsForBook
+          csrfToken="token"
+          book={bookData}
+          bookUrl="works/book url"
+          library="library"
+          allCustomLists={allCustomLists}
+          customListsForBook={customListsForBook}
+          fetchAllCustomLists={fetchAllCustomLists}
+          fetchCustomListsForBook={fetchCustomListsForBook}
+          editCustomListsForBook={editCustomListsForBook}
+          refreshCatalog={refreshCatalog}
+          />
+      );
+
+      let removable = wrapper.find(WithRemoveButton);
+      expect(removable.length).to.equal(1);
+      let removeButton = removable.find(".remove");
+      removeButton.simulate("click");
+
+      let removables = wrapper.find(WithRemoveButton);
+      expect(removables.length).to.equal(0);
+      let links = wrapper.find("a");
+      expect(links.length).to.equal(0);
+
+      expect(editCustomListsForBook.callCount).to.equal(1);
+      expect(editCustomListsForBook.args[0][0]).to.equal("admin/works/book url/lists");
+      let formData = editCustomListsForBook.args[0][1];
+      expect(JSON.parse(formData.get("lists"))).to.deep.equal([]);
+    });
+  });
+});

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -281,9 +281,9 @@ export interface CustomListEntryData {
 }
 
 export interface CustomListData {
-  id: string | number;
+  id?: string | number;
   name: string;
-  entries: CustomListEntryData[];
+  entries?: CustomListEntryData[];
 }
 
 export interface CustomListsData {

--- a/src/reducers/__tests__/createFetchEditReducer-test.ts
+++ b/src/reducers/__tests__/createFetchEditReducer-test.ts
@@ -52,10 +52,24 @@ describe("fetch-edit reducer", () => {
     // start with error state
     newState = Object.assign({}, errorState, {
       isFetching: true,
+      isLoaded: false,
       fetchError: null
     });
     expect(reducer(errorState, action)).to.deep.equal(newState);
     expect(fetchOnlyReducer(errorState, action)).to.deep.equal(newState);
+
+    // start with loaded state
+    let loadedState = Object.assign({}, initState, {
+      data: testData,
+      isLoaded: true
+    });
+    newState = Object.assign({}, loadedState, {
+      data: null,
+      isLoaded: false,
+      isFetching: true
+    });
+    expect(reducer(loadedState, action)).to.deep.equal(newState);
+    expect(fetchOnlyReducer(loadedState, action)).to.deep.equal(newState);
   });
 
   it("handles fetch failure", () => {

--- a/src/reducers/createFetchEditReducer.ts
+++ b/src/reducers/createFetchEditReducer.ts
@@ -28,6 +28,8 @@ export default<T> (fetchPrefix: string, editPrefix?: string): FetchEditReducer<T
     switch (action.type) {
       case `${fetchPrefix}_${ActionCreator.REQUEST}`:
         return Object.assign({}, state, {
+          data: null,
+          isLoaded: false,
           isFetching: true,
           fetchError: null
         });

--- a/src/reducers/customListsForBook.ts
+++ b/src/reducers/customListsForBook.ts
@@ -1,0 +1,5 @@
+import { CustomListsData } from "../interfaces";
+import ActionCreator from "../actions";
+import createFetchEditReducer from "./createFetchEditReducer";
+
+export default createFetchEditReducer<CustomListsData>(ActionCreator.CUSTOM_LISTS_FOR_BOOK, ActionCreator.EDIT_CUSTOM_LISTS_FOR_BOOK);

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -2,6 +2,7 @@ import { combineReducers } from "redux";
 import book, { BookState } from "./book";
 import complaints, { ComplaintsState } from "./complaints";
 import classifications, { ClassificationsState } from "./classifications";
+import customListsForBook from "./customListsForBook";
 import circulationEvents, { CirculationEventsState } from "./circulationEvents";
 import stats, { StatsState } from "./stats";
 import libraries from "./libraries";
@@ -39,6 +40,7 @@ export interface State {
   book: BookState;
   complaints: ComplaintsState;
   classifications: ClassificationsState;
+  customListsForBook: FetchEditState<CustomListsData>;
   circulationEvents: CirculationEventsState;
   stats: StatsState;
   libraries: FetchEditState<LibrariesData>;
@@ -68,6 +70,7 @@ export default combineReducers<State>({
   book,
   complaints,
   classifications,
+  customListsForBook,
   circulationEvents,
   stats,
   libraries,


### PR DESCRIPTION
The idea is to let librarians/curators coordinate their work by making a list like "needs review". Once a librarian has reviewed a book they will remove it from the "needs review" list and possibly add it to a list that controls a lane. It's hard to do this from the list page since the list may have a large number of books. So this adds a way to do it right from the book page.

I'm not sure it belongs on its own tab, but it would be harder to put it on the details tab and I'm not sure if that's actually better.
