### PR TITLE
Updating the media filter when searching to use entry points instead.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.0.63",
+  "version": "0.0.64",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/components/CustomListEditor.tsx
+++ b/src/components/CustomListEditor.tsx
@@ -3,7 +3,6 @@ import {
   CustomListDetailsData,
   CustomListEntryData,
   CollectionData as AdminCollectionData,
-  MediaData,
 } from "../interfaces";
 import { CollectionData } from "opds-web-client/lib/interfaces";
 import TextWithEditMode from "./TextWithEditMode";
@@ -22,14 +21,14 @@ export interface CustomListEditorProps extends React.Props<CustomListEditor> {
   search: (url: string) => Promise<CollectionData>;
   loadMoreSearchResults: (url: string) => Promise<CollectionData>;
   isFetchingMoreSearchResults: boolean;
-  media?: MediaData;
+  entryPoints?: string[];
 }
 
 export interface CustomListEditorState {
   name: string;
   entries: CustomListEntryData[];
   collections: AdminCollectionData[];
-  mediaSelected?: string;
+  entryPointSelected?: string;
 }
 
 /** Right panel of the lists page for editing a single list. */
@@ -40,7 +39,7 @@ export default class CustomListEditor extends React.Component<CustomListEditorPr
       name: this.props.list && this.props.list.name,
       entries: (this.props.list && this.props.list.entries) || [],
       collections: (this.props.list && this.props.list.collections) || [],
-      mediaSelected: "all",
+      entryPointSelected: "all",
     };
 
     this.changeName = this.changeName.bind(this);
@@ -48,8 +47,8 @@ export default class CustomListEditor extends React.Component<CustomListEditorPr
     this.save = this.save.bind(this);
     this.reset = this.reset.bind(this);
     this.search = this.search.bind(this);
-    this.changeMedia = this.changeMedia.bind(this);
-    this.getMediaElements = this.getMediaElements.bind(this);
+    this.changeEntryPoint = this.changeEntryPoint.bind(this);
+    this.getEntryPointsElms = this.getEntryPointsElms.bind(this);
   }
 
   render(): JSX.Element {
@@ -86,11 +85,11 @@ export default class CustomListEditor extends React.Component<CustomListEditorPr
                   }
                 </div>
                 {
-                  this.props.media && (
-                    <div className="media">
-                      <span>Select the media to search for:</span>
-                      <div className="media-selection">
-                        {this.getMediaElements(this.props.media)}
+                  this.props.entryPoints && (
+                    <div className="entry-points">
+                      <span>Select the entry point to search for:</span>
+                      <div className="entry-points-selection">
+                        {this.getEntryPointsElms(this.props.entryPoints)}
                       </div>
                     </div>
                   )
@@ -220,12 +219,12 @@ export default class CustomListEditor extends React.Component<CustomListEditorPr
     this.setState({ name: this.state.name, entries: this.state.entries, collections: newCollections });
   }
 
-  changeMedia(mediaSelected: string) {
+  changeEntryPoint(entryPointSelected: string) {
     this.setState({
       name: this.state.name,
       entries: this.state.entries,
       collections: this.state.collections,
-      mediaSelected,
+      entryPointSelected,
     });
   }
 
@@ -254,65 +253,57 @@ export default class CustomListEditor extends React.Component<CustomListEditorPr
     this.setState({
       name: this.state.name,
       entries: this.state.entries,
-      collections: (this.props.list && this.props.list.collections) || []
+      collections: (this.props.list && this.props.list.collections) || [],
+      entryPointSelected: "all",
     });
   }
 
-  getMediaQuery() {
+  getEntryPointQuery() {
+    const entryPointSelected = this.state.entryPointSelected;
     let query = "";
-    if (this.state.mediaSelected && this.state.mediaSelected !== "all") {
-      query = `&media=${encodeURIComponent(this.state.mediaSelected)}`;
+    if (entryPointSelected && entryPointSelected !== "all") {
+      query = `&entrypoint=${encodeURIComponent(entryPointSelected)}`;
     }
 
     return query;
   }
 
-  getMediaElements(media) {
-    const filteredMedia = {};
-    const mediaElems = [];
-    mediaElems.push(
+  getEntryPointsElms(entryPoints) {
+    const entryPointsElms = [];
+    entryPointsElms.push(
       <EditableInput
         key="all"
         type="radio"
-        name="media-selection"
-        checked={"all" === this.state.mediaSelected}
+        name="enty-points-selection"
+        checked={"all" === this.state.entryPointSelected}
         label="All"
         value="all"
-        onChange={() => this.changeMedia("all")}
+        onChange={() => this.changeEntryPoint("all")}
       />
     );
 
-    for (const key in media) {
-      const label = media[key];
-      if (media.hasOwnProperty(key) && (label === "Audio" || label === "Book")) {
-        filteredMedia[key] = media[key];
-      }
-    }
-
-    for (const key in filteredMedia) {
-      let label = media[key];
-
-      mediaElems.push(
+    entryPoints.forEach(entryPoint =>
+      entryPointsElms.push(
         <EditableInput
-          key={key}
+          key={entryPoint}
           type="radio"
-          name="media-selection"
-          checked={key === this.state.mediaSelected}
-          label={label}
-          value={key}
-          onChange={() => this.changeMedia(key)}
+          name="enty-points-selection"
+          checked={entryPoint === this.state.entryPointSelected}
+          label={entryPoint}
+          value={entryPoint}
+          onChange={() => this.changeEntryPoint(entryPoint)}
         />
-      );
-    }
+      )
+    );
 
-    return mediaElems;
+    return entryPointsElms;
   };
 
   search(event) {
     event.preventDefault();
     const searchTerms = encodeURIComponent((this.refs["searchTerms"] as HTMLInputElement).value);
-    const mediaQuery = this.getMediaQuery();
-    const url = "/" + this.props.library + "/search?q=" + searchTerms + mediaQuery;
+    const entryPointQuery = this.getEntryPointQuery();
+    const url = "/" + this.props.library + "/search?q=" + searchTerms + entryPointQuery;
     this.props.search(url);
   }
 }

--- a/src/components/__tests__/CustomListEditor-test.tsx
+++ b/src/components/__tests__/CustomListEditor-test.tsx
@@ -44,15 +44,7 @@ describe("CustomListEditor", () => {
     { id: 3, name: "collection 3", protocol: "protocol", libraries: [{ short_name: "library" }] }
   ];
 
-  let media = {
-    "http://bib.schema.org/Audiobook": "Audio",
-    "http://schema.org/Course": "Courseware",
-    "http://schema.org/EBook": "Book",
-    "http://schema.org/ImageObject": "Image",
-    "http://schema.org/MusicRecording": "Music",
-    "http://schema.org/PublicationIssue": "Periodical",
-    "http://schema.org/VideoObject": "Video",
-  };
+  let entryPoints = ["Book", "Audio"];
 
   beforeEach(() => {
     editCustomList = stub().returns(new Promise<void>(resolve => resolve()));
@@ -86,7 +78,7 @@ describe("CustomListEditor", () => {
         search={search}
         loadMoreSearchResults={loadMoreSearchResults}
         isFetchingMoreSearchResults={false}
-        media={media}
+        entryPoints={entryPoints}
       />,
       { context: fullContext, childContextTypes }
     );
@@ -128,16 +120,16 @@ describe("CustomListEditor", () => {
     expect(inputs.at(2).props().checked).to.equal(false);
   });
 
-  it("shows media options", () => {
+  it("shows entry point options", () => {
     let inputs = wrapper.find(EditableInput);
     expect(inputs.at(3).props().label).to.equal("All");
     expect(inputs.at(3).props().value).to.equal("all");
     expect(inputs.at(3).props().checked).to.equal(true);
-    expect(inputs.at(4).props().label).to.equal("Audio");
-    expect(inputs.at(4).props().value).to.equal("http://bib.schema.org/Audiobook");
+    expect(inputs.at(4).props().label).to.equal("Book");
+    expect(inputs.at(4).props().value).to.equal("Book");
     expect(inputs.at(4).props().checked).to.equal(false);
-    expect(inputs.at(5).props().label).to.equal("Book");
-    expect(inputs.at(5).props().value).to.equal("http://schema.org/EBook");
+    expect(inputs.at(5).props().label).to.equal("Audio");
+    expect(inputs.at(5).props().value).to.equal("Audio");
     expect(inputs.at(5).props().checked).to.equal(false);
   });
 
@@ -151,6 +143,7 @@ describe("CustomListEditor", () => {
         search={search}
         loadMoreSearchResults={loadMoreSearchResults}
         isFetchingMoreSearchResults={false}
+        entryPoints={entryPoints}
       />,
       { context: fullContext, childContextTypes }
     );
@@ -188,6 +181,7 @@ describe("CustomListEditor", () => {
         search={search}
         loadMoreSearchResults={loadMoreSearchResults}
         isFetchingMoreSearchResults={false}
+        entryPoints={entryPoints}
       />,
       { context: fullContext, childContextTypes }
     );
@@ -227,6 +221,7 @@ describe("CustomListEditor", () => {
         search={search}
         loadMoreSearchResults={loadMoreSearchResults}
         isFetchingMoreSearchResults={false}
+        entryPoints={entryPoints}
       />,
       { context: fullContext, childContextTypes }
     );
@@ -265,6 +260,7 @@ describe("CustomListEditor", () => {
         search={search}
         loadMoreSearchResults={loadMoreSearchResults}
         isFetchingMoreSearchResults={false}
+        entryPoints={entryPoints}
       />,
       { context: fullContext, childContextTypes }
     );
@@ -296,6 +292,7 @@ describe("CustomListEditor", () => {
         search={search}
         loadMoreSearchResults={loadMoreSearchResults}
         isFetchingMoreSearchResults={false}
+        entryPoints={entryPoints}
       />,
       { context: fullContext, childContextTypes }
     );
@@ -325,6 +322,7 @@ describe("CustomListEditor", () => {
         search={search}
         loadMoreSearchResults={loadMoreSearchResults}
         isFetchingMoreSearchResults={false}
+        entryPoints={entryPoints}
       />,
       { context: fullContext, childContextTypes }
     );
@@ -349,24 +347,24 @@ describe("CustomListEditor", () => {
         loadMoreSearchResults={loadMoreSearchResults}
         isFetchingMoreSearchResults={false}
         collections={collections}
-        media={media}
+        entryPoints={entryPoints}
       />,
       { context: fullContext, childContextTypes }
     );
     let textInput = wrapper.find(".form-control") as any;
     textInput.get(0).value = "harry potter";
-    let radioInput = wrapper.find(".media-selection input") as any;
-    const audiobookInput = radioInput.at(1);
+    let radioInput = wrapper.find(".entry-points-selection input") as any;
+    const bookInput = radioInput.at(1);
     let searchForm = wrapper.find("form");
 
-    audiobookInput.checked = true;
-    audiobookInput.simulate("change");
+    bookInput.checked = true;
+    bookInput.simulate("change");
 
     searchForm.simulate("submit");
 
     expect(search.callCount).to.equal(1);
     expect(search.args[0][0])
-      .to.equal("/library/search?q=harry%20potter&media=http%3A%2F%2Fbib.schema.org%2FAudiobook");
+      .to.equal("/library/search?q=harry%20potter&entrypoint=Book");
   });
 
   it("searches with ebook selected", () => {
@@ -380,24 +378,24 @@ describe("CustomListEditor", () => {
         loadMoreSearchResults={loadMoreSearchResults}
         isFetchingMoreSearchResults={false}
         collections={collections}
-        media={media}
+        entryPoints={entryPoints}
       />,
       { context: fullContext, childContextTypes }
     );
     let textInput = wrapper.find(".form-control") as any;
     textInput.get(0).value = "oliver twist";
-    let radioInput = wrapper.find(".media-selection input") as any;
-    const ebookInput = radioInput.at(2);
+    let radioInput = wrapper.find(".entry-points-selection input") as any;
+    const audioInput = radioInput.at(2);
     let searchForm = wrapper.find("form");
 
-    ebookInput.checked = true;
-    ebookInput.simulate("change");
+    audioInput.checked = true;
+    audioInput.simulate("change");
 
     searchForm.simulate("submit");
 
     expect(search.callCount).to.equal(1);
     expect(search.args[0][0])
-      .to.equal("/library/search?q=oliver%20twist&media=http%3A%2F%2Fschema.org%2FEBook");
+      .to.equal("/library/search?q=oliver%20twist&entrypoint=Audio");
   });
 
   it("should keep the same state when the list prop gets updated", () => {
@@ -411,29 +409,29 @@ describe("CustomListEditor", () => {
         loadMoreSearchResults={loadMoreSearchResults}
         isFetchingMoreSearchResults={false}
         collections={collections}
-        media={media}
+        entryPoints={entryPoints}
       />,
       { context: fullContext, childContextTypes }
     );
     const updatedList = { id: 2, name: "updated list", entry_count: 0, collections: [] };
     const newList = Object.assign({}, updatedList, { entries: [] });
-    const radioInput = wrapper.find(".media-selection input") as any;
-    const ebookInput = radioInput.at(2);
+    const radioInput = wrapper.find(".entry-points-selection input") as any;
+    const audioInput = radioInput.at(2);
     let textInput = wrapper.find(".form-control") as any;
 
     textInput.get(0).value = "oliver twist";
-    ebookInput.checked = true;
-    ebookInput.simulate("change");
+    audioInput.checked = true;
+    audioInput.simulate("change");
 
     expect(wrapper.props().list).to.deep.equal(listData);
     expect(textInput.get(0).value).to.equal("oliver twist");
-    expect(wrapper.state("mediaSelected")).to.equal("http://schema.org/EBook");
+    expect(wrapper.state("entryPointSelected")).to.equal("Audio");
 
     // Update the component with a new list.
     wrapper.setProps({ identifier: "2", list: newList });
 
     expect(wrapper.props().list).to.deep.equal(newList);
     expect(textInput.get(0).value).to.equal("oliver twist");
-    expect(wrapper.state("mediaSelected")).to.equal("http://schema.org/EBook");
+    expect(wrapper.state("entryPointSelected")).to.equal("Audio");
   });
 });

--- a/src/components/__tests__/CustomLists-test.tsx
+++ b/src/components/__tests__/CustomLists-test.tsx
@@ -20,7 +20,7 @@ describe("CustomLists", () => {
   let search;
   let loadMoreSearchResults;
   let fetchCollections;
-  let fetchMedia;
+  let fetchLibraries;
 
   let listsData = [
     { id: 1, name: "a list", entry_count: 0, collections: [] },
@@ -45,6 +45,23 @@ describe("CustomLists", () => {
     { id: 3, name: "collection 3", protocol: "protocol", libraries: [{ short_name: "library" }] }
   ];
 
+  let libraries = {
+    libraries: [
+      {
+        short_name: "library",
+        settings: {
+          enabled_entry_points: ["Book", "Audio"],
+        },
+      },
+      {
+        short_name: "another library",
+        settings: {
+          enabled_entry_points: ["Audio"],
+        },
+      },
+    ],
+  };
+
   beforeEach(() => {
     fetchCustomLists = stub();
     fetchCustomListDetails = stub();
@@ -53,7 +70,7 @@ describe("CustomLists", () => {
     search = stub();
     loadMoreSearchResults = stub();
     fetchCollections = stub();
-    fetchMedia = stub();
+    fetchLibraries = stub();
 
     wrapper = shallow(
       <CustomLists
@@ -71,8 +88,8 @@ describe("CustomLists", () => {
         search={search}
         loadMoreSearchResults={loadMoreSearchResults}
         fetchCollections={fetchCollections}
-        fetchMedia={fetchMedia}
-        />
+        fetchLibraries={fetchLibraries}
+      />
     );
   });
 
@@ -136,8 +153,8 @@ describe("CustomLists", () => {
         search={search}
         loadMoreSearchResults={loadMoreSearchResults}
         fetchCollections={fetchCollections}
-        fetchMedia={fetchMedia}
-        />
+        fetchLibraries={fetchLibraries}
+      />
     );
     wrapper.setProps({ lists: [] });
     expect(window.location.href).to.contain("create");
@@ -158,8 +175,8 @@ describe("CustomLists", () => {
         search={search}
         loadMoreSearchResults={loadMoreSearchResults}
         fetchCollections={fetchCollections}
-        fetchMedia={fetchMedia}
-        />
+        fetchLibraries={fetchLibraries}
+      />
     );
     wrapper.setProps({ lists: listsData });
     expect(window.location.href).to.contain("edit");
@@ -183,8 +200,8 @@ describe("CustomLists", () => {
         search={search}
         loadMoreSearchResults={loadMoreSearchResults}
         fetchCollections={fetchCollections}
-        fetchMedia={fetchMedia}
-        />
+        fetchLibraries={fetchLibraries}
+      />
     );
     let radioButtons = wrapper.find(EditableInput);
     let ascendingButton = radioButtons.at(0);
@@ -334,5 +351,39 @@ describe("CustomLists", () => {
     editor = wrapper.find(CustomListEditor);
     expect(editor.props().list).to.deep.equal(newListDetails);
     expect(fetchCustomListDetails.callCount).to.equal(2);
+  });
+
+  it("gets the correct entry points list", () => {
+    let entryPoints = wrapper.instance().getEnabledEntryPoints(libraries);
+
+    expect(entryPoints.length).to.equal(2);
+    expect(entryPoints).to.eql(["Book", "Audio"]);
+  });
+
+  it("sorts lists", () => {
+    wrapper = mount(
+      <CustomLists
+        csrfToken="token"
+        library="another library"
+        lists={listsData}
+        searchResults={searchResults}
+        collections={collections}
+        isFetching={false}
+        isFetchingMoreSearchResults={false}
+        fetchCustomLists={fetchCustomLists}
+        fetchCustomListDetails={fetchCustomListDetails}
+        editCustomList={editCustomList}
+        deleteCustomList={deleteCustomList}
+        search={search}
+        loadMoreSearchResults={loadMoreSearchResults}
+        fetchCollections={fetchCollections}
+        fetchLibraries={fetchLibraries}
+      />
+    );
+
+    let entryPoints = wrapper.instance().getEnabledEntryPoints(libraries);
+
+    expect(entryPoints.length).to.equal(1);
+    expect(entryPoints).to.eql(["Audio"]);
   });
 });

--- a/src/stylesheets/custom_list_editor.scss
+++ b/src/stylesheets/custom_list_editor.scss
@@ -40,10 +40,10 @@
       }
     }
 
-    .media {
+    .entry-points {
       display: block;
-      margin: 10px 0;
-      padding-top: 10px;
+      margin: 20px 0 10px;
+      padding-top: 15px;
       width: 100%;
 
       .form-group {


### PR DESCRIPTION
Help fix [circulation #931](https://github.com/NYPL-Simplified/circulation/issues/931).

Uses a library's entry points settings instead of media to generate the available radio button options in the UI for searching. The "All" doesn't work yet and will be changed later.