### PR TITLE
Audiobook admin search

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.0.59",
+  "version": "0.0.60",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/components/CustomListEditor.tsx
+++ b/src/components/CustomListEditor.tsx
@@ -29,7 +29,6 @@ export interface CustomListEditorState {
   name: string;
   entries: CustomListEntryData[];
   collections: AdminCollectionData[];
-  media?: MediaData;
   mediaSelected?: string;
 }
 
@@ -41,7 +40,6 @@ export default class CustomListEditor extends React.Component<CustomListEditorPr
       name: this.props.list && this.props.list.name,
       entries: (this.props.list && this.props.list.entries) || [],
       collections: (this.props.list && this.props.list.collections) || [],
-      media: this.props.media || {},
       mediaSelected: "all",
     };
 
@@ -51,7 +49,6 @@ export default class CustomListEditor extends React.Component<CustomListEditorPr
     this.reset = this.reset.bind(this);
     this.search = this.search.bind(this);
     this.changeMedia = this.changeMedia.bind(this);
-    this.getMediaQuery = this.getMediaQuery.bind(this);
     this.getMediaElements = this.getMediaElements.bind(this);
   }
 
@@ -221,13 +218,12 @@ export default class CustomListEditor extends React.Component<CustomListEditorPr
     this.setState({ name: this.state.name, entries: this.state.entries, collections: newCollections });
   }
 
-  changeMedia(media: string) {
+  changeMedia(mediaSelected: string) {
     this.setState({
       name: this.state.name,
       entries: this.state.entries,
       collections: this.state.collections,
-      media: this.state.media,
-      mediaSelected: media,
+      mediaSelected,
     });
   }
 

--- a/src/components/CustomListEditor.tsx
+++ b/src/components/CustomListEditor.tsx
@@ -1,5 +1,10 @@
 import * as React from "react";
-import { CustomListDetailsData, CustomListEntryData, CollectionData as AdminCollectionData } from "../interfaces";
+import {
+  CustomListDetailsData,
+  CustomListEntryData,
+  CollectionData as AdminCollectionData,
+  Media,
+} from "../interfaces";
 import { CollectionData } from "opds-web-client/lib/interfaces";
 import TextWithEditMode from "./TextWithEditMode";
 import EditableInput from "./EditableInput";
@@ -17,12 +22,6 @@ export interface CustomListEditorProps extends React.Props<CustomListEditor> {
   search: (url: string) => Promise<CollectionData>;
   loadMoreSearchResults: (url: string) => Promise<CollectionData>;
   isFetchingMoreSearchResults: boolean;
-}
-
-export interface Media {
-  type: string;
-  label: string;
-  active: boolean;
 }
 
 export interface CustomListEditorState {
@@ -53,7 +52,7 @@ export default class CustomListEditor extends React.Component<CustomListEditorPr
     this.reset = this.reset.bind(this);
     this.search = this.search.bind(this);
     this.changeMedia = this.changeMedia.bind(this);
-    this.getMediaTerm = this.getMediaTerm.bind(this);
+    this.getMediaQuery = this.getMediaQuery.bind(this);
   }
 
   render(): JSX.Element {
@@ -87,6 +86,7 @@ export default class CustomListEditor extends React.Component<CustomListEditorPr
                     )
                   }
                 </div>
+                <br /><br />
                 <span>Select the media to search for:</span>
                 <div className="media-selection">
                   {
@@ -274,10 +274,9 @@ export default class CustomListEditor extends React.Component<CustomListEditorPr
     });
   }
 
-  getMediaTerm() {
-    let media = '';
-
-    this.state.media.map(m => {
+  getMediaQuery() {
+    let media = "";
+    this.state.media.forEach(m => {
       if (m.active && m.type !== "all") {
         media = `&media=${encodeURIComponent(m.type)}`;
       }
@@ -289,9 +288,8 @@ export default class CustomListEditor extends React.Component<CustomListEditorPr
   search(event) {
     event.preventDefault();
     const searchTerms = encodeURIComponent((this.refs["searchTerms"] as HTMLInputElement).value);
-    const mediaTerm = this.getMediaTerm();
-    console.log(mediaTerm);
-    const url = "/" + this.props.library + "/search?q=" + searchTerms + mediaTerm;
+    const mediaQuery = this.getMediaQuery();
+    const url = "/" + this.props.library + "/search?q=" + searchTerms + mediaQuery;
     this.props.search(url);
   }
 }

--- a/src/components/CustomLists.tsx
+++ b/src/components/CustomLists.tsx
@@ -6,7 +6,14 @@ import { State } from "../reducers/index";
 import ActionCreator from "../actions";
 import DataFetcher from "opds-web-client/lib/DataFetcher";
 import { adapter } from "opds-web-client/lib/OPDSDataAdapter";
-import { CustomListData, CustomListDetailsData, CustomListsData, CollectionsData, CollectionData as AdminCollectionData } from "../interfaces";
+import {
+  CustomListData,
+  CustomListDetailsData,
+  CustomListsData,
+  CollectionsData,
+  CollectionData as AdminCollectionData,
+  MediaData,
+} from "../interfaces";
 import { FetchErrorData, CollectionData } from "opds-web-client/lib/interfaces";
 import CustomListEditor from "./CustomListEditor";
 import LoadingIndicator from "opds-web-client/lib/components/LoadingIndicator";
@@ -24,6 +31,7 @@ export interface CustomListsStateProps {
   fetchError?: FetchErrorData;
   isFetching: boolean;
   isFetchingMoreSearchResults: boolean;
+  media?: MediaData;
 }
 
 export interface CustomListsDispatchProps {
@@ -34,6 +42,7 @@ export interface CustomListsDispatchProps {
   search: (url: string) => Promise<CollectionData>;
   loadMoreSearchResults: (url: string) => Promise<CollectionData>;
   fetchCollections: () => Promise<CollectionsData>;
+  fetchMedia: () => void;
 }
 
 export interface CustomListsOwnProps {
@@ -151,6 +160,7 @@ export class CustomLists extends React.Component<CustomListsProps, CustomListsSt
               searchResults={this.props.searchResults}
               editedIdentifier={this.props.editedIdentifier}
               isFetchingMoreSearchResults={this.props.isFetchingMoreSearchResults}
+              media={this.props.media}
               />
           }
 
@@ -164,6 +174,7 @@ export class CustomLists extends React.Component<CustomListsProps, CustomListsSt
               loadMoreSearchResults={this.props.loadMoreSearchResults}
               searchResults={this.props.searchResults}
               isFetchingMoreSearchResults={this.props.isFetchingMoreSearchResults}
+              media={this.props.media}
               />
           }
         </div>
@@ -181,6 +192,7 @@ export class CustomLists extends React.Component<CustomListsProps, CustomListsSt
     if (this.props.fetchCollections) {
       this.props.fetchCollections();
     }
+    this.props.fetchMedia();
   }
 
   componentWillReceiveProps(nextProps) {
@@ -266,7 +278,8 @@ function mapStateToProps(state, ownProps) {
     isFetching: state.editor.customLists.isFetching || state.editor.customLists.isEditing || state.editor.customListDetails.isFetching || state.editor.customListDetails.isEditing || !ownProps.editOrCreate || (state.editor.collection && state.editor.collection.isFetching) || state.editor.collections.isFetching,
     searchResults: state.editor.collection && state.editor.collection.data,
     isFetchingMoreSearchResults: state.editor.collection && state.editor.collection.isFetchingPage,
-    collections: state.editor.collections && state.editor.collections.data && state.editor.collections.data.collections
+    collections: state.editor.collections && state.editor.collections.data && state.editor.collections.data.collections,
+    media: state.editor.media.data,
   };
 }
 
@@ -280,7 +293,8 @@ function mapDispatchToProps(dispatch, ownProps) {
     deleteCustomList: (listId: string) => dispatch(actions.deleteCustomList(ownProps.library, listId)),
     search: (url: string) => dispatch(actions.fetchCollection(url)),
     loadMoreSearchResults: (url: string) => dispatch(actions.fetchPage(url)),
-    fetchCollections: () => dispatch(actions.fetchCollections())
+    fetchCollections: () => dispatch(actions.fetchCollections()),
+    fetchMedia: () => dispatch(actions.fetchMedia()),
   };
 }
 

--- a/src/components/__tests__/CustomListEditor-test.tsx
+++ b/src/components/__tests__/CustomListEditor-test.tsx
@@ -370,4 +370,40 @@ describe("CustomListEditor", () => {
     expect(search.args[0][0])
       .to.equal("/library/search?q=oliver%20twist&media=http%3A%2F%2Fschema.org%2FEBook");
   });
+
+  it("should keep the same state when the list prop gets updated", () => {
+    wrapper = mount(
+      <CustomListEditor
+        library="library"
+        list={listData}
+        searchResults={searchResults}
+        editCustomList={editCustomList}
+        search={search}
+        loadMoreSearchResults={loadMoreSearchResults}
+        isFetchingMoreSearchResults={false}
+        collections={collections}
+        media={media}
+      />
+    );
+    const updatedList = { id: 2, name: "updated list", entry_count: 0, collections: [] };
+    const newList = Object.assign({}, updatedList, { entries: [] });
+    const radioInput = wrapper.find(".media-selection input") as any;
+    const ebookInput = radioInput.at(2);
+    let textInput = wrapper.find(".form-control") as any;
+
+    textInput.get(0).value = "oliver twist";
+    ebookInput.checked = true;
+    ebookInput.simulate("change");
+
+    expect(wrapper.props().list).to.deep.equal(listData);
+    expect(textInput.get(0).value).to.equal("oliver twist");
+    expect(wrapper.state("mediaSelected")).to.equal("http://schema.org/EBook");
+
+    // Update the component with a new list.
+    wrapper.setProps({ identifier: "2", list: newList });
+
+    expect(wrapper.props().list).to.deep.equal(newList);
+    expect(textInput.get(0).value).to.equal("oliver twist");
+    expect(wrapper.state("mediaSelected")).to.equal("http://schema.org/EBook");
+  });
 });

--- a/src/components/__tests__/CustomListEditor-test.tsx
+++ b/src/components/__tests__/CustomListEditor-test.tsx
@@ -84,7 +84,7 @@ describe("CustomListEditor", () => {
 
   it("shows collections", () => {
     let inputs = wrapper.find(EditableInput);
-    expect(inputs.length).to.equal(3);
+    expect(inputs.length).to.equal(6);
     expect(inputs.at(0).props().label).to.equal("collection 1");
     expect(inputs.at(0).props().value).to.equal("1");
     expect(inputs.at(0).props().checked).to.equal(false);
@@ -94,6 +94,20 @@ describe("CustomListEditor", () => {
     expect(inputs.at(2).props().label).to.equal("collection 3");
     expect(inputs.at(2).props().value).to.equal("3");
     expect(inputs.at(2).props().checked).to.equal(false);
+  });
+
+  it("shows state media options", () => {
+    let inputs = wrapper.find(EditableInput);
+    expect(inputs.length).to.equal(6);
+    expect(inputs.at(3).props().label).to.equal("All");
+    expect(inputs.at(3).props().value).to.equal("all");
+    expect(inputs.at(3).props().checked).to.equal(true);
+    expect(inputs.at(4).props().label).to.equal("Audiobooks");
+    expect(inputs.at(4).props().value).to.equal("audiobooks");
+    expect(inputs.at(4).props().checked).to.equal(false);
+    expect(inputs.at(5).props().label).to.equal("E-books");
+    expect(inputs.at(5).props().value).to.equal("ebooks");
+    expect(inputs.at(5).props().checked).to.equal(false);
   });
 
   it("saves list", () => {
@@ -285,5 +299,61 @@ describe("CustomListEditor", () => {
 
     expect(search.callCount).to.equal(1);
     expect(search.args[0][0]).to.equal("/library/search?q=test");
+  });
+
+  it("searches with audiobooks selected", () => {
+    wrapper = mount(
+      <CustomListEditor
+        library="library"
+        list={listData}
+        searchResults={searchResults}
+        editCustomList={editCustomList}
+        search={search}
+        loadMoreSearchResults={loadMoreSearchResults}
+        isFetchingMoreSearchResults={false}
+        collections={collections}
+      />
+    );
+    let textInput = wrapper.find(".form-control") as any;
+    textInput.get(0).value = "harry potter";
+    let radioInput = wrapper.find(".media-selection input") as any;
+    const audiobookInput = radioInput.at(1);
+    let searchForm = wrapper.find("form");
+
+    audiobookInput.checked = true;
+    audiobookInput.simulate("change");
+
+    searchForm.simulate("submit");
+
+    expect(search.callCount).to.equal(1);
+    expect(search.args[0][0]).to.equal("/library/search?q=harry%20potter&media=audiobooks");
+  });
+
+  it("searches with ebook selected", () => {
+    wrapper = mount(
+      <CustomListEditor
+        library="library"
+        list={listData}
+        searchResults={searchResults}
+        editCustomList={editCustomList}
+        search={search}
+        loadMoreSearchResults={loadMoreSearchResults}
+        isFetchingMoreSearchResults={false}
+        collections={collections}
+      />
+    );
+    let textInput = wrapper.find(".form-control") as any;
+    textInput.get(0).value = "oliver twist";
+    let radioInput = wrapper.find(".media-selection input") as any;
+    const ebookInput = radioInput.at(2);
+    let searchForm = wrapper.find("form");
+
+    ebookInput.checked = true;
+    ebookInput.simulate("change");
+
+    searchForm.simulate("submit");
+
+    expect(search.callCount).to.equal(1);
+    expect(search.args[0][0]).to.equal("/library/search?q=oliver%20twist&media=ebooks");
   });
 });

--- a/src/components/__tests__/CustomListEditor-test.tsx
+++ b/src/components/__tests__/CustomListEditor-test.tsx
@@ -42,6 +42,16 @@ describe("CustomListEditor", () => {
     { id: 3, name: "collection 3", protocol: "protocol", libraries: [{ short_name: "library" }] }
   ];
 
+  let media = {
+    "http://bib.schema.org/Audiobook": "Audio",
+    "http://schema.org/Course": "Courseware",
+    "http://schema.org/EBook": "Book",
+    "http://schema.org/ImageObject": "Image",
+    "http://schema.org/MusicRecording": "Music",
+    "http://schema.org/PublicationIssue": "Periodical",
+    "http://schema.org/VideoObject": "Video",
+  };
+
   beforeEach(() => {
     editCustomList = stub().returns(new Promise<void>(resolve => resolve()));
     search = stub();
@@ -56,7 +66,8 @@ describe("CustomListEditor", () => {
         search={search}
         loadMoreSearchResults={loadMoreSearchResults}
         isFetchingMoreSearchResults={false}
-        />
+        media={media}
+      />
     );
   });
 
@@ -96,17 +107,16 @@ describe("CustomListEditor", () => {
     expect(inputs.at(2).props().checked).to.equal(false);
   });
 
-  it("shows state media options", () => {
+  it("shows media options", () => {
     let inputs = wrapper.find(EditableInput);
-    expect(inputs.length).to.equal(6);
     expect(inputs.at(3).props().label).to.equal("All");
     expect(inputs.at(3).props().value).to.equal("all");
     expect(inputs.at(3).props().checked).to.equal(true);
-    expect(inputs.at(4).props().label).to.equal("Audiobooks");
-    expect(inputs.at(4).props().value).to.equal("audiobooks");
+    expect(inputs.at(4).props().label).to.equal("Audio");
+    expect(inputs.at(4).props().value).to.equal("http://bib.schema.org/Audiobook");
     expect(inputs.at(4).props().checked).to.equal(false);
-    expect(inputs.at(5).props().label).to.equal("E-books");
-    expect(inputs.at(5).props().value).to.equal("ebooks");
+    expect(inputs.at(5).props().label).to.equal("Book");
+    expect(inputs.at(5).props().value).to.equal("http://schema.org/EBook");
     expect(inputs.at(5).props().checked).to.equal(false);
   });
 
@@ -312,6 +322,7 @@ describe("CustomListEditor", () => {
         loadMoreSearchResults={loadMoreSearchResults}
         isFetchingMoreSearchResults={false}
         collections={collections}
+        media={media}
       />
     );
     let textInput = wrapper.find(".form-control") as any;
@@ -326,7 +337,8 @@ describe("CustomListEditor", () => {
     searchForm.simulate("submit");
 
     expect(search.callCount).to.equal(1);
-    expect(search.args[0][0]).to.equal("/library/search?q=harry%20potter&media=audiobooks");
+    expect(search.args[0][0])
+      .to.equal("/library/search?q=harry%20potter&media=http%3A%2F%2Fbib.schema.org%2FAudiobook");
   });
 
   it("searches with ebook selected", () => {
@@ -340,6 +352,7 @@ describe("CustomListEditor", () => {
         loadMoreSearchResults={loadMoreSearchResults}
         isFetchingMoreSearchResults={false}
         collections={collections}
+        media={media}
       />
     );
     let textInput = wrapper.find(".form-control") as any;
@@ -354,6 +367,7 @@ describe("CustomListEditor", () => {
     searchForm.simulate("submit");
 
     expect(search.callCount).to.equal(1);
-    expect(search.args[0][0]).to.equal("/library/search?q=oliver%20twist&media=ebooks");
+    expect(search.args[0][0])
+      .to.equal("/library/search?q=oliver%20twist&media=http%3A%2F%2Fschema.org%2FEBook");
   });
 });

--- a/src/components/__tests__/CustomLists-test.tsx
+++ b/src/components/__tests__/CustomLists-test.tsx
@@ -20,6 +20,7 @@ describe("CustomLists", () => {
   let search;
   let loadMoreSearchResults;
   let fetchCollections;
+  let fetchMedia;
 
   let listsData = [
     { id: 1, name: "a list", entry_count: 0, collections: [] },
@@ -52,6 +53,7 @@ describe("CustomLists", () => {
     search = stub();
     loadMoreSearchResults = stub();
     fetchCollections = stub();
+    fetchMedia = stub();
 
     wrapper = shallow(
       <CustomLists
@@ -69,6 +71,7 @@ describe("CustomLists", () => {
         search={search}
         loadMoreSearchResults={loadMoreSearchResults}
         fetchCollections={fetchCollections}
+        fetchMedia={fetchMedia}
         />
     );
   });
@@ -133,6 +136,7 @@ describe("CustomLists", () => {
         search={search}
         loadMoreSearchResults={loadMoreSearchResults}
         fetchCollections={fetchCollections}
+        fetchMedia={fetchMedia}
         />
     );
     wrapper.setProps({ lists: [] });
@@ -154,6 +158,7 @@ describe("CustomLists", () => {
         search={search}
         loadMoreSearchResults={loadMoreSearchResults}
         fetchCollections={fetchCollections}
+        fetchMedia={fetchMedia}
         />
     );
     wrapper.setProps({ lists: listsData });
@@ -178,6 +183,7 @@ describe("CustomLists", () => {
         search={search}
         loadMoreSearchResults={loadMoreSearchResults}
         fetchCollections={fetchCollections}
+        fetchMedia={fetchMedia}
         />
     );
     let radioButtons = wrapper.find(EditableInput);

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -325,3 +325,9 @@ export interface LaneData {
 export interface LanesData {
   lanes: LaneData[];
 }
+
+export interface Media {
+  type: string;
+  label: string;
+  active: boolean;
+}

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -325,9 +325,3 @@ export interface LaneData {
 export interface LanesData {
   lanes: LaneData[];
 }
-
-export interface Media {
-  type: string;
-  label: string;
-  active: boolean;
-}


### PR DESCRIPTION
Added a radio select option in the admin search to select between audiobook, ebook, or all media types.

Ties in with [circulation #907](https://github.com/NYPL-Simplified/circulation/pull/907) and [server-core #833](https://github.com/NYPL-Simplified/server_core/pull/833).