### PR TITLE
Made it possible to associate collections with a custom list.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.0.53",
+  "version": "0.0.54",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/components/CustomListEditor.tsx
+++ b/src/components/CustomListEditor.tsx
@@ -179,16 +179,12 @@ export default class CustomListEditor extends React.Component<CustomListEditorPr
   }
 
   changeCollection(collection: AdminCollectionData) {
-    let hadCollection = false;
-    const newCollections = [];
-    for (const stateCollection of this.state.collections) {
-      if (stateCollection.id === collection.id) {
-        hadCollection = true;
-      } else {
-        newCollections.push(stateCollection);
-      }
-    }
-    if (!hadCollection) {
+    const hasCollection = this.hasCollection(collection);
+    let newCollections;
+    if (hasCollection) {
+      newCollections = this.state.collections.filter(stateCollection => stateCollection.id !== collection.id);
+    } else {
+      newCollections = this.state.collections.slice(0);
       newCollections.push(collection);
     }
     this.setState({ name: this.state.name, entries: this.state.entries, collections: newCollections });

--- a/src/components/CustomListEditor.tsx
+++ b/src/components/CustomListEditor.tsx
@@ -1,7 +1,8 @@
 import * as React from "react";
-import { CustomListData, CustomListEntryData } from "../interfaces";
+import { CustomListData, CustomListEntryData, CollectionData as AdminCollectionData } from "../interfaces";
 import { CollectionData } from "opds-web-client/lib/interfaces";
 import TextWithEditMode from "./TextWithEditMode";
+import EditableInput from "./EditableInput";
 import CustomListEntriesEditor from "./CustomListEntriesEditor";
 import XCloseIcon from "./icons/XCloseIcon";
 import SearchIcon from "./icons/SearchIcon";
@@ -9,6 +10,7 @@ import SearchIcon from "./icons/SearchIcon";
 export interface CustomListEditorProps extends React.Props<CustomListEditor> {
   library: string;
   list?: CustomListData;
+  collections?: AdminCollectionData[];
   editedIdentifier?: string;
   searchResults?: CollectionData;
   editCustomList: (data: FormData) => Promise<void>;
@@ -20,6 +22,7 @@ export interface CustomListEditorProps extends React.Props<CustomListEditor> {
 export interface CustomListEditorState {
   name: string;
   entries: CustomListEntryData[];
+  collections: AdminCollectionData[];
 }
 
 /** Right panel of the lists page for editing a single list. */
@@ -28,7 +31,8 @@ export default class CustomListEditor extends React.Component<CustomListEditorPr
     super(props);
     this.state = {
       name: this.props.list && this.props.list.name,
-      entries: this.props.list && this.props.list.entries || []
+      entries: (this.props.list && this.props.list.entries) || [],
+      collections: (this.props.list && this.props.list.collections) || []
     };
 
     this.changeName = this.changeName.bind(this);
@@ -51,6 +55,25 @@ export default class CustomListEditor extends React.Component<CustomListEditorPr
               />
             { this.props.list &&
               <h4>ID-{this.props.list.id}</h4>
+            }
+            { this.props.collections && this.props.collections.length &&
+              <div>
+                <span>Automatically add new books from these collections to this list:</span>
+                <div className="collections">
+                  { this.props.collections.map(collection =>
+                      <EditableInput
+                        key={collection.id}
+                        type="checkbox"
+                        name="collection"
+                        checked={this.hasCollection(collection)}
+                        label={collection.name}
+                        value={String(collection.id)}
+                        onChange={() => {this.changeCollection(collection);}}
+                        />
+                    )
+                  }
+                </div>
+              </div>
             }
           </div>
           <span>
@@ -101,7 +124,8 @@ export default class CustomListEditor extends React.Component<CustomListEditorPr
     if (this.props.list && (!nextProps.list || nextProps.list.id !== this.props.list.id)) {
       this.setState({
         name: nextProps.list && nextProps.list.name,
-        entries: nextProps.list && nextProps.list.entries
+        entries: (nextProps.list && nextProps.list.entries) || [],
+        collections: (nextProps.list && nextProps.list.collections) || []
       });
     }
   }
@@ -112,7 +136,7 @@ export default class CustomListEditor extends React.Component<CustomListEditorPr
     if (this.props.list && this.props.list.entries.length !== this.state.entries.length) {
       entriesChanged = true;
     } else {
-      let propsPwids = (this.props.list && this.props.list.entries || []).map(entry => entry.pwid).sort();
+      let propsPwids = ((this.props.list && this.props.list.entries) || []).map(entry => entry.pwid).sort();
       let statePwids = this.state.entries.map(entry => entry.pwid).sort();
       for (let i = 0; i < propsPwids.length; i++) {
         if (propsPwids[i] !== statePwids[i]) {
@@ -121,15 +145,53 @@ export default class CustomListEditor extends React.Component<CustomListEditorPr
         }
       }
     }
-    return nameChanged || entriesChanged;
+    let collectionsChanged = false;
+    if (this.props.list && this.props.list.collections && this.props.list.collections.length !== this.state.collections.length) {
+      collectionsChanged = true;
+    } else {
+      let propsIds = ((this.props.list && this.props.list.collections) || []).map(collection => collection.id).sort();
+      let stateIds = this.state.collections.map(collection => collection.id).sort();
+      for (let i = 0; i < propsIds.length; i++) {
+        if (propsIds[i] !== stateIds[i]) {
+          collectionsChanged = true;
+          break;
+        }
+      }
+    }
+    return nameChanged || entriesChanged || collectionsChanged;
   }
 
   changeName(name: string) {
-    this.setState({ name, entries: this.state.entries });
+    this.setState({ name, entries: this.state.entries, collections: this.state.collections });
   }
 
   changeEntries(entries: CustomListEntryData[]) {
-    this.setState({ entries, name: this.state.name });
+    this.setState({ entries, name: this.state.name, collections: this.state.collections });
+  }
+
+  hasCollection(collection: AdminCollectionData) {
+    for (const stateCollection of this.state.collections) {
+      if (stateCollection.id === collection.id) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  changeCollection(collection: AdminCollectionData) {
+    let hadCollection = false;
+    const newCollections = [];
+    for (const stateCollection of this.state.collections) {
+      if (stateCollection.id === collection.id) {
+        hadCollection = true;
+      } else {
+        newCollections.push(stateCollection);
+      }
+    }
+    if (!hadCollection) {
+      newCollections.push(collection);
+    }
+    this.setState({ name: this.state.name, entries: this.state.entries, collections: newCollections });
   }
 
   save() {
@@ -141,6 +203,8 @@ export default class CustomListEditor extends React.Component<CustomListEditorPr
     data.append("name", name);
     let entries = (this.refs["listEntries"] as CustomListEntriesEditor).getEntries();
     data.append("entries", JSON.stringify(entries));
+    let collections = this.state.collections.map(collection => collection.id);
+    data.append("collections", JSON.stringify(collections));
     this.props.editCustomList(data).then(() => {
       // If a new list was created, go to the new list's edit page.
       if (!this.props.list && this.props.editedIdentifier) {
@@ -152,6 +216,11 @@ export default class CustomListEditor extends React.Component<CustomListEditorPr
   reset() {
     (this.refs["listName"] as TextWithEditMode).reset();
     (this.refs["listEntries"] as CustomListEntriesEditor).reset();
+    this.setState({
+      name: this.state.name,
+      entries: this.state.entries,
+      collections: (this.props.list && this.props.list.collections) || []
+    });
   }
 
   search(event) {

--- a/src/components/__tests__/CustomLists-test.tsx
+++ b/src/components/__tests__/CustomLists-test.tsx
@@ -18,10 +18,12 @@ describe("CustomLists", () => {
   let deleteCustomList;
   let search;
   let loadMoreSearchResults;
+  let fetchCollections;
 
   let listsData = [
-    { id: 1, name: "a list", entries: [] },
-    { id: 2, name: "z list", entries: [{ pwid: "1", title: "title", authors: [] }] }
+    { id: 1, name: "a list", entries: [], collections: [] },
+    { id: 2, name: "z list", entries: [{ pwid: "1", title: "title", authors: [] }],
+      collections: [{id: 3, name: "collection 3", protocol: "protocol" }] }
   ];
 
   let searchResults = {
@@ -33,12 +35,19 @@ describe("CustomLists", () => {
     navigationLinks: []
   };
 
+  let collections = [
+    { id: 1, name: "collection 1", protocol: "protocol", libraries: [{ short_name: "other library" }] },
+    { id: 2, name: "collection 2", protocol: "protocol", libraries: [{ short_name: "library" }] },
+    { id: 3, name: "collection 3", protocol: "protocol", libraries: [{ short_name: "library" }] }
+  ];
+
   beforeEach(() => {
     fetchCustomLists = stub();
     editCustomList = stub().returns(new Promise<void>(resolve => resolve()));
     deleteCustomList = stub().returns(new Promise<void>(resolve => resolve()));
     search = stub();
     loadMoreSearchResults = stub();
+    fetchCollections = stub();
 
     wrapper = shallow(
       <CustomLists
@@ -46,6 +55,7 @@ describe("CustomLists", () => {
         library="library"
         lists={listsData}
         searchResults={searchResults}
+        collections={collections}
         isFetching={false}
         isFetchingMoreSearchResults={false}
         fetchCustomLists={fetchCustomLists}
@@ -53,6 +63,7 @@ describe("CustomLists", () => {
         deleteCustomList={deleteCustomList}
         search={search}
         loadMoreSearchResults={loadMoreSearchResults}
+        fetchCollections={fetchCollections}
         />
     );
   });
@@ -107,6 +118,7 @@ describe("CustomLists", () => {
         library="library"
         lists={undefined}
         searchResults={searchResults}
+        collections={collections}
         isFetching={false}
         isFetchingMoreSearchResults={false}
         fetchCustomLists={fetchCustomLists}
@@ -114,6 +126,7 @@ describe("CustomLists", () => {
         deleteCustomList={deleteCustomList}
         search={search}
         loadMoreSearchResults={loadMoreSearchResults}
+        fetchCollections={fetchCollections}
         />
     );
     wrapper.setProps({ lists: [] });
@@ -125,6 +138,7 @@ describe("CustomLists", () => {
         library="library"
         lists={undefined}
         searchResults={searchResults}
+        collections={collections}
         isFetching={false}
         isFetchingMoreSearchResults={false}
         fetchCustomLists={fetchCustomLists}
@@ -132,6 +146,7 @@ describe("CustomLists", () => {
         deleteCustomList={deleteCustomList}
         search={search}
         loadMoreSearchResults={loadMoreSearchResults}
+        fetchCollections={fetchCollections}
         />
     );
     wrapper.setProps({ lists: listsData });
@@ -146,6 +161,7 @@ describe("CustomLists", () => {
         library="library"
         lists={listsData}
         searchResults={searchResults}
+        collections={collections}
         isFetching={false}
         isFetchingMoreSearchResults={false}
         fetchCustomLists={fetchCustomLists}
@@ -153,6 +169,7 @@ describe("CustomLists", () => {
         deleteCustomList={deleteCustomList}
         search={search}
         loadMoreSearchResults={loadMoreSearchResults}
+        fetchCollections={fetchCollections}
         />
     );
     let radioButtons = wrapper.find(EditableInput);
@@ -263,6 +280,7 @@ describe("CustomLists", () => {
     expect(editor.props().searchResults).to.equal(searchResults);
     expect(editor.props().editedIdentifier).to.be.undefined;
     expect(editor.props().isFetchingMoreSearchResults).to.equal(false);
+    expect(editor.props().collections).to.deep.equal([collections[1], collections[2]]);
 
     expect(fetchCustomLists.callCount).to.equal(1);
     let editCustomListProp = editor.props().editCustomList;
@@ -288,5 +306,6 @@ describe("CustomLists", () => {
     expect(editor.props().loadMoreSearchResults).to.equal(loadMoreSearchResults);
     expect(editor.props().searchResults).to.equal(searchResults);
     expect(editor.props().isFetchingMoreSearchResults).to.equal(false);
+    expect(editor.props().collections).to.deep.equal([collections[1], collections[2]]);
   });
 });

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -284,6 +284,7 @@ export interface CustomListData {
   id?: string | number;
   name: string;
   entries?: CustomListEntryData[];
+  collections?: CollectionData[];
 }
 
 export interface CustomListsData {

--- a/src/stylesheets/custom_list_editor.scss
+++ b/src/stylesheets/custom_list_editor.scss
@@ -30,6 +30,12 @@
       color: lighten($pagetextcolor, 40%);
     }
 
+    .collections .form-group {
+      float: left;
+      margin-right: 15px;
+      margin-bottom: 2px;
+    }
+
     a {
       margin-left: 5px;
       font-size: 0.7em;


### PR DESCRIPTION
This adds a section to the custom list edit page where you can check off collections that should be associated with the list. I debated whether to put this on the collection edit page or the list page, and I think the list page makes sense plus it was easier to implement that way.  But I'm still concerned that it clutters up the page a lot, and particularly when we have advanced search it won't be a good use of space.