### PR TITLE
Separate route for custom list with entries

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.0.54",
+  "version": "0.0.55",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -7,8 +7,8 @@ import {
   MetadataServicesData, AnalyticsServicesData,
   CDNServicesData, SearchServicesData,
   DiscoveryServicesData, LibraryRegistrationsData,
-  CustomListsData, LanesData, RolesData, MediaData,
-  LanguagesData
+  CustomListsData, CustomListDetailsData, LanesData,
+  RolesData, MediaData, LanguagesData
 } from "./interfaces";
 import DataFetcher from "opds-web-client/lib/DataFetcher";
 import { RequestError, RequestRejector } from "opds-web-client/lib/DataFetcher";
@@ -68,6 +68,7 @@ export default class ActionCreator extends BaseActionCreator {
   static readonly REGISTER_LIBRARY = "REGISTER_LIBRARY";
   static readonly LIBRARY_REGISTRATIONS = "LIBRARY_REGISTRATIONS";
   static readonly CUSTOM_LISTS = "CUSTOM_LISTS";
+  static readonly CUSTOM_LIST_DETAILS = "CUSTOM_LIST_DETAILS";
   static readonly EDIT_CUSTOM_LIST = "EDIT_CUSTOM_LIST";
   static readonly DELETE_CUSTOM_LIST = "DELETE_CUSTOM_LIST";
   static readonly LANES = "LANES";
@@ -487,8 +488,16 @@ export default class ActionCreator extends BaseActionCreator {
     return this.fetchJSON<CustomListsData>(ActionCreator.CUSTOM_LISTS, url).bind(this);
   }
 
-  editCustomList(library: string, data: FormData) {
-    const url = "/" + library + "/admin/custom_lists";
+  fetchCustomListDetails(library: string, id: string) {
+    const url = "/" + library + "/admin/custom_list/" + id;
+    return this.fetchJSON<CustomListDetailsData>(ActionCreator.CUSTOM_LIST_DETAILS, url).bind(this);
+  }
+
+  editCustomList(library: string, data: FormData, id?: string) {
+    let url = "/" + library + "/admin/custom_lists";
+    if (id) {
+      url = "/" + library + "/admin/custom_list/" + id;
+    }
     return this.postForm(ActionCreator.EDIT_CUSTOM_LIST, url, data).bind(this);
   }
 

--- a/src/components/CustomListEditor.tsx
+++ b/src/components/CustomListEditor.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { CustomListData, CustomListEntryData, CollectionData as AdminCollectionData } from "../interfaces";
+import { CustomListDetailsData, CustomListEntryData, CollectionData as AdminCollectionData } from "../interfaces";
 import { CollectionData } from "opds-web-client/lib/interfaces";
 import TextWithEditMode from "./TextWithEditMode";
 import EditableInput from "./EditableInput";
@@ -9,11 +9,11 @@ import SearchIcon from "./icons/SearchIcon";
 
 export interface CustomListEditorProps extends React.Props<CustomListEditor> {
   library: string;
-  list?: CustomListData;
+  list?: CustomListDetailsData;
   collections?: AdminCollectionData[];
   editedIdentifier?: string;
   searchResults?: CollectionData;
-  editCustomList: (data: FormData) => Promise<void>;
+  editCustomList: (data: FormData, listId?: string) => Promise<void>;
   search: (url: string) => Promise<CollectionData>;
   loadMoreSearchResults: (url: string) => Promise<CollectionData>;
   isFetchingMoreSearchResults: boolean;
@@ -56,7 +56,7 @@ export default class CustomListEditor extends React.Component<CustomListEditorPr
             { this.props.list &&
               <h4>ID-{this.props.list.id}</h4>
             }
-            { this.props.collections && this.props.collections.length &&
+            { this.props.collections && this.props.collections.length > 0 &&
               <div>
                 <span>Automatically add new books from these collections to this list:</span>
                 <div className="collections">
@@ -201,7 +201,7 @@ export default class CustomListEditor extends React.Component<CustomListEditorPr
     data.append("entries", JSON.stringify(entries));
     let collections = this.state.collections.map(collection => collection.id);
     data.append("collections", JSON.stringify(collections));
-    this.props.editCustomList(data).then(() => {
+    this.props.editCustomList(data, this.props.list && String(this.props.list.id)).then(() => {
       // If a new list was created, go to the new list's edit page.
       if (!this.props.list && this.props.editedIdentifier) {
         window.location.href = "/admin/web/lists/" + this.props.library + "/edit/" + this.props.editedIdentifier;

--- a/src/components/LaneCustomListsEditor.tsx
+++ b/src/components/LaneCustomListsEditor.tsx
@@ -66,7 +66,7 @@ export default class LaneCustomListsEditor extends React.Component<LaneCustomLis
                             <GrabIcon />
                             <div className="list-info">
                               <div className="list-name">{list.name}</div>
-                              <div className="list-count">Items in list: {list.entries.length}</div>
+                              <div className="list-count">Items in list: {list.entry_count}</div>
                               <div className="list-id">ID-{list.id}</div>
                             </div>
                             <div className="links">
@@ -116,7 +116,7 @@ export default class LaneCustomListsEditor extends React.Component<LaneCustomLis
                             <GrabIcon />
                             <div className="list-info">
                               <div className="list-name">{list.name}</div>
-                              <div className="list-count">Items in list: {list.entries.length}</div>
+                              <div className="list-count">Items in list: {list.entry_count}</div>
                               <div className="list-id">ID-{list.id}</div>
                             </div>
                             <div className="links">

--- a/src/components/__tests__/CustomListEditor-test.tsx
+++ b/src/components/__tests__/CustomListEditor-test.tsx
@@ -122,6 +122,8 @@ describe("CustomListEditor", () => {
     expect(formData.get("name")).to.equal("new list name");
     expect(formData.get("entries")).to.equal(JSON.stringify(newEntries));
     expect(formData.get("collections")).to.equal(JSON.stringify([2]));
+    let listId = editCustomList.args[0][1];
+    expect(listId).to.equal("1");
 
     getTextStub.restore();
     getEntriesStub.restore();

--- a/src/components/__tests__/LaneCustomListsEditor-test.tsx
+++ b/src/components/__tests__/LaneCustomListsEditor-test.tsx
@@ -15,9 +15,9 @@ describe("LaneCustomListsEditor", () => {
   let onUpdate;
 
   let allCustomListsData = [
-    { id: 1, name: "list 1", entries: [] },
-    { id: 2, name: "list 2", entries: [{ pwid: "2a", title: "", authors: []}, { pwid: "2b", title: "", authors: []}] },
-    { id: 3, name: "list 3", entries: [] }
+    { id: 1, name: "list 1", entry_count: 0 },
+    { id: 2, name: "list 2", entry_count: 2 },
+    { id: 3, name: "list 3", entry_count: 0 }
   ];
 
   beforeEach(() => {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -283,8 +283,12 @@ export interface CustomListEntryData {
 export interface CustomListData {
   id?: string | number;
   name: string;
-  entries?: CustomListEntryData[];
+  entry_count?: number;
   collections?: CollectionData[];
+}
+
+export interface CustomListDetailsData extends CustomListData {
+  entries: CustomListEntryData[];
 }
 
 export interface CustomListsData {

--- a/src/reducers/customListDetails.ts
+++ b/src/reducers/customListDetails.ts
@@ -1,0 +1,5 @@
+import { CustomListDetailsData } from "../interfaces";
+import ActionCreator from "../actions";
+import createFetchEditReducer from "./createFetchEditReducer";
+
+export default createFetchEditReducer<CustomListDetailsData>(ActionCreator.CUSTOM_LIST_DETAILS);

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -19,6 +19,7 @@ import discoveryServices from "./discoveryServices";
 import registerLibrary, { RegisterLibraryState } from "./registerLibrary";
 import libraryRegistrations from "./libraryRegistrations";
 import customLists from "./customLists";
+import customListDetails from "./customListDetails";
 import lanes from "./lanes";
 import laneVisibility from "./laneVisibility";
 import resetLanes from "./resetLanes";
@@ -32,7 +33,7 @@ import {
   PatronAuthServicesData, SitewideSettingsData, MetadataServicesData,
   AnalyticsServicesData, CDNServicesData, SearchServicesData,
   DiscoveryServicesData, LibraryRegistrationsData, CustomListsData,
-  LanesData, RolesData, MediaData, LanguagesData
+  CustomListDetailsData, LanesData, RolesData, MediaData, LanguagesData
 } from "../interfaces";
 
 
@@ -57,6 +58,7 @@ export interface State {
   registerLibrary: RegisterLibraryState;
   libraryRegistrations: FetchEditState<LibraryRegistrationsData>;
   customLists: FetchEditState<CustomListsData>;
+  customListDetails: FetchEditState<CustomListDetailsData>;
   collection: CollectionState;
   lanes: FetchEditState<LanesData>;
   laneVisibility: FetchEditState<void>;
@@ -87,6 +89,7 @@ export default combineReducers<State>({
   registerLibrary,
   libraryRegistrations,
   customLists,
+  customListDetails,
   collection,
   lanes,
   laneVisibility,


### PR DESCRIPTION
This uses the changes from https://github.com/NYPL-Simplified/circulation/pull/845.

Custom list entries are no longer fetched unless you're on the edit page for a list. I added a new action to hit the custom list endpoint to get entries when you are on that page.