### PR TITLE
Fixed bug where collections weren't getting set in CustomListEditor state.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.0.55",
+  "version": "0.0.56",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/components/CustomListEditor.tsx
+++ b/src/components/CustomListEditor.tsx
@@ -128,6 +128,13 @@ export default class CustomListEditor extends React.Component<CustomListEditorPr
         collections: (nextProps.list && nextProps.list.collections) || []
       });
     }
+    else if ((!this.props.list || !this.props.list.collections) && nextProps.list && nextProps.list.collections) {
+      this.setState({
+        name: this.state.name,
+        entries: this.state.entries,
+        collections: nextProps.list.collections
+      });
+    }
   }
 
   hasChanges(): boolean {


### PR DESCRIPTION
This fixes a bug where collections were sometimes missing from the CustomListEditor state. It caused the checkboxes for the collections to be unchecked, so if the form was resubmitted collections could be accidentally removed from a list.