### PR TITLE
Admin roles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.0.64",
+  "version": "0.0.65",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -131,6 +131,8 @@ export default class ActionCreator extends BaseActionCreator {
   static readonly STATS_FAILURE = "STATS_FAILURE";
   static readonly STATS_LOAD = "STATS_LOAD";
 
+  static readonly CHANGE_PASSWORD = "CHANGE_PASSWORD";
+
   csrfToken: string;
 
   constructor(fetcher?: DataFetcher, csrfToken?: string) {
@@ -583,5 +585,10 @@ export default class ActionCreator extends BaseActionCreator {
   resetLanes(library: string) {
     const url = "/" + library + "/admin/lanes/reset";
     return this.postForm(ActionCreator.RESET_LANES, url, null).bind(this);
+  }
+
+  changePassword(data: FormData) {
+    const url = "/admin/change_password";
+    return this.postForm(ActionCreator.CHANGE_PASSWORD, url, data).bind(this);
   }
 }

--- a/src/components/AccountPage.tsx
+++ b/src/components/AccountPage.tsx
@@ -1,0 +1,37 @@
+import * as React from "react";
+import { Store } from "redux";
+import ChangePasswordForm from "./ChangePasswordForm";
+import { State } from "../reducers/index";
+import Header from "./Header";
+
+export interface AccountPageContext {
+  editorStore: Store<State>;
+  csrfToken: string;
+}
+
+/** Page for configuring account settings. */
+export default class AccountPage extends React.Component<void, void> {
+  context: AccountPageContext;
+
+  static contextTypes: React.ValidationMap<AccountPageContext> = {
+    editorStore: React.PropTypes.object.isRequired,
+    csrfToken: React.PropTypes.string.isRequired,
+  };
+
+
+  render(): JSX.Element {
+    return (
+      <div className="account">
+        <Header />
+        <ChangePasswordForm
+          store={this.context.editorStore}
+          csrfToken={this.context.csrfToken}
+          />
+      </div>
+    );
+  }
+
+  componentWillMount() {
+    document.title = "Circulation Manager - Account";
+  }
+}

--- a/src/components/AdminAuthServices.tsx
+++ b/src/components/AdminAuthServices.tsx
@@ -18,8 +18,12 @@ export class AdminAuthServices extends EditableConfigList<AdminAuthServicesData,
 }
 
 function mapStateToProps(state, ownProps) {
+  const data = Object.assign({}, state.editor.adminAuthServices && state.editor.adminAuthServices.data);
+  if (state.editor.libraries && state.editor.libraries.data) {
+    data.allLibraries = state.editor.libraries.data.libraries;
+  }
   return {
-    data: state.editor.adminAuthServices && state.editor.adminAuthServices.data,
+    data,
     editedIdentifier: state.editor.adminAuthServices && state.editor.adminAuthServices.editedIdentifier,
     fetchError: state.editor.adminAuthServices.fetchError,
     isFetching: state.editor.adminAuthServices.isFetching || state.editor.adminAuthServices.isEditing

--- a/src/components/ChangePasswordForm.tsx
+++ b/src/components/ChangePasswordForm.tsx
@@ -1,0 +1,117 @@
+import * as React from "react";
+import { Store } from "redux";
+import { FetchErrorData } from "opds-web-client/lib/interfaces";
+import { State } from "../reducers/index";
+import { connect } from "react-redux";
+import ActionCreator from "../actions";
+import LoadingIndicator from "opds-web-client/lib/components/LoadingIndicator";
+import ErrorMessage from "./ErrorMessage";
+import EditableInput from "./EditableInput";
+import { Alert } from "react-bootstrap";
+
+export interface ChangePasswordFormStateProps {
+  fetchError?: FetchErrorData;
+  isFetching?: boolean;
+}
+
+export interface ChangePasswordFormDispatchProps {
+  changePassword?: (data: FormData) => Promise<void>;
+}
+
+export interface ChangePasswordFormOwnProps {
+  store?: Store<State>;
+  csrfToken: string;
+}
+
+export interface ChangePasswordFormProps extends ChangePasswordFormStateProps, ChangePasswordFormDispatchProps, ChangePasswordFormOwnProps {}
+
+export interface ChangePasswordState {
+  success: boolean;
+  error: string | null;
+}
+
+export class ChangePasswordForm extends React.Component<ChangePasswordFormProps, ChangePasswordState> {
+  constructor(props) {
+    super(props);
+    this.state = { success: false, error: null };
+    this.save = this.save.bind(this);
+  }
+
+  render(): JSX.Element {
+    return (
+      <div className="change-password-form">
+        <h2>Change Password</h2>
+        { this.props.fetchError &&
+          <ErrorMessage error={this.props.fetchError} />
+        }
+        { this.state.error &&
+          <Alert bsStyle="danger">{ this.state.error }</Alert>
+        }
+        { this.props.isFetching &&
+          <LoadingIndicator />
+        }
+        { this.state.success &&
+          <Alert bsStyle="success">Password changed successfully.</Alert>
+        }
+        <form ref="form" onSubmit={this.save}>
+          <EditableInput
+            elementType="input"
+            type="password"
+            disabled={this.props.isFetching}
+            name="password"
+            label="New Password"
+            ref="password"
+            />
+          <EditableInput
+            elementType="input"
+            type="password"
+            disabled={this.props.isFetching}
+            name="confirm_password"
+            label="Confirm New Password"
+            ref="confirm"
+            />
+          <button
+            type="submit"
+            className="btn btn-default"
+            disabled={this.props.isFetching}
+            >Submit</button>
+        </form>
+      </div>
+    );
+  }
+
+  save(event) {
+    event.preventDefault();
+    let password = (this.refs["password"] as any).getValue();
+    let confirm = (this.refs["confirm"] as any).getValue();
+    if (password !== confirm) {
+      this.setState({ success: false, error: "Passwords do not match." });
+    } else {
+      const data = new (window as any).FormData(this.refs["form"] as any);
+      this.props.changePassword(data).then(() => {
+        this.setState({ success: true, error: null });
+      });
+    }
+  }
+}
+
+function mapStateToProps(state, ownProps) {
+  return {
+    fetchError: state.editor.changePassword && state.editor.changePassword.fetchError,
+    isFetching: state.editor.changePassword && state.editor.changePassword.isFetching
+  };
+}
+
+function mapDispatchToProps(dispatch, ownProps) {
+  let actions = new ActionCreator(null, ownProps.csrfToken);
+  return {
+    changePassword: (data: FormData) => dispatch(actions.changePassword(data))
+  };
+}
+
+const ConnectedChangePasswordForm = connect<ChangePasswordFormStateProps, ChangePasswordFormDispatchProps, ChangePasswordFormOwnProps>(
+  mapStateToProps,
+  mapDispatchToProps
+)(ChangePasswordForm);
+
+export default ConnectedChangePasswordForm;

--- a/src/components/ConfigTabContainer.tsx
+++ b/src/components/ConfigTabContainer.tsx
@@ -12,123 +12,139 @@ import SearchServices from "./SearchServices";
 import StorageServices from "./StorageServices";
 import DiscoveryServices from "./DiscoveryServices";
 import LoggingServices from "./LoggingServices";
-import { TabContainer, TabContainerProps } from "./TabContainer";
+import { TabContainer, TabContainerProps, TabContainerContext } from "./TabContainer";
+import Admin from "../models/Admin";
 
 export interface ConfigTabContainerProps extends TabContainerProps {
   editOrCreate?: string;
   identifier?: string;
 }
 
+export interface ConfigTabContainerContext extends TabContainerContext {
+  admin: Admin;
+}
+
 /** Body of the system configuration page, with a tab for each type of
     service that can be configured. */
 export default class ConfigTabContainer extends TabContainer<ConfigTabContainerProps> {
+  context: ConfigTabContainerContext;
+  static contextTypes: React.ValidationMap<ConfigTabContainerContext> = {
+    router: React.PropTypes.object.isRequired,
+    pathFor: React.PropTypes.func.isRequired,
+    admin: React.PropTypes.object.isRequired
+  };
+
   tabs() {
-    return {
-      libraries: (
+    const tabs = {};
+    if (this.context.admin.isLibraryManagerOfSomeLibrary()) {
+      tabs["libraries"] = (
         <Libraries
           store={this.props.store}
           csrfToken={this.props.csrfToken}
           editOrCreate={this.props.editOrCreate}
           identifier={this.props.identifier}
           />
-      ),
-      collections: (
-        <Collections
-          store={this.props.store}
-          csrfToken={this.props.csrfToken}
-          editOrCreate={this.props.editOrCreate}
-          identifier={this.props.identifier}
-          />
-      ),
-      adminAuth: (
-        <AdminAuthServices
-          store={this.props.store}
-          csrfToken={this.props.csrfToken}
-          editOrCreate={this.props.editOrCreate}
-          identifier={this.props.identifier}
-          />
-      ),
-      individualAdmins: (
+      );
+      tabs["individualAdmins"] = (
         <IndividualAdmins
           store={this.props.store}
           csrfToken={this.props.csrfToken}
           editOrCreate={this.props.editOrCreate}
           identifier={this.props.identifier}
           />
-      ),
-      patronAuth: (
+      );
+    }
+    if (this.context.admin.isSystemAdmin()) {
+      tabs["collections"] = (
+        <Collections
+          store={this.props.store}
+          csrfToken={this.props.csrfToken}
+          editOrCreate={this.props.editOrCreate}
+          identifier={this.props.identifier}
+          />
+      );
+      tabs["adminAuth"] = (
+        <AdminAuthServices
+          store={this.props.store}
+          csrfToken={this.props.csrfToken}
+          editOrCreate={this.props.editOrCreate}
+          identifier={this.props.identifier}
+          />
+      );
+      tabs["patronAuth"] = (
         <PatronAuthServices
           store={this.props.store}
           csrfToken={this.props.csrfToken}
           editOrCreate={this.props.editOrCreate}
           identifier={this.props.identifier}
           />
-      ),
-      sitewideSettings: (
+      );
+      tabs["sitewideSettings"] = (
         <SitewideSettings
           store={this.props.store}
           csrfToken={this.props.csrfToken}
           editOrCreate={this.props.editOrCreate}
           identifier={this.props.identifier}
           />
-      ),
-      loggingServices: (
+      );
+      tabs["logging"] = (
         <LoggingServices
           store={this.props.store}
           csrfToken={this.props.csrfToken}
           editOrCreate={this.props.editOrCreate}
           identifier={this.props.identifier}
           />
-      ),
-      metadata: (
+      );
+      tabs["metadata"] = (
         <MetadataServices
           store={this.props.store}
           csrfToken={this.props.csrfToken}
           editOrCreate={this.props.editOrCreate}
           identifier={this.props.identifier}
           />
-      ),
-      analytics: (
+      );
+      tabs["analytics"] = (
         <AnalyticsServices
           store={this.props.store}
           csrfToken={this.props.csrfToken}
           editOrCreate={this.props.editOrCreate}
           identifier={this.props.identifier}
           />
-      ),
-      cdn: (
+      );
+      tabs["cdn"] = (
         <CDNServices
           store={this.props.store}
           csrfToken={this.props.csrfToken}
           editOrCreate={this.props.editOrCreate}
           identifier={this.props.identifier}
           />
-      ),
-      search: (
+      );
+      tabs["search"] = (
         <SearchServices
           store={this.props.store}
           csrfToken={this.props.csrfToken}
           editOrCreate={this.props.editOrCreate}
           identifier={this.props.identifier}
           />
-      ),
-      storage: (
+      );
+      tabs["storage"] = (
         <StorageServices
           store={this.props.store}
           csrfToken={this.props.csrfToken}
           editOrCreate={this.props.editOrCreate}
           identifier={this.props.identifier}
           />
-      ),
-      discovery: (
+      );
+      tabs["discovery"] = (
         <DiscoveryServices
           store={this.props.store}
           csrfToken={this.props.csrfToken}
           editOrCreate={this.props.editOrCreate}
           identifier={this.props.identifier}
           />
-      ),
-    };
+      );
+    }
+    return tabs;
   }
 
   handleSelect(event) {
@@ -142,15 +158,13 @@ export default class ConfigTabContainer extends TabContainer<ConfigTabContainerP
     if (name === "adminAuth") {
       return "Admin Authentication";
     } else if (name === "individualAdmins") {
-      return "Individual Admins";
+      return "Admins";
     } else if (name === "patronAuth") {
       return "Patron Authentication";
     } else if (name === "sitewideSettings") {
       return "Sitewide Settings";
     } else if (name === "cdn") {
       return "CDN";
-    } else if (name === "loggingServices") {
-      return "Logging";
     } else {
       return super.tabDisplayName(name);
     }

--- a/src/components/ContextProvider.tsx
+++ b/src/components/ContextProvider.tsx
@@ -9,6 +9,7 @@ export interface ContextProviderProps extends React.Props<any> {
   csrfToken: string;
   showCircEventsDownload?: boolean;
   settingUp?: boolean;
+  email?: string;
   roles?: {
     role: string;
     library?: string;
@@ -25,7 +26,7 @@ export default class ContextProvider extends React.Component<ContextProviderProp
   constructor(props) {
     super(props);
     this.store = buildStore();
-    this.admin = new Admin(props.roles || []);
+    this.admin = new Admin(props.roles || [], props.email || null);
     this.pathFor = (collectionUrl: string, bookUrl: string, tab?: string) => {
       let path = "/admin/web";
       path +=

--- a/src/components/ContextProvider.tsx
+++ b/src/components/ContextProvider.tsx
@@ -3,22 +3,29 @@ import { Store } from "redux";
 import buildStore from "../store";
 import { PathFor } from "../interfaces";
 import { State } from "../reducers/index";
+import Admin from "../models/Admin";
 
 export interface ContextProviderProps extends React.Props<any> {
   csrfToken: string;
   showCircEventsDownload?: boolean;
   settingUp?: boolean;
+  roles?: {
+    role: string;
+    library?: string;
+  }[];
 }
 
 /** Provides a redux store, configuration options, and a function to create URLs
     as context to admin interface pages. */
 export default class ContextProvider extends React.Component<ContextProviderProps, void> {
   store: Store<State>;
+  admin: Admin;
   pathFor: PathFor;
 
   constructor(props) {
     super(props);
     this.store = buildStore();
+    this.admin = new Admin(props.roles || []);
     this.pathFor = (collectionUrl: string, bookUrl: string, tab?: string) => {
       let path = "/admin/web";
       path +=
@@ -59,7 +66,8 @@ export default class ContextProvider extends React.Component<ContextProviderProp
     pathFor: React.PropTypes.func.isRequired,
     csrfToken: React.PropTypes.string.isRequired,
     showCircEventsDownload: React.PropTypes.bool.isRequired,
-    settingUp: React.PropTypes.bool.isRequired
+    settingUp: React.PropTypes.bool.isRequired,
+    admin: React.PropTypes.object.isRequired
   };
 
   getChildContext() {
@@ -68,7 +76,8 @@ export default class ContextProvider extends React.Component<ContextProviderProp
       pathFor: this.pathFor,
       csrfToken: this.props.csrfToken,
       showCircEventsDownload: this.props.showCircEventsDownload || false,
-      settingUp: this.props.settingUp || false
+      settingUp: this.props.settingUp || false,
+      admin: this.admin
     };
   }
 

--- a/src/components/CustomLists.tsx
+++ b/src/components/CustomLists.tsx
@@ -14,6 +14,7 @@ import {
   CollectionData as AdminCollectionData,
   MediaData,
 } from "../interfaces";
+import Admin from "../models/Admin";
 import { FetchErrorData, CollectionData } from "opds-web-client/lib/interfaces";
 import CustomListEditor from "./CustomListEditor";
 import LoadingIndicator from "opds-web-client/lib/components/LoadingIndicator";
@@ -62,6 +63,12 @@ export interface CustomListsState {
 /** Body of the custom lists page, with all a library's lists shown in a left sidebar and
     a list editor on the right. */
 export class CustomLists extends React.Component<CustomListsProps, CustomListsState> {
+  context: { admin: Admin };
+
+  static contextTypes = {
+    admin: React.PropTypes.object.isRequired
+  };
+
   constructor(props) {
     super(props);
     this.editCustomList = this.editCustomList.bind(this);
@@ -133,12 +140,14 @@ export class CustomLists extends React.Component<CustomListsProps, CustomListsSt
                                     <PencilIcon />
                                 </Link>
                               }
-                              <button
-                                className="btn btn-default"
-                                onClick={() => this.deleteCustomList(list)}
-                                >Delete List
-                                  <TrashIcon />
-                              </button>
+                              { this.context.admin.isLibraryManager(this.props.library) &&
+                                <button
+                                  className="btn btn-default"
+                                  onClick={() => this.deleteCustomList(list)}
+                                  >Delete List
+                                    <TrashIcon />
+                                </button>
+                              }
                             </div>
                           </div>
                         </li>

--- a/src/components/EditableConfigList.tsx
+++ b/src/components/EditableConfigList.tsx
@@ -74,7 +74,7 @@ export abstract class GenericEditableConfigList<T, U, V extends EditableConfigLi
 
         { !this.props.isFetching && !this.props.editOrCreate && this.props.data && this.props.data[this.listDataKey] &&
           <div>
-            { (!this.limitOne || this.props.data[this.listDataKey].length === 0) &&
+            { (!this.limitOne || this.props.data[this.listDataKey].length === 0) && this.canCreate() &&
               <a
                 className="btn btn-default create-item"
                 href={this.urlBase + "create"}
@@ -95,15 +95,17 @@ export abstract class GenericEditableConfigList<T, U, V extends EditableConfigLi
                     <h4>
                       {this.label(item)}
                     </h4>
-                    <button
-                      className="btn btn-danger delete-item"
-                      onClick={() => this.delete(item) }
-                      >
-                        <span>
-                          Delete
-                          <TrashIcon />
-                        </span>
-                    </button>
+                    { this.canDelete(item) &&
+                      <button
+                        className="btn btn-danger delete-item"
+                        onClick={() => this.delete(item) }
+                        >
+                          <span>
+                            Delete
+                            <TrashIcon />
+                          </span>
+                      </button>
+                    }
                   </li>
                 )
               }
@@ -144,6 +146,14 @@ export abstract class GenericEditableConfigList<T, U, V extends EditableConfigLi
 
   label(item): string {
     return item[this.labelKey];
+  }
+
+  canCreate() {
+    return true;
+  }
+
+  canDelete(item) {
+    return true;
   }
 
   componentWillMount() {

--- a/src/components/EditableConfigList.tsx
+++ b/src/components/EditableConfigList.tsx
@@ -83,9 +83,6 @@ export abstract class GenericEditableConfigList<T, U, V extends EditableConfigLi
             <ul>
               { this.props.data[this.listDataKey].map((item, index) =>
                   <li key={index}>
-                    <h4>
-                      {this.label(item)}
-                    </h4>
                     <a
                       className="btn btn-default edit-item"
                       href={this.urlBase + "edit/" + item[this.identifierKey]}
@@ -95,8 +92,11 @@ export abstract class GenericEditableConfigList<T, U, V extends EditableConfigLi
                           <PencilIcon />
                         </span>
                     </a>
+                    <h4>
+                      {this.label(item)}
+                    </h4>
                     <button
-                      className="btn btn-default delete-item"
+                      className="btn btn-danger delete-item"
                       onClick={() => this.delete(item) }
                       >
                         <span>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -26,9 +26,13 @@ export interface HeaderOwnProps {
 
 export interface HeaderProps extends React.Props<Header>, HeaderStateProps, HeaderDispatchProps, HeaderOwnProps {}
 
+export interface HeaderState {
+  showAccountDropdown: boolean;
+}
+
 /** Header of all admin interface pages, with a dropdown for selecting a library,
     library-specific links for the current library, and site-wide links. */
-export class Header extends React.Component<HeaderProps, void> {
+export class Header extends React.Component<HeaderProps, HeaderState> {
   context: { library: () => string, router: Router, admin: Admin };
 
   static contextTypes = {
@@ -39,7 +43,9 @@ export class Header extends React.Component<HeaderProps, void> {
 
   constructor(props) {
     super(props);
+    this.state = { showAccountDropdown: false };
     this.changeLibrary = this.changeLibrary.bind(this);
+    this.toggleAccountDropdown = this.toggleAccountDropdown.bind(this);
   }
 
   render(): JSX.Element {
@@ -111,6 +117,24 @@ export class Header extends React.Component<HeaderProps, void> {
                 <Link to="/admin/web/config">System Configuration</Link>
               </li>
             }
+            { this.context.admin.email &&
+              <li className="dropdown">
+                <a
+                  className="dropdown-toggle"
+                  href="#"
+                  role="button"
+                  aria-haspopup="true"
+                  aria-expanded={this.state.showAccountDropdown}
+                  onClick={this.toggleAccountDropdown}
+                  >{ this.context.admin.email } &#9660;</a>
+                { this.state.showAccountDropdown &&
+                  <ul className="dropdown-menu">
+                    <li><Link to="/admin/web/account">Change password</Link></li>
+                    <li><a href="/admin/sign_out">Sign out</a></li>
+                  </ul>
+                }
+              </li>
+            }
           </Nav>
         </Navbar.Collapse>
       </Navbar>
@@ -129,6 +153,11 @@ export class Header extends React.Component<HeaderProps, void> {
       this.context.router.push("/admin/web/collection/" + library + "%2Fgroups");
       this.forceUpdate();
     }
+  }
+
+  toggleAccountDropdown() {
+    let showAccountDropdown = !this.state.showAccountDropdown;
+    this.setState({ showAccountDropdown });
   }
 }
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -5,6 +5,7 @@ import { Store } from "redux";
 import { State } from "../reducers/index";
 import ActionCreator from "../actions";
 import { LibraryData, LibrariesData } from "../interfaces";
+import Admin from "../models/Admin";
 import EditableInput from "./EditableInput";
 import CatalogLink from "opds-web-client/lib/components/CatalogLink";
 import { Link } from "react-router";
@@ -28,11 +29,12 @@ export interface HeaderProps extends React.Props<Header>, HeaderStateProps, Head
 /** Header of all admin interface pages, with a dropdown for selecting a library,
     library-specific links for the current library, and site-wide links. */
 export class Header extends React.Component<HeaderProps, void> {
-  context: { library: () => string, router: Router };
+  context: { library: () => string, router: Router, admin: Admin };
 
   static contextTypes = {
     library: React.PropTypes.func,
-    router: React.PropTypes.object.isRequired
+    router: React.PropTypes.object.isRequired,
+    admin: React.PropTypes.object.isRequired
   };
 
   constructor(props) {
@@ -93,18 +95,22 @@ export class Header extends React.Component<HeaderProps, void> {
               <li>
                 <Link to={"/admin/web/lists/" + this.context.library()}>Lists</Link>
               </li>
-              <li>
-                <Link to={"/admin/web/lanes/" + this.context.library()}>Lanes</Link>
-              </li>
+              { this.context.admin.isLibraryManager(this.context.library()) &&
+                <li>
+                  <Link to={"/admin/web/lanes/" + this.context.library()}>Lanes</Link>
+                </li>
+              }
             </Nav>
           }
           <Nav className="pull-right">
             <li>
               <Link to="/admin/web/dashboard">Dashboard</Link>
             </li>
-            <li>
-              <Link to="/admin/web/config">Configuration</Link>
-            </li>
+            { this.context.admin.isLibraryManagerOfSomeLibrary() &&
+              <li>
+                <Link to="/admin/web/config">System Configuration</Link>
+              </li>
+            }
           </Nav>
         </Navbar.Collapse>
       </Navbar>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -46,6 +46,12 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
     this.state = { showAccountDropdown: false };
     this.changeLibrary = this.changeLibrary.bind(this);
     this.toggleAccountDropdown = this.toggleAccountDropdown.bind(this);
+
+    document.body.addEventListener("click", (event: MouseEvent) => {
+      if (this.state.showAccountDropdown && (event.target as any).className !== "account-dropdown-toggle") {
+        this.toggleAccountDropdown();
+      }
+    });
   }
 
   render(): JSX.Element {
@@ -121,6 +127,7 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
               <li className="dropdown">
                 <a
                   href="#"
+                  className="account-dropdown-toggle"
                   role="button"
                   aria-haspopup="true"
                   aria-expanded={this.state.showAccountDropdown}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -120,7 +120,6 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
             { this.context.admin.email &&
               <li className="dropdown">
                 <a
-                  className="dropdown-toggle"
                   href="#"
                   role="button"
                   aria-haspopup="true"

--- a/src/components/IndividualAdminEditForm.tsx
+++ b/src/components/IndividualAdminEditForm.tsx
@@ -178,7 +178,9 @@ export default class IndividualAdminEditForm extends React.Component<IndividualA
       }
     } else if (role === "librarian-all") {
       if (this.isSelected(role)) {
-        this.setState(Object.assign({}, this.state, { roles: [] }));
+        // Remove librarian-all role, but leave manager roles.
+        const roles = this.state.roles.filter(stateRole => stateRole.role === "manager");
+        this.setState(Object.assign({}, this.state, { roles }));
       } else {
         // Remove old librarian roles, but leave manager roles.
         const roles = this.state.roles.filter(stateRole => stateRole.role === "manager");
@@ -200,8 +202,12 @@ export default class IndividualAdminEditForm extends React.Component<IndividualA
           roles.push({ role: "librarian-all" });
           this.setState(Object.assign({}, this.state, { roles }));
         } else {
+          // Remove the manager role for this library and add the librarian role,
+          // unless librarian-all is already selected.
           const roles = this.state.roles.filter(stateRole => stateRole.library !== library);
-          roles.push({ role: "manager", library: library });
+          if (!this.isSelected("librarian-all")) {
+            roles.push({ role: "librarian", library: library });
+          }
           this.setState(Object.assign({}, this.state, { roles }));
         }
       } else {
@@ -249,6 +255,7 @@ export default class IndividualAdminEditForm extends React.Component<IndividualA
   save(event) {
     event.preventDefault();
     const data = new (window as any).FormData(this.refs["form"] as any);
+    data.append("roles", JSON.stringify(this.state.roles));
     this.props.editItem(data).then(() => {
       // If we're setting up an admin for the first time, refresh the page
       // to go to login.

--- a/src/components/IndividualAdminEditForm.tsx
+++ b/src/components/IndividualAdminEditForm.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import EditableInput from "./EditableInput";
 import { IndividualAdminsData, IndividualAdminData, AdminRoleData } from "../interfaces";
+import Admin from "../models/Admin";
 
 export interface IndividualAdminEditFormProps {
   data: IndividualAdminsData;
@@ -18,6 +19,7 @@ export interface IndividualAdminEditFormState {
 
 export interface IndividualAdminEditFormContext {
   settingUp: boolean;
+  admin: Admin;
 }
 
 /** Form for editing an individual admin from the individual admin configuration page. */
@@ -25,7 +27,8 @@ export default class IndividualAdminEditForm extends React.Component<IndividualA
   context: IndividualAdminEditFormContext;
 
   static contextTypes: React.ValidationMap<IndividualAdminEditFormContext> = {
-    settingUp: React.PropTypes.bool.isRequired
+    settingUp: React.PropTypes.bool.isRequired,
+    admin: React.PropTypes.object.isRequired
   };
 
   constructor(props) {
@@ -61,7 +64,7 @@ export default class IndividualAdminEditForm extends React.Component<IndividualA
         <EditableInput
           elementType="input"
           type="checkbox"
-          disabled={this.props.disabled}
+          disabled={this.isDisabled("system")}
           name="system"
           label="System Admin"
           checked={this.isSelected("system")}
@@ -75,7 +78,7 @@ export default class IndividualAdminEditForm extends React.Component<IndividualA
                 <EditableInput
                   elementType="input"
                    type="checkbox"
-                   disabled={this.props.disabled}
+                   disabled={this.isDisabled("manager-all")}
                    name="manager-all"
                    label="Library Manager"
                    checked={this.isSelected("manager-all")}
@@ -86,7 +89,7 @@ export default class IndividualAdminEditForm extends React.Component<IndividualA
                 <EditableInput
                   elementType="input"
                   type="checkbox"
-                  disabled={this.props.disabled}
+                  disabled={this.isDisabled("librarian-all")}
                   name="librarian-all"
                   label="Librarian"
                   checked={this.isSelected("librarian-all")}
@@ -105,7 +108,7 @@ export default class IndividualAdminEditForm extends React.Component<IndividualA
                   <EditableInput
                     elementType="input"
                     type="checkbox"
-                    disabled={this.props.disabled}
+                    disabled={this.isDisabled("manager", library.short_name)}
                     name={"manager-" + library.short_name}
                     label=""
                     checked={this.isSelected("manager", library.short_name)}
@@ -116,7 +119,7 @@ export default class IndividualAdminEditForm extends React.Component<IndividualA
                   <EditableInput
                     elementType="input"
                     type="checkbox"
-                    disabled={this.props.disabled}
+                    disabled={this.isDisabled("librarian", library.short_name)}
                     name={"librarian-" + library.short_name}
                     label=""
                     checked={this.isSelected("librarian", library.short_name)}
@@ -161,6 +164,30 @@ export default class IndividualAdminEditForm extends React.Component<IndividualA
       }
     }
     return false;
+  }
+
+  isDisabled(role: string, library?: string) {
+    if (this.props.disabled) {
+      return true;
+    }
+    if (role === "system" || this.isSelected("system")) {
+      return !this.context.admin.isSystemAdmin();
+    }
+    if (role === "manager-all" || role === "librarian-all") {
+      return !this.context.admin.isSitewideLibraryManager();
+    }
+    if (role === "manager") {
+      if (this.isSelected("manager-all")) {
+        return !this.context.admin.isSitewideLibraryManager();
+      }
+      return !this.context.admin.isLibraryManager(library);
+    }
+    if (role === "librarian") {
+      if (this.isSelected("librarian-all")) {
+        return !this.context.admin.isSitewideLibraryManager();
+      }
+      return !this.context.admin.isLibraryManager(library);
+    }
   }
 
   handleRoleChange(role: string, library?: string) {

--- a/src/components/IndividualAdminEditForm.tsx
+++ b/src/components/IndividualAdminEditForm.tsx
@@ -53,13 +53,15 @@ export default class IndividualAdminEditForm extends React.Component<IndividualA
           label="Email"
           value={this.props.item && this.props.item.email}
           />
-        <EditableInput
-          elementType="input"
-          type="text"
-          disabled={this.props.disabled}
-          name="password"
-          label="Password"
-          />
+        { this.canChangePassword() &&
+          <EditableInput
+            elementType="input"
+            type="text"
+            disabled={this.props.disabled}
+            name="password"
+            label="Password"
+            />
+        }
         { !this.context.settingUp &&
           <div>
             <h4>Roles</h4>
@@ -146,6 +148,28 @@ export default class IndividualAdminEditForm extends React.Component<IndividualA
   componentWillReceiveProps(nextProps) {
     if (nextProps.item && nextProps.item !== this.props.item) {
       this.setState({ admin: new Admin(nextProps.item.roles || []) });
+    }
+  }
+
+  canChangePassword() {
+    if (!this.props.item || !this.props.item.roles) {
+      return true;
+    }
+    if (this.props.item.roles.length === 0) {
+      return this.context.admin.isLibraryManagerOfSomeLibrary();
+    }
+    let targetAdmin = new Admin(this.props.item.roles || []);
+    if (targetAdmin.isSystemAdmin()) {
+      return this.context.admin.isSystemAdmin();
+    } else if (targetAdmin.isSitewideLibraryManager()) {
+      return this.context.admin.isSitewideLibraryManager();
+    } else {
+      for (const role of targetAdmin.roles) {
+        if (this.context.admin.isLibraryManager(role.library)) {
+          return true;
+        }
+      }
+      return false;
     }
   }
 

--- a/src/components/IndividualAdminEditForm.tsx
+++ b/src/components/IndividualAdminEditForm.tsx
@@ -60,76 +60,80 @@ export default class IndividualAdminEditForm extends React.Component<IndividualA
           name="password"
           label="Password"
           />
-        <h4>Roles</h4>
-        <EditableInput
-          elementType="input"
-          type="checkbox"
-          disabled={this.isDisabled("system")}
-          name="system"
-          label="System Admin"
-          checked={this.isSelected("system")}
-          onChange={() => this.handleRoleChange("system")}
-          />
-        <table className="library-admin-roles">
-          <thead>
-            <tr>
-              <th></th>
-              <th>
-                <EditableInput
-                  elementType="input"
-                   type="checkbox"
-                   disabled={this.isDisabled("manager-all")}
-                   name="manager-all"
-                   label="Library Manager"
-                   checked={this.isSelected("manager-all")}
-                   onChange={() => this.handleRoleChange("manager-all")}
-                   />
-              </th>
-              <th>
-                <EditableInput
-                  elementType="input"
-                  type="checkbox"
-                  disabled={this.isDisabled("librarian-all")}
-                  name="librarian-all"
-                  label="Librarian"
-                  checked={this.isSelected("librarian-all")}
-                  onChange={() => this.handleRoleChange("librarian-all")}
-                  />
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            { this.props.data && this.props.data.allLibraries && this.props.data.allLibraries.map(library =>
-              <tr key={library.short_name}>
-                <td>
-                  {library.name}
-                </td>
-                <td>
-                  <EditableInput
-                    elementType="input"
-                    type="checkbox"
-                    disabled={this.isDisabled("manager", library.short_name)}
-                    name={"manager-" + library.short_name}
-                    label=""
-                    checked={this.isSelected("manager", library.short_name)}
-                    onChange={() => this.handleRoleChange("manager", library.short_name)}
-                    />
-                </td>
-                <td>
-                  <EditableInput
-                    elementType="input"
-                    type="checkbox"
-                    disabled={this.isDisabled("librarian", library.short_name)}
-                    name={"librarian-" + library.short_name}
-                    label=""
-                    checked={this.isSelected("librarian", library.short_name)}
-                    onChange={() => this.handleRoleChange("librarian", library.short_name)}
-                    />
-                </td>
-              </tr>
-            ) }
-          </tbody>
-        </table>
+        { !this.context.settingUp &&
+          <div>
+            <h4>Roles</h4>
+            <EditableInput
+              elementType="input"
+              type="checkbox"
+              disabled={this.isDisabled("system")}
+              name="system"
+              label="System Admin"
+              checked={this.isSelected("system")}
+              onChange={() => this.handleRoleChange("system")}
+              />
+            <table className="library-admin-roles">
+              <thead>
+                <tr>
+                  <th></th>
+                  <th>
+                    <EditableInput
+                      elementType="input"
+                       type="checkbox"
+                       disabled={this.isDisabled("manager-all")}
+                       name="manager-all"
+                       label="Library Manager"
+                       checked={this.isSelected("manager-all")}
+                       onChange={() => this.handleRoleChange("manager-all")}
+                       />
+                  </th>
+                  <th>
+                    <EditableInput
+                      elementType="input"
+                      type="checkbox"
+                      disabled={this.isDisabled("librarian-all")}
+                      name="librarian-all"
+                      label="Librarian"
+                      checked={this.isSelected("librarian-all")}
+                      onChange={() => this.handleRoleChange("librarian-all")}
+                      />
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                { this.props.data && this.props.data.allLibraries && this.props.data.allLibraries.map(library =>
+                  <tr key={library.short_name}>
+                    <td>
+                      {library.name}
+                    </td>
+                    <td>
+                      <EditableInput
+                        elementType="input"
+                        type="checkbox"
+                        disabled={this.isDisabled("manager", library.short_name)}
+                        name={"manager-" + library.short_name}
+                        label=""
+                        checked={this.isSelected("manager", library.short_name)}
+                        onChange={() => this.handleRoleChange("manager", library.short_name)}
+                        />
+                    </td>
+                    <td>
+                      <EditableInput
+                        elementType="input"
+                        type="checkbox"
+                        disabled={this.isDisabled("librarian", library.short_name)}
+                        name={"librarian-" + library.short_name}
+                        label=""
+                        checked={this.isSelected("librarian", library.short_name)}
+                        onChange={() => this.handleRoleChange("librarian", library.short_name)}
+                        />
+                    </td>
+                  </tr>
+                ) }
+              </tbody>
+            </table>
+          </div>
+        }
         <button
           type="submit"
           className="btn btn-default"
@@ -265,7 +269,12 @@ export default class IndividualAdminEditForm extends React.Component<IndividualA
   save(event) {
     event.preventDefault();
     const data = new (window as any).FormData(this.refs["form"] as any);
-    data.append("roles", JSON.stringify(this.state.admin.roles));
+    let roles = this.state.admin.roles;
+    if (this.context && this.context.settingUp) {
+      // When setting up the only thing you can do is create a system admin.
+      roles = [{ role: "system" }];
+    }
+    data.append("roles", JSON.stringify(roles));
     this.props.editItem(data).then(() => {
       // If we're setting up an admin for the first time, refresh the page
       // to go to login.

--- a/src/components/IndividualAdminEditForm.tsx
+++ b/src/components/IndividualAdminEditForm.tsx
@@ -106,7 +106,7 @@ export default class IndividualAdminEditForm extends React.Component<IndividualA
                     elementType="input"
                     type="checkbox"
                     disabled={this.props.disabled}
-                    name="manager"
+                    name={"manager-" + library.short_name}
                     label=""
                     checked={this.isSelected("manager", library.short_name)}
                     onChange={() => this.handleRoleChange("manager", library.short_name)}
@@ -117,7 +117,7 @@ export default class IndividualAdminEditForm extends React.Component<IndividualA
                     elementType="input"
                     type="checkbox"
                     disabled={this.props.disabled}
-                    name="librarian"
+                    name={"librarian-" + library.short_name}
                     label=""
                     checked={this.isSelected("librarian", library.short_name)}
                     onChange={() => this.handleRoleChange("librarian", library.short_name)}
@@ -134,6 +134,12 @@ export default class IndividualAdminEditForm extends React.Component<IndividualA
           >Submit</button>
       </form>
     );
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.item && nextProps.item !== this.props.item) {
+      this.setState({ roles: nextProps.item.roles || [] });
+    }
   }
 
   isSelected(role: string, library?: string) {
@@ -230,7 +236,7 @@ export default class IndividualAdminEditForm extends React.Component<IndividualA
            }
         } else {
           const roles = this.state.roles.filter(stateRole => stateRole.library !== library);
-          this.setState(Object.assign({}, this.state, { roles }));  
+          this.setState(Object.assign({}, this.state, { roles }));
         }
       } else {
           const roles = this.state.roles;
@@ -238,7 +244,7 @@ export default class IndividualAdminEditForm extends React.Component<IndividualA
           this.setState(Object.assign({}, this.state, { roles }));
       }
     }
-  }  
+  }
 
   save(event) {
     event.preventDefault();

--- a/src/components/IndividualAdmins.tsx
+++ b/src/components/IndividualAdmins.tsx
@@ -17,8 +17,12 @@ export class IndividualAdmins extends EditableConfigList<IndividualAdminsData, I
 }
 
 function mapStateToProps(state, ownProps) {
+  const data = Object.assign({}, state.editor.individualAdmins && state.editor.individualAdmins.data || {});
+  if (state.editor.libraries && state.editor.libraries.data) {
+    data.allLibraries = state.editor.libraries.data.libraries;
+  }
   return {
-    data: state.editor.individualAdmins && state.editor.individualAdmins.data,
+    data: data,
     editedIdentifier: state.editor.individualAdmins && state.editor.individualAdmins.editedIdentifier,
     fetchError: state.editor.individualAdmins.fetchError,
     isFetching: state.editor.individualAdmins.isFetching || state.editor.individualAdmins.isEditing

--- a/src/components/IndividualAdmins.tsx
+++ b/src/components/IndividualAdmins.tsx
@@ -1,7 +1,9 @@
+import * as React from "react";
 import EditableConfigList, { EditableConfigListStateProps, EditableConfigListDispatchProps, EditableConfigListOwnProps } from "./EditableConfigList";
 import { connect } from "react-redux";
 import ActionCreator from "../actions";
 import { IndividualAdminsData, IndividualAdminData } from "../interfaces";
+import Admin from "../models/Admin";
 import IndividualAdminEditForm from "./IndividualAdminEditForm";
 
 /** Right panel for individual admin configuration on the system configuration page.
@@ -14,6 +16,15 @@ export class IndividualAdmins extends EditableConfigList<IndividualAdminsData, I
   urlBase = "/admin/web/config/individualAdmins/";
   identifierKey = "email";
   labelKey = "email";
+
+  context: { admin: Admin };
+  static contextTypes = {
+    admin: React.PropTypes.object.isRequired
+  };
+
+  canDelete(item) {
+    return this.context.admin.isSystemAdmin();
+  }
 }
 
 function mapStateToProps(state, ownProps) {

--- a/src/components/Libraries.tsx
+++ b/src/components/Libraries.tsx
@@ -1,7 +1,9 @@
+import * as React from "react";
 import EditableConfigList, { EditableConfigListStateProps, EditableConfigListDispatchProps, EditableConfigListOwnProps } from "./EditableConfigList";
 import { connect } from "react-redux";
 import ActionCreator from "../actions";
 import { LibrariesData, LibraryData } from "../interfaces";
+import Admin from "../models/Admin";
 import LibraryEditForm from "./LibraryEditForm";
 
 /** Right panel for library configuration on the system configuration page.
@@ -15,8 +17,21 @@ export class Libraries extends EditableConfigList<LibrariesData, LibraryData> {
   identifierKey = "uuid";
   labelKey = "name";
 
+  context: { admin: Admin };
+  static contextTypes = {
+    admin: React.PropTypes.object.isRequired
+  };
+
   label(item): string {
     return item[this.labelKey] || item.short_name || item.uuid;
+  }
+
+  canCreate() {
+    return this.context.admin.isSystemAdmin();
+  }
+
+  canDelete(item) {
+    return this.context.admin.isSystemAdmin();
   }
 }
 

--- a/src/components/ProtocolFormField.tsx
+++ b/src/components/ProtocolFormField.tsx
@@ -168,7 +168,11 @@ export default class ProtocolFormField extends React.Component<ProtocolFormField
   }
 
   getValue() {
-    return (this.refs["element"] as any).getValue();
+    if (this.props.setting.type === "list" && !this.props.setting.options) {
+      return this.state.listItems;
+    } else {
+      return (this.refs["element"] as any).getValue();
+    }
   }
 
   removeListItem(listItem: string) {

--- a/src/components/ServiceEditForm.tsx
+++ b/src/components/ServiceEditForm.tsx
@@ -110,7 +110,7 @@ export default class ServiceEditForm<T extends ServicesData> extends React.Compo
               />
           )
         }
-        { !this.sitewide() &&
+        { (!this.sitewide() || this.protocolLibrarySettings().length > 0) &&
           <div className="form-group">
             <label>Libraries</label>
             { this.state.libraries.map(library =>
@@ -156,7 +156,7 @@ export default class ServiceEditForm<T extends ServicesData> extends React.Compo
             }
           </div>
         }
-        { !this.sitewide() && this.availableLibraries().length > 0 &&
+        { (!this.sitewide() || this.protocolLibrarySettings().length > 0) && this.availableLibraries().length > 0 &&
           <div className="form-group">
             <EditableInput
               elementType="select"

--- a/src/components/SetupPage.tsx
+++ b/src/components/SetupPage.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import { Store } from "redux";
-import AdminAuthServices from "./AdminAuthServices";
 import IndividualAdmins from "./IndividualAdmins";
 import { State } from "../reducers/index";
 
@@ -25,18 +24,11 @@ export default class SetupPage extends React.Component<void, void> {
 
   render(): JSX.Element {
     return (
-      <div>
-        <AdminAuthServices
-          store={this.context.editorStore}
-          csrfToken={this.context.csrfToken}
-          editOrCreate="create"
-          />
-        <IndividualAdmins
-          store={this.context.editorStore}
-          csrfToken={this.context.csrfToken}
-          editOrCreate="create"
-          />
-      </div>
+      <IndividualAdmins
+        store={this.context.editorStore}
+        csrfToken={this.context.csrfToken}
+        editOrCreate="create"
+        />
     );
   }
 }

--- a/src/components/__tests__/AccountPage-test.tsx
+++ b/src/components/__tests__/AccountPage-test.tsx
@@ -1,0 +1,32 @@
+import { expect } from "chai";
+
+import * as React from "react";
+import { shallow } from "enzyme";
+
+import AccountPage from "../AccountPage";
+import Header from "../Header";
+import ChangePasswordForm from "../ChangePasswordForm";
+import buildStore from "../../store";
+
+describe("AccountPage", () => {
+  let wrapper;
+  let store;
+  let context;
+
+  beforeEach(() => {
+    store = buildStore();
+    context = { editorStore: store, csrfToken: "token" };
+    wrapper = shallow(<AccountPage />, { context });
+  });
+
+  it("shows Header", () => {
+    let header = wrapper.find(Header);
+    expect(header.length).to.equal(1);
+  });
+
+  it("shows ChangePasswordForm", () => {
+    let form = wrapper.find(ChangePasswordForm);
+    expect(form.prop("store")).to.equal(store);
+    expect(form.prop("csrfToken")).to.equal("token");
+  });
+});

--- a/src/components/__tests__/ChangePasswordForm-test.tsx
+++ b/src/components/__tests__/ChangePasswordForm-test.tsx
@@ -1,0 +1,135 @@
+import { expect } from "chai";
+import { stub } from "sinon";
+
+import * as React from "react";
+import { shallow, mount } from "enzyme";
+
+import { ChangePasswordForm } from "../ChangePasswordForm";
+import LoadingIndicator from "opds-web-client/lib/components/LoadingIndicator";
+import ErrorMessage from "../ErrorMessage";
+import EditableInput from "../EditableInput";
+import { Alert } from "react-bootstrap";
+
+describe("ChangePasswordForm", () => {
+  let wrapper;
+  let changePassword;
+
+  beforeEach(() => {
+    changePassword = stub().returns(new Promise<void>(resolve => resolve()));
+    wrapper = shallow(
+      <ChangePasswordForm
+        isFetching={false}
+        csrfToken="token"
+        changePassword={changePassword}
+        />
+    );
+  });
+
+  it("shows ErrorMessage on request error", () => {
+    let error = wrapper.find(ErrorMessage);
+    expect(error.length).to.equal(0);
+
+    let fetchError = {
+      status: 500,
+      response: "response",
+      url: ""
+    };
+    wrapper.setProps({ fetchError });
+    error = wrapper.find(ErrorMessage);
+    expect(error.length).to.equal(1);
+  });
+
+  it("shows LoadingIndicator", () => {
+    let loading = wrapper.find(LoadingIndicator);
+    expect(loading.length).to.equal(0);
+
+    wrapper.setProps({ isFetching: true });
+    loading = wrapper.find(LoadingIndicator);
+    expect(loading.length).to.equal(1);
+  });
+
+  it("shows validation error", () => {
+    let error = wrapper.find(Alert);
+    expect(error.length).to.equal(0);
+
+    wrapper.setState({ success: false, error: "Error!" });
+    error = wrapper.find(Alert);
+    expect(error.length).to.equal(1);
+    expect(error.prop("bsStyle")).to.equal("danger");
+  });
+
+  it("shows success message", () => {
+    let success = wrapper.find(Alert);
+    expect(success.length).to.equal(0);
+
+    wrapper.setState({ success: true, error: null });
+    success = wrapper.find(Alert);
+    expect(success.length).to.equal(1);
+    expect(success.prop("bsStyle")).to.equal("success");
+  });
+
+  it("shows password inputs", () => {
+    let inputs = wrapper.find(EditableInput);
+    expect(inputs.length).to.equal(2);
+    expect(inputs.at(0).prop("label")).to.contain("New Password");
+    expect(inputs.at(1).prop("label")).to.contain("Confirm New Password");
+    expect(inputs.at(0).prop("type")).to.equal("password");
+    expect(inputs.at(1).prop("type")).to.equal("password");
+  });
+
+  it("checks if passwords match", () => {
+    wrapper = mount(
+      <ChangePasswordForm
+        isFetching={false}
+        csrfToken="token"
+        changePassword={changePassword}
+        />
+    );
+    let passwordInput = wrapper.find("input[name='password']");
+    let confirmInput = wrapper.find("input[name='confirm_password']");
+    let passwordInputElement = passwordInput.get(0);
+    passwordInputElement.value = "newPassword";
+    passwordInput.simulate("change");
+    let confirmInputElement = confirmInput.get(0);
+    confirmInputElement.value = "somethingElse";
+    confirmInput.simulate("change");
+
+    let form = wrapper.find("form");
+    form.simulate("submit");
+
+    expect(changePassword.callCount).to.equal(0);
+    expect(wrapper.instance().state.error).to.contain("Passwords do not match");
+  });
+
+  it("submits new password", async () => {
+    wrapper = mount(
+      <ChangePasswordForm
+        isFetching={false}
+        csrfToken="token"
+        changePassword={changePassword}
+        />
+    );
+    let passwordInput = wrapper.find("input[name='password']");
+    let confirmInput = wrapper.find("input[name='confirm_password']");
+    let passwordInputElement = passwordInput.get(0);
+    passwordInputElement.value = "newPassword";
+    passwordInput.simulate("change");
+    let confirmInputElement = confirmInput.get(0);
+    confirmInputElement.value = "newPassword";
+    confirmInput.simulate("change");
+
+    let form = wrapper.find("form");
+    form.simulate("submit");
+
+    expect(changePassword.callCount).to.equal(1);
+    let formData = changePassword.args[0][0];
+    expect(formData.get("password")).to.equal("newPassword");
+
+    // Let the call stack clear so the callback after editItem will run.
+    const pause = (): Promise<void> => {
+      return new Promise<void>(resolve => setTimeout(resolve, 0));
+    };
+    await pause();
+    expect(wrapper.instance().state.success).to.equal(true);
+  });
+});

--- a/src/components/__tests__/ConfigTabContainer-test.tsx
+++ b/src/components/__tests__/ConfigTabContainer-test.tsx
@@ -19,7 +19,7 @@ import SearchServices from "../SearchServices";
 import StorageServices from "../StorageServices";
 import DiscoveryServices from "../DiscoveryServices";
 import { mockRouterContext } from "./routing";
-
+import Admin from "../../models/Admin";
 
 describe("ConfigTabContainer", () => {
   let wrapper;
@@ -27,54 +27,152 @@ describe("ConfigTabContainer", () => {
   let push;
   let store;
 
-  beforeEach(() => {
-    store = buildStore();
-    push = stub();
-    context = mockRouterContext(push);
-    wrapper = mount(
-      <ConfigTabContainer
-        tab={null}
-        csrfToken="token"
-        store={store}
-        editOrCreate="edit"
-        identifier="identifier"
-        />,
-      { context }
-    );
+  const systemAdmin = new Admin([{ "role": "system" }]);
+  const libraryManagerA = new Admin([{ "role": "manager", "library": "a" }]);
+  const sitewideLibrarian = new Admin([{ "role": "librarian-all" }]);
+
+  describe("for system admin", () => {
+    beforeEach(() => {
+      store = buildStore();
+      push = stub();
+      context = mockRouterContext(push);
+      context["admin"] = systemAdmin;
+      wrapper = mount(
+        <ConfigTabContainer
+          tab={null}
+          csrfToken="token"
+          store={store}
+          editOrCreate="edit"
+          identifier="identifier"
+          />,
+        { context }
+      );
+    });
+
+    it("shows tabs", () => {
+      let links = wrapper.find("ul.nav-tabs").find("a");
+      let linkTexts = links.map(link => link.text());
+      expect(linkTexts).to.contain("Libraries");
+      expect(linkTexts).to.contain("Admins");
+      expect(linkTexts).to.contain("Collections");
+      expect(linkTexts).to.contain("Admin Authentication");
+      expect(linkTexts).to.contain("Patron Authentication");
+      expect(linkTexts).to.contain("Sitewide Settings");
+      expect(linkTexts).to.contain("Metadata");
+      expect(linkTexts).to.contain("CDN");
+    });
+
+    it("shows components", () => {
+      const componentClasses = [
+        Libraries, IndividualAdmins, Collections,
+        AdminAuthServices, PatronAuthServices, SitewideSettings,
+        MetadataServices, AnalyticsServices, CDNServices,
+        SearchServices, StorageServices, DiscoveryServices
+      ];
+      for (const componentClass of componentClasses) {
+        const component = wrapper.find(componentClass);
+        expect(component.props().csrfToken).to.equal("token");
+        expect(component.props().editOrCreate).to.equal("edit");
+        expect(component.props().identifier).to.equal("identifier");
+      }
+    });
+
+    it("uses router to navigate when tab is clicked", () => {
+      let tabs = wrapper.find("ul.nav-tabs").find("a");
+      tabs.at(1).simulate("click", { target : { dataset: { tabkey: "collections" } } });
+      expect(push.callCount).to.equal(1);
+      expect(push.args[0][0]).to.equal("/admin/web/config/collections");
+    });
   });
 
-  it("shows tabs", () => {
-    let links = wrapper.find("ul.nav-tabs").find("a");
-    let linkTexts = links.map(link => link.text());
-    expect(linkTexts).to.contain("Libraries");
-    expect(linkTexts).to.contain("Collections");
-    expect(linkTexts).to.contain("Admin Authentication");
-    expect(linkTexts).to.contain("Individual Admins");
-    expect(linkTexts).to.contain("Patron Authentication");
-    expect(linkTexts).to.contain("Sitewide Settings");
-    expect(linkTexts).to.contain("Metadata");
-    expect(linkTexts).to.contain("CDN");
+  describe("for library manager", () => {
+    beforeEach(() => {
+      store = buildStore();
+      push = stub();
+      context = mockRouterContext(push);
+      context["admin"] = libraryManagerA;
+      wrapper = mount(
+        <ConfigTabContainer
+          tab={null}
+          csrfToken="token"
+          store={store}
+          editOrCreate="edit"
+          identifier="identifier"
+          />,
+        { context }
+      );
+    });
+
+    it("shows tabs", () => {
+      let links = wrapper.find("ul.nav-tabs").find("a");
+      let linkTexts = links.map(link => link.text());
+      expect(linkTexts).to.contain("Libraries");
+      expect(linkTexts).to.contain("Admins");
+      expect(linkTexts).not.to.contain("Collections");
+      expect(linkTexts).not.to.contain("Admin Authentication");
+      expect(linkTexts).not.to.contain("Patron Authentication");
+      expect(linkTexts).not.to.contain("Sitewide Settings");
+      expect(linkTexts).not.to.contain("Metadata");
+      expect(linkTexts).not.to.contain("CDN");
+    });
+
+    it("shows components", () => {
+      const expectedComponentClasses = [
+        Libraries, IndividualAdmins
+      ];
+      for (const componentClass of expectedComponentClasses) {
+        const component = wrapper.find(componentClass);
+        expect(component.props().csrfToken).to.equal("token");
+        expect(component.props().editOrCreate).to.equal("edit");
+        expect(component.props().identifier).to.equal("identifier");
+      }
+
+      const hiddenComponentClasses = [
+        Collections, AdminAuthServices, PatronAuthServices, SitewideSettings,
+        MetadataServices, AnalyticsServices, CDNServices,
+        SearchServices, StorageServices, DiscoveryServices
+      ];
+      for (const componentClass of hiddenComponentClasses) {
+        const component = wrapper.find(componentClass);
+        expect(component.length).to.equal(0);
+      }
+    });
   });
 
-  it("shows components", () => {
-    const componentClasses = [
-      Libraries, Collections, AdminAuthServices,
-      IndividualAdmins, PatronAuthServices, SitewideSettings,
-      MetadataServices, AnalyticsServices, CDNServices,
-      SearchServices, StorageServices, DiscoveryServices
-    ];
-    for (const componentClass of componentClasses) {
-      const component = wrapper.find(componentClass);
-      expect(component.props().csrfToken).to.equal("token");
-      expect(component.props().editOrCreate).to.equal("edit");
-      expect(component.props().identifier).to.equal("identifier");
-    }
-  });
+  describe("for librarian", () => {
+    beforeEach(() => {
+      store = buildStore();
+      push = stub();
+      context = mockRouterContext(push);
+      context["admin"] = sitewideLibrarian;
+      wrapper = mount(
+        <ConfigTabContainer
+          tab={null}
+          csrfToken="token"
+          store={store}
+          editOrCreate="edit"
+          identifier="identifier"
+          />,
+        { context }
+      );
+    });
 
-  it("uses router to navigate when tab is clicked", () => {
-    let tabs = wrapper.find("ul.nav-tabs").find("a");
-    tabs.at(1).simulate("click", { target : { dataset: { tabkey: "collections" } } });
-    expect(push.callCount).to.equal(1);
-    expect(push.args[0][0]).to.equal("/admin/web/config/collections");
+    it("shows no tabs", () => {
+      let links = wrapper.find("ul.nav-tabs").find("a");
+      expect(links.length).to.equal(0);
+    });
+
+    it("shows no components", () => {
+      const componentClasses = [
+        Libraries, IndividualAdmins, Collections,
+        AdminAuthServices, PatronAuthServices, SitewideSettings,
+        MetadataServices, AnalyticsServices, CDNServices,
+        SearchServices, StorageServices, DiscoveryServices
+      ];
+      for (const componentClass of componentClasses) {
+        const component = wrapper.find(componentClass);
+        expect(component.length).to.equal(0);
+      }
+    });
   });
 });

--- a/src/components/__tests__/ContextProvider-test.tsx
+++ b/src/components/__tests__/ContextProvider-test.tsx
@@ -5,6 +5,7 @@ import { shallow } from "enzyme";
 import * as jsdom from "jsdom";
 
 import ContextProvider from "../ContextProvider";
+import Admin from "../../models/Admin";
 
 class FakeChild extends React.Component<any, any> {}
 
@@ -14,7 +15,9 @@ describe("ContextProvider", () => {
   beforeEach(() => {
     wrapper = shallow(
       <ContextProvider
-        csrfToken="token">
+        csrfToken="token"
+        roles={ [{ "role": "system" }] }
+        >
         <FakeChild />
       </ContextProvider>
     );
@@ -26,6 +29,9 @@ describe("ContextProvider", () => {
     expect(context.editorStore.getState().catalog).to.be.ok;
     expect(context.pathFor).to.equal(wrapper.instance().pathFor);
     expect(context.csrfToken).to.equal("token");
+    expect(context.settingUp).not.to.be.ok;
+    expect(context.admin instanceof Admin).to.be.ok;
+    expect(context.admin.isSystemAdmin()).to.be.ok;
   });
 
   it("renders child", () => {

--- a/src/components/__tests__/ContextProvider-test.tsx
+++ b/src/components/__tests__/ContextProvider-test.tsx
@@ -17,6 +17,7 @@ describe("ContextProvider", () => {
       <ContextProvider
         csrfToken="token"
         roles={ [{ "role": "system" }] }
+        email="email"
         >
         <FakeChild />
       </ContextProvider>
@@ -32,6 +33,7 @@ describe("ContextProvider", () => {
     expect(context.settingUp).not.to.be.ok;
     expect(context.admin instanceof Admin).to.be.ok;
     expect(context.admin.isSystemAdmin()).to.be.ok;
+    expect(context.admin.email).to.equal("email");
   });
 
   it("renders child", () => {

--- a/src/components/__tests__/CustomLists-test.tsx
+++ b/src/components/__tests__/CustomLists-test.tsx
@@ -10,6 +10,7 @@ import LoadingIndicator from "opds-web-client/lib/components/LoadingIndicator";
 import EditableInput from "../EditableInput";
 import CustomListEditor from "../CustomListEditor";
 import { Link } from "react-router";
+import Admin from "../../models/Admin";
 
 describe("CustomLists", () => {
   let wrapper;
@@ -45,6 +46,9 @@ describe("CustomLists", () => {
     { id: 3, name: "collection 3", protocol: "protocol", libraries: [{ short_name: "library" }] }
   ];
 
+  const libraryManager = new Admin([{ "role": "manager", "library": "library" }]);
+  const librarian = new Admin([{ "role": "librarian", "library": "library" }]);
+
   beforeEach(() => {
     fetchCustomLists = stub();
     fetchCustomListDetails = stub();
@@ -72,7 +76,8 @@ describe("CustomLists", () => {
         loadMoreSearchResults={loadMoreSearchResults}
         fetchCollections={fetchCollections}
         fetchMedia={fetchMedia}
-        />
+        />,
+      { context: { admin: libraryManager }}
     );
   });
 
@@ -137,7 +142,8 @@ describe("CustomLists", () => {
         loadMoreSearchResults={loadMoreSearchResults}
         fetchCollections={fetchCollections}
         fetchMedia={fetchMedia}
-        />
+        />,
+      { context: { admin: libraryManager }}
     );
     wrapper.setProps({ lists: [] });
     expect(window.location.href).to.contain("create");
@@ -159,7 +165,8 @@ describe("CustomLists", () => {
         loadMoreSearchResults={loadMoreSearchResults}
         fetchCollections={fetchCollections}
         fetchMedia={fetchMedia}
-        />
+        />,
+      { context: { admin: libraryManager }}
     );
     wrapper.setProps({ lists: listsData });
     expect(window.location.href).to.contain("edit");
@@ -184,7 +191,8 @@ describe("CustomLists", () => {
         loadMoreSearchResults={loadMoreSearchResults}
         fetchCollections={fetchCollections}
         fetchMedia={fetchMedia}
-        />
+        />,
+      { context: { admin: libraryManager }}
     );
     let radioButtons = wrapper.find(EditableInput);
     let ascendingButton = radioButtons.at(0);
@@ -213,7 +221,7 @@ describe("CustomLists", () => {
     expect(secondLink.text()).to.contain("z list");
   });
 
-  it("renders delete button and edit link or disabled editing message", () => {
+  it("renders delete button and edit link or disabled editing message for library manager", () => {
     let lists = wrapper.find("li");
     expect(lists.length).to.equal(2);
     expect(lists.at(0).props().className).not.to.contain("active");
@@ -254,6 +262,43 @@ describe("CustomLists", () => {
     expect(listZButtons.length).to.equal(2);
     expect(listZButtons.at(0).text()).to.contain("Editing");
     expect(listZButtons.at(1).text()).to.contain("Delete List");
+  });
+
+  it("renders edit link but does not render delete button for librarian", () => {
+    wrapper = shallow(
+      <CustomLists
+        csrfToken="token"
+        library="library"
+        lists={listsData}
+        searchResults={searchResults}
+        collections={collections}
+        isFetching={false}
+        isFetchingMoreSearchResults={false}
+        fetchCustomLists={fetchCustomLists}
+        fetchCustomListDetails={fetchCustomListDetails}
+        editCustomList={editCustomList}
+        deleteCustomList={deleteCustomList}
+        search={search}
+        loadMoreSearchResults={loadMoreSearchResults}
+        fetchCollections={fetchCollections}
+        fetchMedia={fetchMedia}
+        />,
+      { context: { admin: librarian }}
+    );
+    let lists = wrapper.find("li");
+    expect(lists.length).to.equal(2);
+
+    let listAEditLink = lists.at(0).find(Link);
+    let listZEditLink = lists.at(1).find(Link);
+    let listAButtons = lists.at(0).find("button");
+    let listZButtons = lists.at(1).find("button");
+
+    expect(listAEditLink.length).to.equal(1);
+    expect(listAEditLink.props().to).to.equal("/admin/web/lists/library/edit/1");
+    expect(listZEditLink.length).to.equal(1);
+    expect(listZEditLink.props().to).to.equal("/admin/web/lists/library/edit/2");
+    expect(listAButtons.length).to.equal(0);
+    expect(listZButtons.length).to.equal(0);
   });
 
   it("deletes a list", () => {

--- a/src/components/__tests__/EditableConfigList-test.tsx
+++ b/src/components/__tests__/EditableConfigList-test.tsx
@@ -24,6 +24,9 @@ describe("EditableConfigList", () => {
     }
   }
 
+  let canCreate: boolean;
+  let canDelete: boolean;
+
   class ThingEditableConfigList extends EditableConfigList<Things, Thing> {
     EditForm = ThingEditForm;
     listDataKey = "things";
@@ -34,6 +37,14 @@ describe("EditableConfigList", () => {
 
     label(item): string {
       return "test " + super.label(item);
+    }
+
+    canCreate() {
+      return canCreate;
+    }
+
+    canDelete(item) {
+      return canDelete;
     }
   }
 
@@ -56,6 +67,8 @@ describe("EditableConfigList", () => {
     fetchData = stub();
     editItem = stub().returns(new Promise<void>(resolve => resolve()));
     deleteItem = stub().returns(new Promise<void>(resolve => resolve()));
+    canCreate = true;
+    canDelete = true;
 
     wrapper = shallow(
       <ThingEditableConfigList
@@ -100,6 +113,22 @@ describe("EditableConfigList", () => {
     expect(createLink.props().href).to.equal("/admin/things/create");
   });
 
+  it("hides create link if canCreate returns false", () => {
+    canCreate = false;
+    wrapper = shallow(
+      <ThingEditableConfigList
+        data={thingsData}
+        fetchData={fetchData}
+        editItem={editItem}
+        deleteItem={deleteItem}
+        csrfToken="token"
+        isFetching={false}
+        />
+    );
+    let createLink = wrapper.find(".create-item");
+    expect(createLink.length).to.equal(0);
+  });
+
   it("hides create link if only one item is allowed and it already exists", () => {
     wrapper = shallow(
       <OneThingEditableConfigList
@@ -125,6 +154,25 @@ describe("EditableConfigList", () => {
     createLink = wrapper.find(".create-item");
     expect(createLink.length).to.equal(1);
     expect(createLink.prop("href")).to.equal("/admin/things/create");
+  });
+
+  it("hides delete button if canDelete returns false", () => {
+    canDelete = false;
+    wrapper = shallow(
+      <ThingEditableConfigList
+        data={thingsData}
+        fetchData={fetchData}
+        editItem={editItem}
+        deleteItem={deleteItem}
+        csrfToken="token"
+        isFetching={false}
+        />
+    );
+
+    let things = wrapper.find("li");
+    expect(things.length).to.equal(1);
+    let deleteButton = things.at(0).find(".delete-item");
+    expect(deleteButton.length).to.equal(0);
   });
 
   it("deletes an item", () => {

--- a/src/components/__tests__/Header-test.tsx
+++ b/src/components/__tests__/Header-test.tsx
@@ -133,6 +133,15 @@ describe("Header", () => {
       expect(dashboardLink.prop("to")).to.equal("/admin/web/dashboard");
       expect(dashboardLink.children().text()).to.equal("Dashboard");
     });
+
+    it("shows account dropdown when the admin has an email", () => {
+      const admin = new Admin([{ "role": "librarian", "library": "nypl" }], "admin@nypl.org");
+      wrapper.setContext({ library: () => "nypl", admin: admin });
+
+      let links = wrapper.find("a.dropdown-toggle");
+      expect(links.length).to.equal(1);
+      expect(links.text()).to.contain("admin@nypl.org");
+    });
   });
 
   describe("behavior", () => {
@@ -184,6 +193,27 @@ describe("Header", () => {
 
       expect(fullContext.router.push.callCount).to.equal(1);
       expect(fullContext.router.push.args[0][0]).to.equal("/admin/web/collection/bpl%2Fgroups");
+    });
+
+    it("toggles account dropdown", () => {
+      const admin = new Admin([{ "role": "librarian", "library": "nypl" }], "admin@nypl.org");
+      wrapper.setContext({ library: () => "nypl", admin: admin });
+
+      let toggle = wrapper.find("a.dropdown-toggle");
+      let dropdownLinks = wrapper.find("ul.dropdown-menu a");
+      expect(dropdownLinks.length).to.equal(0);
+
+      toggle.simulate("click");
+      dropdownLinks = wrapper.find("ul.dropdown-menu li");
+      expect(dropdownLinks.length).to.equal(2);
+      let changePassword = dropdownLinks.find(Link);
+      expect(changePassword.prop("to")).to.equal("/admin/web/account");
+      let signOut = dropdownLinks.find("a");
+      expect(signOut.prop("href")).to.equal("/admin/sign_out");
+
+      toggle.simulate("click");
+      dropdownLinks = wrapper.find("ul.dropdown-menu li");
+      expect(dropdownLinks.length).to.equal(0);
     });
   });
 });

--- a/src/components/__tests__/Header-test.tsx
+++ b/src/components/__tests__/Header-test.tsx
@@ -138,7 +138,7 @@ describe("Header", () => {
       const admin = new Admin([{ "role": "librarian", "library": "nypl" }], "admin@nypl.org");
       wrapper.setContext({ library: () => "nypl", admin: admin });
 
-      let links = wrapper.find("a.dropdown-toggle");
+      let links = wrapper.find("li.dropdown > a");
       expect(links.length).to.equal(1);
       expect(links.text()).to.contain("admin@nypl.org");
     });
@@ -199,7 +199,7 @@ describe("Header", () => {
       const admin = new Admin([{ "role": "librarian", "library": "nypl" }], "admin@nypl.org");
       wrapper.setContext({ library: () => "nypl", admin: admin });
 
-      let toggle = wrapper.find("a.dropdown-toggle");
+      let toggle = wrapper.find("li.dropdown > a");
       let dropdownLinks = wrapper.find("ul.dropdown-menu a");
       expect(dropdownLinks.length).to.equal(0);
 

--- a/src/components/__tests__/IndividualAdminEditForm-test.tsx
+++ b/src/components/__tests__/IndividualAdminEditForm-test.tsx
@@ -19,6 +19,17 @@ describe("IndividualAdminEditForm", () => {
     { short_name: "bpl" }
   ];
 
+  let systemAdmin = [{ role: "system" }];
+  let managerAll = [{ role: "manager-all" }];
+  let librarianAll = [{ role: "librarian-all" }];
+  let nyplManager = [{ role: "manager", library: "nypl" }];
+  let bplManager = [{ role: "manager", library: "bpl" }];
+  let bothManager = [{ role: "manager", library: "nypl" }, { role: "manager", library: "bpl" }];
+  let nyplLibrarian = [{ role: "librarian", library: "nypl" }];
+  let bplLibrarian = [{ role: "librarian", library: "bpl" }];
+  let bothLibrarian = [{ role: "librarian", library: "nypl" }, { role: "librarian", library: "bpl" }];
+  let nyplManagerLibrarianAll = [{ role: "manager", library: "nypl" }, { role: "librarian-all" }];
+
   let editableInputByName = (name) => {
     let inputs = wrapper.find(EditableInput);
     if (inputs.length >= 1) {
@@ -61,277 +72,78 @@ describe("IndividualAdminEditForm", () => {
     });
 
     describe("roles", () => {
-      let input;
-      let adminDataWithRoles;
-      let systemAdmin = [{ role: "system" }];
-      let managerAll = [{ role: "manager-all" }];
-      let librarianAll = [{ role: "librarian-all" }];
-      let nyplManager = [{ role: "manager", library: "nypl" }];
-      let bplManager = [{ role: "manager", library: "bpl" }];
-      let bothManager = [{ role: "manager", library: "nypl" }, { role: "manager", library: "bpl" }];
-      let nyplLibrarian = [{ role: "librarian", library: "nypl" }];
-      let bplLibrarian = [{ role: "librarian", library: "bpl" }];
-      let bothLibrarian = [{ role: "librarian", library: "nypl" }, { role: "librarian", library: "bpl" }];
-      let nyplManagerBplLibrarian = [{ role: "manager", library: "nypl" }, { role: "librarian", library: "bpl" }];
-      let nyplManagerLibrarianAll = [{ role: "manager", library: "nypl" }, { role: "librarian-all" }];
+      const expectRole = (startingRoles, role, shouldBeChecked: boolean) => {
+        let adminDataWithRoles = Object.assign({}, adminData, { roles: startingRoles });
+        wrapper.setProps({ item: adminDataWithRoles });
+        let input = editableInputByName(role);
+        expect(input.props().checked).to.equal(shouldBeChecked);
+      };
 
       it("renders system admin role", () => {
-        let role = "system";
-        input = editableInputByName(role);
-        expect(input.props().checked).not.to.be.ok;
-
-        adminDataWithRoles = Object.assign({}, adminData, { roles: systemAdmin });
-        wrapper.setProps({ item: adminDataWithRoles });
-        input = editableInputByName(role);
-        expect(input.props().checked).to.be.ok;
-
-        adminDataWithRoles = Object.assign({}, adminData, { roles: managerAll });
-        wrapper.setProps({ item: adminDataWithRoles });
-        input = editableInputByName(role);
-        expect(input.props().checked).not.to.be.ok;
-
-        adminDataWithRoles = Object.assign({}, adminData, { roles: bothLibrarian });
-        wrapper.setProps({ item: adminDataWithRoles });
-        input = editableInputByName(role);
-        expect(input.props().checked).not.to.be.ok;
+        expectRole([], "system", false);
+        expectRole(systemAdmin, "system", true);
+        expectRole(managerAll, "system", false);
+        expectRole(bothLibrarian, "system", false);
       });
 
       it("renders manager all role", () => {
-        let role = "manager-all";
-        input = editableInputByName(role);
-        expect(input.props().checked).not.to.be.ok;
-
-        adminDataWithRoles = Object.assign({}, adminData, { roles: systemAdmin });
-        wrapper.setProps({ item: adminDataWithRoles });
-        input = editableInputByName(role);
-        expect(input.props().checked).to.be.ok;
-
-        adminDataWithRoles = Object.assign({}, adminData, { roles: managerAll });
-        wrapper.setProps({ item: adminDataWithRoles });
-        input = editableInputByName(role);
-        expect(input.props().checked).to.be.ok;
-
-        adminDataWithRoles = Object.assign({}, adminData, { roles: bothManager });
-        wrapper.setProps({ item: adminDataWithRoles });
-        input = editableInputByName(role);
-        expect(input.props().checked).not.to.be.ok;
-
-        adminDataWithRoles = Object.assign({}, adminData, { roles: nyplManager });
-        wrapper.setProps({ item: adminDataWithRoles });
-        input = editableInputByName(role);
-        expect(input.props().checked).not.to.be.ok;
-
-        adminDataWithRoles = Object.assign({}, adminData, { roles: librarianAll });
-        wrapper.setProps({ item: adminDataWithRoles });
-        input = editableInputByName(role);
-        expect(input.props().checked).not.to.be.ok;
+        expectRole([], "manager-all", false);
+        expectRole(systemAdmin, "manager-all", true);
+        expectRole(managerAll, "manager-all", true);
+        expectRole(bothManager, "manager-all", false);
+        expectRole(nyplManager, "manager-all", false);
+        expectRole(librarianAll, "manager-all", false);
       });
 
       it("renders librarian all role", () => {
-        let role = "librarian-all";
-        input = editableInputByName(role);
-        expect(input.props().checked).not.to.be.ok;
-
-        adminDataWithRoles = Object.assign({}, adminData, { roles: systemAdmin });
-        wrapper.setProps({ item: adminDataWithRoles });
-        input = editableInputByName(role);
-        expect(input.props().checked).to.be.ok;
-
-        adminDataWithRoles = Object.assign({}, adminData, { roles: managerAll });
-        wrapper.setProps({ item: adminDataWithRoles });
-        input = editableInputByName(role);
-        expect(input.props().checked).to.be.ok;
-
-        adminDataWithRoles = Object.assign({}, adminData, { roles: bothManager });
-        wrapper.setProps({ item: adminDataWithRoles });
-        input = editableInputByName(role);
-        expect(input.props().checked).not.to.be.ok;
-
-        adminDataWithRoles = Object.assign({}, adminData, { roles: nyplManager });
-        wrapper.setProps({ item: adminDataWithRoles });
-        input = editableInputByName(role);
-        expect(input.props().checked).not.to.be.ok;
-
-        adminDataWithRoles = Object.assign({}, adminData, { roles: librarianAll });
-        wrapper.setProps({ item: adminDataWithRoles });
-        input = editableInputByName(role);
-        expect(input.props().checked).to.be.ok;
-
-        adminDataWithRoles = Object.assign({}, adminData, { roles: bothLibrarian });
-        wrapper.setProps({ item: adminDataWithRoles });
-        input = editableInputByName(role);
-        expect(input.props().checked).not.to.be.ok;
-
-        adminDataWithRoles = Object.assign({}, adminData, { roles: nyplLibrarian });
-        wrapper.setProps({ item: adminDataWithRoles });
-        input = editableInputByName(role);
-        expect(input.props().checked).not.to.be.ok;
+        expectRole([], "librarian-all", false);
+        expectRole(systemAdmin, "librarian-all", true);
+        expectRole(managerAll, "librarian-all", true);
+        expectRole(bothManager, "librarian-all", false);
+        expectRole(nyplManager, "librarian-all", false);
+        expectRole(librarianAll, "librarian-all", true);
+        expectRole(bothLibrarian, "librarian-all", false);
+        expectRole(nyplLibrarian, "librarian-all", false);
       });
 
       it("renders manager role for each library", () => {
-        let role = "manager-nypl";
-        input = editableInputByName(role);
-        expect(input.props().checked).not.to.be.ok;
+        expectRole([], "manager-nypl", false);
+        expectRole(systemAdmin, "manager-nypl", true);
+        expectRole(managerAll, "manager-nypl", true);
+        expectRole(bothManager, "manager-nypl", true);
+        expectRole(nyplManager, "manager-nypl", true);
+        expectRole(librarianAll, "manager-nypl", false);
+        expectRole(bplManager, "manager-nypl", false);
+        expectRole(nyplLibrarian, "manager-nypl", false);
 
-        adminDataWithRoles = Object.assign({}, adminData, { roles: systemAdmin });
-        wrapper.setProps({ item: adminDataWithRoles });
-        input = editableInputByName(role);
-        expect(input.props().checked).to.be.ok;
-
-        adminDataWithRoles = Object.assign({}, adminData, { roles: managerAll });
-        wrapper.setProps({ item: adminDataWithRoles });
-        input = editableInputByName(role);
-        expect(input.props().checked).to.be.ok;
-
-        adminDataWithRoles = Object.assign({}, adminData, { roles: bothManager });
-        wrapper.setProps({ item: adminDataWithRoles });
-        input = editableInputByName(role);
-        expect(input.props().checked).to.be.ok;
-
-        adminDataWithRoles = Object.assign({}, adminData, { roles: nyplManager });
-        wrapper.setProps({ item: adminDataWithRoles });
-        input = editableInputByName(role);
-        expect(input.props().checked).to.be.ok;
-
-        adminDataWithRoles = Object.assign({}, adminData, { roles: librarianAll });
-        wrapper.setProps({ item: adminDataWithRoles });
-        input = editableInputByName(role);
-        expect(input.props().checked).not.to.be.ok;
-
-        adminDataWithRoles = Object.assign({}, adminData, { roles: bplManager });
-        wrapper.setProps({ item: adminDataWithRoles });
-        input = editableInputByName(role);
-        expect(input.props().checked).not.to.be.ok;
-
-        adminDataWithRoles = Object.assign({}, adminData, { roles: nyplLibrarian });
-        wrapper.setProps({ item: adminDataWithRoles });
-        input = editableInputByName(role);
-        expect(input.props().checked).not.to.be.ok;
-
-        role = "manager-bpl";
-
-        adminDataWithRoles = Object.assign({}, adminData, { roles: systemAdmin });
-        wrapper.setProps({ item: adminDataWithRoles });
-        input = editableInputByName(role);
-        expect(input.props().checked).to.be.ok;
-
-        adminDataWithRoles = Object.assign({}, adminData, { roles: managerAll });
-        wrapper.setProps({ item: adminDataWithRoles });
-        input = editableInputByName(role);
-        expect(input.props().checked).to.be.ok;
-
-        adminDataWithRoles = Object.assign({}, adminData, { roles: bothManager });
-        wrapper.setProps({ item: adminDataWithRoles });
-        input = editableInputByName(role);
-        expect(input.props().checked).to.be.ok;
-
-        adminDataWithRoles = Object.assign({}, adminData, { roles: nyplManager });
-        wrapper.setProps({ item: adminDataWithRoles });
-        input = editableInputByName(role);
-        expect(input.props().checked).not.to.be.ok;
-
-        adminDataWithRoles = Object.assign({}, adminData, { roles: librarianAll });
-        wrapper.setProps({ item: adminDataWithRoles });
-        input = editableInputByName(role);
-        expect(input.props().checked).not.to.be.ok;
-
-        adminDataWithRoles = Object.assign({}, adminData, { roles: bplManager });
-        wrapper.setProps({ item: adminDataWithRoles });
-        input = editableInputByName(role);
-        expect(input.props().checked).to.be.ok;
-
-        adminDataWithRoles = Object.assign({}, adminData, { roles: nyplLibrarian });
-        wrapper.setProps({ item: adminDataWithRoles });
-        input = editableInputByName(role);
-        expect(input.props().checked).not.to.be.ok;
+        expectRole(systemAdmin, "manager-bpl", true);
+        expectRole(managerAll, "manager-bpl", true);
+        expectRole(bothManager, "manager-bpl", true);
+        expectRole(nyplManager, "manager-bpl", false);
+        expectRole(librarianAll, "manager-bpl", false);
+        expectRole(bplManager, "manager-bpl", true);
+        expectRole(nyplLibrarian, "manager-bpl", false);
       });
 
       it("renders librarian role for each library", () => {
-        let role = "librarian-nypl";
-        input = editableInputByName(role);
-        expect(input.props().checked).not.to.be.ok;
+        expectRole([], "librarian-nypl", false);
+        expectRole(systemAdmin, "librarian-nypl", true);
+        expectRole(managerAll, "librarian-nypl", true);
+        expectRole(bothManager, "librarian-nypl", true);
+        expectRole(nyplManager, "librarian-nypl", true);
+        expectRole(librarianAll, "librarian-nypl", true);
+        expectRole(bplManager, "librarian-nypl", false);
+        expectRole(nyplLibrarian, "librarian-nypl", true);
+        expectRole(bplLibrarian, "librarian-nypl", false);
 
-        adminDataWithRoles = Object.assign({}, adminData, { roles: systemAdmin });
-        wrapper.setProps({ item: adminDataWithRoles });
-        input = editableInputByName(role);
-        expect(input.props().checked).to.be.ok;
-
-        adminDataWithRoles = Object.assign({}, adminData, { roles: managerAll });
-        wrapper.setProps({ item: adminDataWithRoles });
-        input = editableInputByName(role);
-        expect(input.props().checked).to.be.ok;
-
-        adminDataWithRoles = Object.assign({}, adminData, { roles: bothManager });
-        wrapper.setProps({ item: adminDataWithRoles });
-        input = editableInputByName(role);
-        expect(input.props().checked).to.be.ok;
-
-        adminDataWithRoles = Object.assign({}, adminData, { roles: nyplManager });
-        wrapper.setProps({ item: adminDataWithRoles });
-        input = editableInputByName(role);
-        expect(input.props().checked).to.be.ok;
-
-        adminDataWithRoles = Object.assign({}, adminData, { roles: librarianAll });
-        wrapper.setProps({ item: adminDataWithRoles });
-        input = editableInputByName(role);
-        expect(input.props().checked).to.be.ok;
-
-        adminDataWithRoles = Object.assign({}, adminData, { roles: bplManager });
-        wrapper.setProps({ item: adminDataWithRoles });
-        input = editableInputByName(role);
-        expect(input.props().checked).not.to.be.ok;
-
-        adminDataWithRoles = Object.assign({}, adminData, { roles: nyplLibrarian });
-        wrapper.setProps({ item: adminDataWithRoles });
-        input = editableInputByName(role);
-        expect(input.props().checked).to.be.ok;
-
-        adminDataWithRoles = Object.assign({}, adminData, { roles: bplLibrarian });
-        wrapper.setProps({ item: adminDataWithRoles });
-        input = editableInputByName(role);
-        expect(input.props().checked).not.to.be.ok;
-
-        role = "librarian-bpl";
-
-        adminDataWithRoles = Object.assign({}, adminData, { roles: systemAdmin });
-        wrapper.setProps({ item: adminDataWithRoles });
-        input = editableInputByName(role);
-        expect(input.props().checked).to.be.ok;
-
-        adminDataWithRoles = Object.assign({}, adminData, { roles: managerAll });
-        wrapper.setProps({ item: adminDataWithRoles });
-        input = editableInputByName(role);
-        expect(input.props().checked).to.be.ok;
-
-        adminDataWithRoles = Object.assign({}, adminData, { roles: bothManager });
-        wrapper.setProps({ item: adminDataWithRoles });
-        input = editableInputByName(role);
-        expect(input.props().checked).to.be.ok;
-
-        adminDataWithRoles = Object.assign({}, adminData, { roles: nyplManager });
-        wrapper.setProps({ item: adminDataWithRoles });
-        input = editableInputByName(role);
-        expect(input.props().checked).not.to.be.ok;
-
-        adminDataWithRoles = Object.assign({}, adminData, { roles: librarianAll });
-        wrapper.setProps({ item: adminDataWithRoles });
-        input = editableInputByName(role);
-        expect(input.props().checked).to.be.ok;
-
-        adminDataWithRoles = Object.assign({}, adminData, { roles: bplManager });
-        wrapper.setProps({ item: adminDataWithRoles });
-        input = editableInputByName(role);
-        expect(input.props().checked).to.be.ok;
-
-        adminDataWithRoles = Object.assign({}, adminData, { roles: nyplLibrarian });
-        wrapper.setProps({ item: adminDataWithRoles });
-        input = editableInputByName(role);
-        expect(input.props().checked).not.to.be.ok;
-
-        adminDataWithRoles = Object.assign({}, adminData, { roles: bplLibrarian });
-        wrapper.setProps({ item: adminDataWithRoles });
-        input = editableInputByName(role);
-        expect(input.props().checked).to.be.ok;
+        expectRole(systemAdmin, "librarian-bpl", true);
+        expectRole(managerAll, "librarian-bpl", true);
+        expectRole(bothManager, "librarian-bpl", true);
+        expectRole(nyplManager, "librarian-bpl", false);
+        expectRole(librarianAll, "librarian-bpl", true);
+        expectRole(bplManager, "librarian-bpl", true);
+        expectRole(nyplLibrarian, "librarian-bpl", false);
+        expectRole(bplLibrarian, "librarian-bpl", true);
       });
     });
   });
@@ -341,13 +153,144 @@ describe("IndividualAdminEditForm", () => {
       editIndividualAdmin = stub().returns(new Promise<void>(resolve => resolve()));
       wrapper = mount(
         <IndividualAdminEditForm
-          data={{ individualAdmins: [adminData] }}
+          data={{ individualAdmins: [adminData], allLibraries }}
           disabled={false}
           editItem={editIndividualAdmin}
           urlBase="url base"
           listDataKey="admins"
           />
       );
+    });
+
+    describe("roles", () => {
+      let input;
+      let adminDataWithRoles;
+      const allRoles = ["system", "manager-all", "librarian-all", "manager-nypl", "manager-bpl", "librarian-nypl", "librarian-bpl"];
+      const expectRoles = (expected) => {
+        for (const role of allRoles) {
+          let shouldBeChecked = expected.includes(role);
+          expect(editableInputByName(role).props().checked).to.equal(shouldBeChecked);
+        }
+      };
+
+      it("changes system admin role", () => {
+        adminDataWithRoles = Object.assign({}, adminData, { roles: nyplManagerLibrarianAll });
+        wrapper.setProps({ item: adminDataWithRoles });
+
+        input = editableInputByName("system");
+        input.find("input").simulate("change");
+        expectRoles(allRoles);
+
+        input.find("input").simulate("change");
+        expectRoles([]);
+      });
+
+      it("changes manager all role", () => {
+        input = editableInputByName("manager-all");
+        input.find("input").simulate("change");
+        expectRoles(["manager-all", "librarian-all", "manager-nypl", "manager-bpl", "librarian-nypl", "librarian-bpl"]);
+
+        input.find("input").simulate("change");
+        expectRoles(["librarian-all", "librarian-nypl", "librarian-bpl"]);
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: systemAdmin });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input.find("input").simulate("change");
+        expectRoles(["librarian-all", "librarian-nypl", "librarian-bpl"]);
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: nyplManagerLibrarianAll });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input.find("input").simulate("change");
+        expectRoles(["manager-all", "librarian-all", "manager-nypl", "manager-bpl", "librarian-nypl", "librarian-bpl"]);
+      });
+
+      it("changes librarian all role", () => {
+        input = editableInputByName("librarian-all");
+        input.find("input").simulate("change");
+        expectRoles(["librarian-all", "librarian-nypl", "librarian-bpl"]);
+
+        input.find("input").simulate("change");
+        expectRoles([]);
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: systemAdmin });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input.find("input").simulate("change");
+        expectRoles([]);
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: nyplManagerLibrarianAll });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input.find("input").simulate("change");
+        expectRoles(["manager-nypl", "librarian-nypl"]);
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: nyplLibrarian });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input.find("input").simulate("change");
+        expectRoles(["librarian-all", "librarian-nypl", "librarian-bpl"]);
+      });
+
+      it("changes manager role for each library", () => {
+        let role = "manager-nypl";
+        input = editableInputByName(role);
+        input.find("input").simulate("change");
+        expectRoles(["manager-nypl", "librarian-nypl"]);
+
+        input.find("input").simulate("change");
+        expectRoles(["librarian-nypl"]);
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: systemAdmin });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input.find("input").simulate("change");
+        expectRoles(["librarian-all", "manager-bpl", "librarian-nypl", "librarian-bpl"]);
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: managerAll });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input.find("input").simulate("change");
+        expectRoles(["librarian-all", "manager-bpl", "librarian-nypl", "librarian-bpl"]);
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: nyplManagerLibrarianAll });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input.find("input").simulate("change");
+        expectRoles(["librarian-all", "librarian-nypl", "librarian-bpl"]);
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: nyplLibrarian });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input.find("input").simulate("change");
+        expectRoles(["manager-nypl", "librarian-nypl"]);
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: bplLibrarian });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input.find("input").simulate("change");
+        expectRoles(["manager-nypl", "librarian-nypl", "librarian-bpl"]);
+      });
+
+      it("changes librarian role for each library", () => {
+        input = editableInputByName("librarian-nypl");
+        input.find("input").simulate("change");
+        expectRoles(["librarian-nypl"]);
+
+        input.find("input").simulate("change");
+        expectRoles([]);
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: systemAdmin });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input.find("input").simulate("change");
+        expectRoles(["manager-bpl", "librarian-bpl"]);
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: managerAll });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input.find("input").simulate("change");
+        expectRoles(["manager-bpl", "librarian-bpl"]);
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: nyplManagerLibrarianAll });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input.find("input").simulate("change");
+        expectRoles(["librarian-bpl"]);
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: bplLibrarian });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input.find("input").simulate("change");
+        expectRoles(["librarian-nypl", "librarian-bpl"]);
+      });
     });
 
     it("submits data", async () => {
@@ -363,6 +306,10 @@ describe("IndividualAdminEditForm", () => {
       let pwInputElement = pwInput.get(0);
       pwInputElement.value = "newPassword";
       pwInput.simulate("change");
+      let librarianAllInput = editableInputByName("librarian-all");
+      librarianAllInput.find("input").simulate("change");
+      let managerNyplInput = editableInputByName("manager-nypl");
+      managerNyplInput.find("input").simulate("change");
 
       let form = wrapper.find("form");
       form.simulate("submit");
@@ -371,6 +318,7 @@ describe("IndividualAdminEditForm", () => {
       let formData = editIndividualAdmin.args[0][0];
       expect(formData.get("email")).to.equal("newEmail");
       expect(formData.get("password")).to.equal("newPassword");
+      expect(formData.get("roles")).to.equal(JSON.stringify([{ role: "librarian-all" }, { role: "manager", library: "nypl" }]));
 
       wrapper.setProps({ editedIdentifier: "newEmail" });
       // Let the call stack clear so the callback after editItem will run.

--- a/src/components/__tests__/IndividualAdminEditForm-test.tsx
+++ b/src/components/__tests__/IndividualAdminEditForm-test.tsx
@@ -63,14 +63,94 @@ describe("IndividualAdminEditForm", () => {
       expect(input.props().value).to.equal("test@nypl.org");
     });
 
-    it("renders password", () => {
+    it("renders password if admin is allowed to edit it", () => {
       let input = editableInputByName("password");
       expect(input.props().value).not.to.be.ok;
 
-      wrapper.setProps({ item: adminData });
-      input = editableInputByName("password");
-      // Doesn't show the old password even if it's in the props.
-      expect(input.props().value).not.to.be.ok;
+      const expectPasswordEditable = (targetAdminRoles, editingAdminRoles, editable: boolean = true) => {
+        let targetAdmin = new Admin(targetAdminRoles);
+        let editingAdmin = new Admin(editingAdminRoles);
+        wrapper.setProps({ item: targetAdmin });
+        wrapper.setContext({ admin: editingAdmin });
+        let input = editableInputByName("password");
+        if (editable) {
+          expect(input.length).to.equal(1);
+          // The old password isn't shown even if it's editable.
+          expect(input.props().value).not.to.be.ok;
+        } else {
+          expect(input.length).to.equal(0);
+        }
+      };
+
+      expectPasswordEditable([], systemAdmin);
+      expectPasswordEditable([], managerAll);
+      expectPasswordEditable([], librarianAll, false);
+      expectPasswordEditable([], nyplManager);
+      expectPasswordEditable([], nyplLibrarian, false);
+      expectPasswordEditable([], nyplManagerLibrarianAll);
+
+      expectPasswordEditable(systemAdmin, systemAdmin);
+      expectPasswordEditable(systemAdmin, managerAll, false);
+      expectPasswordEditable(systemAdmin, librarianAll, false);
+      expectPasswordEditable(systemAdmin, nyplManager, false);
+      expectPasswordEditable(systemAdmin, nyplLibrarian, false);
+      expectPasswordEditable(systemAdmin, nyplManagerLibrarianAll, false);
+
+      expectPasswordEditable(managerAll, systemAdmin);
+      expectPasswordEditable(managerAll, managerAll);
+      expectPasswordEditable(managerAll, librarianAll, false);
+      expectPasswordEditable(managerAll, nyplManager, false);
+      expectPasswordEditable(managerAll, nyplLibrarian, false);
+      expectPasswordEditable(managerAll, nyplManagerLibrarianAll, false);
+
+      expectPasswordEditable(librarianAll, systemAdmin);
+      expectPasswordEditable(librarianAll, managerAll);
+      expectPasswordEditable(librarianAll, librarianAll, false);
+      expectPasswordEditable(librarianAll, nyplManager, false);
+      expectPasswordEditable(librarianAll, nyplLibrarian, false);
+      expectPasswordEditable(librarianAll, nyplManagerLibrarianAll, false);
+
+      expectPasswordEditable(nyplManager, systemAdmin);
+      expectPasswordEditable(nyplManager, managerAll);
+      expectPasswordEditable(nyplManager, librarianAll, false);
+      expectPasswordEditable(nyplManager, nyplManager);
+      expectPasswordEditable(nyplManager, nyplLibrarian, false);
+      expectPasswordEditable(nyplManager, nyplManagerLibrarianAll);
+
+      expectPasswordEditable(bplManager, systemAdmin);
+      expectPasswordEditable(bplManager, managerAll);
+      expectPasswordEditable(bplManager, librarianAll, false);
+      expectPasswordEditable(bplManager, nyplManager, false);
+      expectPasswordEditable(bplManager, nyplLibrarian, false);
+      expectPasswordEditable(bplManager, nyplManagerLibrarianAll, false);
+
+      expectPasswordEditable(bothManager, systemAdmin);
+      expectPasswordEditable(bothManager, managerAll);
+      expectPasswordEditable(bothManager, librarianAll, false);
+      expectPasswordEditable(bothManager, nyplManager);
+      expectPasswordEditable(bothManager, nyplLibrarian, false);
+      expectPasswordEditable(bothManager, nyplManagerLibrarianAll);
+
+      expectPasswordEditable(nyplLibrarian, systemAdmin);
+      expectPasswordEditable(nyplLibrarian, managerAll);
+      expectPasswordEditable(nyplLibrarian, librarianAll, false);
+      expectPasswordEditable(nyplLibrarian, nyplManager);
+      expectPasswordEditable(nyplLibrarian, nyplLibrarian, false);
+      expectPasswordEditable(nyplLibrarian, nyplManagerLibrarianAll);
+
+      expectPasswordEditable(bplLibrarian, systemAdmin);
+      expectPasswordEditable(bplLibrarian, managerAll);
+      expectPasswordEditable(bplLibrarian, librarianAll, false);
+      expectPasswordEditable(bplLibrarian, nyplManager, false);
+      expectPasswordEditable(bplLibrarian, nyplLibrarian, false);
+      expectPasswordEditable(bplLibrarian, nyplManagerLibrarianAll, false);
+
+      expectPasswordEditable(nyplManagerLibrarianAll, systemAdmin);
+      expectPasswordEditable(nyplManagerLibrarianAll, managerAll);
+      expectPasswordEditable(nyplManagerLibrarianAll, librarianAll, false);
+      expectPasswordEditable(nyplManagerLibrarianAll, nyplManager);
+      expectPasswordEditable(nyplManagerLibrarianAll, nyplLibrarian, false);
+      expectPasswordEditable(nyplManagerLibrarianAll, nyplManagerLibrarianAll);
     });
 
     describe("roles", () => {

--- a/src/components/__tests__/IndividualAdminEditForm-test.tsx
+++ b/src/components/__tests__/IndividualAdminEditForm-test.tsx
@@ -270,6 +270,14 @@ describe("IndividualAdminEditForm", () => {
         expectRole(nyplLibrarian, "librarian-bpl", false, true);
         expectRole(bplLibrarian, "librarian-bpl", true, true);
       });
+
+      it("does not render roles when setting up first admin", () => {
+        wrapper.setContext({ settingUp: true });
+        for (const role of ["system", "manager-all", "librarian-all", "manager-nypl", "librarian-nypl"]) {
+          let input = editableInputByName(role);
+          expect(input.length).to.equal(0);
+        }
+      });
     });
   });
 
@@ -454,6 +462,30 @@ describe("IndividualAdminEditForm", () => {
       await pause();
       expect(window.location.href).to.contain("edit");
       expect(window.location.href).to.contain("newEmail");
+    });
+
+    it("submits system admin when setting up", () => {
+      Object.defineProperty(window.location, "href", { writable: true, value: "url base/create" });
+
+      wrapper.setContext({ settingUp: true });
+
+      let emailInput = wrapper.find("input[name='email']");
+      let emailInputElement = emailInput.get(0);
+      emailInputElement.value = "newEmail";
+      emailInput.simulate("change");
+      let pwInput = wrapper.find("input[name='password']");
+      let pwInputElement = pwInput.get(0);
+      pwInputElement.value = "newPassword";
+      pwInput.simulate("change");
+
+      let form = wrapper.find("form");
+      form.simulate("submit");
+
+      expect(editIndividualAdmin.callCount).to.equal(1);
+      let formData = editIndividualAdmin.args[0][0];
+      expect(formData.get("email")).to.equal("newEmail");
+      expect(formData.get("password")).to.equal("newPassword");
+      expect(formData.get("roles")).to.equal(JSON.stringify([{ role: "system" }]));
     });
   });
 });

--- a/src/components/__tests__/IndividualAdminEditForm-test.tsx
+++ b/src/components/__tests__/IndividualAdminEditForm-test.tsx
@@ -14,6 +14,10 @@ describe("IndividualAdminEditForm", () => {
     email: "test@nypl.org",
     password: "password"
   };
+  let allLibraries = [
+    { short_name: "nypl" },
+    { short_name: "bpl" }
+  ];
 
   let editableInputByName = (name) => {
     let inputs = wrapper.find(EditableInput);
@@ -28,7 +32,7 @@ describe("IndividualAdminEditForm", () => {
       editIndividualAdmin = stub();
       wrapper = shallow(
         <IndividualAdminEditForm
-          data={{ individualAdmins: [adminData] }}
+          data={{ individualAdmins: [adminData], allLibraries }}
           disabled={false}
           editItem={editIndividualAdmin}
           urlBase="url base"
@@ -54,6 +58,281 @@ describe("IndividualAdminEditForm", () => {
       input = editableInputByName("password");
       // Doesn't show the old password even if it's in the props.
       expect(input.props().value).not.to.be.ok;
+    });
+
+    describe("roles", () => {
+      let input;
+      let adminDataWithRoles;
+      let systemAdmin = [{ role: "system" }];
+      let managerAll = [{ role: "manager-all" }];
+      let librarianAll = [{ role: "librarian-all" }];
+      let nyplManager = [{ role: "manager", library: "nypl" }];
+      let bplManager = [{ role: "manager", library: "bpl" }];
+      let bothManager = [{ role: "manager", library: "nypl" }, { role: "manager", library: "bpl" }];
+      let nyplLibrarian = [{ role: "librarian", library: "nypl" }];
+      let bplLibrarian = [{ role: "librarian", library: "bpl" }];
+      let bothLibrarian = [{ role: "librarian", library: "nypl" }, { role: "librarian", library: "bpl" }];
+      let nyplManagerBplLibrarian = [{ role: "manager", library: "nypl" }, { role: "librarian", library: "bpl" }];
+      let nyplManagerLibrarianAll = [{ role: "manager", library: "nypl" }, { role: "librarian-all" }];
+
+      it("renders system admin role", () => {
+        let role = "system";
+        input = editableInputByName(role);
+        expect(input.props().checked).not.to.be.ok;
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: systemAdmin });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input = editableInputByName(role);
+        expect(input.props().checked).to.be.ok;
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: managerAll });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input = editableInputByName(role);
+        expect(input.props().checked).not.to.be.ok;
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: bothLibrarian });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input = editableInputByName(role);
+        expect(input.props().checked).not.to.be.ok;
+      });
+
+      it("renders manager all role", () => {
+        let role = "manager-all";
+        input = editableInputByName(role);
+        expect(input.props().checked).not.to.be.ok;
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: systemAdmin });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input = editableInputByName(role);
+        expect(input.props().checked).to.be.ok;
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: managerAll });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input = editableInputByName(role);
+        expect(input.props().checked).to.be.ok;
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: bothManager });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input = editableInputByName(role);
+        expect(input.props().checked).not.to.be.ok;
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: nyplManager });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input = editableInputByName(role);
+        expect(input.props().checked).not.to.be.ok;
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: librarianAll });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input = editableInputByName(role);
+        expect(input.props().checked).not.to.be.ok;
+      });
+
+      it("renders librarian all role", () => {
+        let role = "librarian-all";
+        input = editableInputByName(role);
+        expect(input.props().checked).not.to.be.ok;
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: systemAdmin });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input = editableInputByName(role);
+        expect(input.props().checked).to.be.ok;
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: managerAll });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input = editableInputByName(role);
+        expect(input.props().checked).to.be.ok;
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: bothManager });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input = editableInputByName(role);
+        expect(input.props().checked).not.to.be.ok;
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: nyplManager });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input = editableInputByName(role);
+        expect(input.props().checked).not.to.be.ok;
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: librarianAll });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input = editableInputByName(role);
+        expect(input.props().checked).to.be.ok;
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: bothLibrarian });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input = editableInputByName(role);
+        expect(input.props().checked).not.to.be.ok;
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: nyplLibrarian });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input = editableInputByName(role);
+        expect(input.props().checked).not.to.be.ok;
+      });
+
+      it("renders manager role for each library", () => {
+        let role = "manager-nypl";
+        input = editableInputByName(role);
+        expect(input.props().checked).not.to.be.ok;
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: systemAdmin });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input = editableInputByName(role);
+        expect(input.props().checked).to.be.ok;
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: managerAll });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input = editableInputByName(role);
+        expect(input.props().checked).to.be.ok;
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: bothManager });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input = editableInputByName(role);
+        expect(input.props().checked).to.be.ok;
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: nyplManager });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input = editableInputByName(role);
+        expect(input.props().checked).to.be.ok;
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: librarianAll });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input = editableInputByName(role);
+        expect(input.props().checked).not.to.be.ok;
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: bplManager });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input = editableInputByName(role);
+        expect(input.props().checked).not.to.be.ok;
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: nyplLibrarian });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input = editableInputByName(role);
+        expect(input.props().checked).not.to.be.ok;
+
+        role = "manager-bpl";
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: systemAdmin });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input = editableInputByName(role);
+        expect(input.props().checked).to.be.ok;
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: managerAll });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input = editableInputByName(role);
+        expect(input.props().checked).to.be.ok;
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: bothManager });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input = editableInputByName(role);
+        expect(input.props().checked).to.be.ok;
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: nyplManager });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input = editableInputByName(role);
+        expect(input.props().checked).not.to.be.ok;
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: librarianAll });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input = editableInputByName(role);
+        expect(input.props().checked).not.to.be.ok;
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: bplManager });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input = editableInputByName(role);
+        expect(input.props().checked).to.be.ok;
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: nyplLibrarian });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input = editableInputByName(role);
+        expect(input.props().checked).not.to.be.ok;
+      });
+
+      it("renders librarian role for each library", () => {
+        let role = "librarian-nypl";
+        input = editableInputByName(role);
+        expect(input.props().checked).not.to.be.ok;
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: systemAdmin });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input = editableInputByName(role);
+        expect(input.props().checked).to.be.ok;
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: managerAll });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input = editableInputByName(role);
+        expect(input.props().checked).to.be.ok;
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: bothManager });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input = editableInputByName(role);
+        expect(input.props().checked).to.be.ok;
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: nyplManager });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input = editableInputByName(role);
+        expect(input.props().checked).to.be.ok;
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: librarianAll });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input = editableInputByName(role);
+        expect(input.props().checked).to.be.ok;
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: bplManager });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input = editableInputByName(role);
+        expect(input.props().checked).not.to.be.ok;
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: nyplLibrarian });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input = editableInputByName(role);
+        expect(input.props().checked).to.be.ok;
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: bplLibrarian });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input = editableInputByName(role);
+        expect(input.props().checked).not.to.be.ok;
+
+        role = "librarian-bpl";
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: systemAdmin });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input = editableInputByName(role);
+        expect(input.props().checked).to.be.ok;
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: managerAll });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input = editableInputByName(role);
+        expect(input.props().checked).to.be.ok;
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: bothManager });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input = editableInputByName(role);
+        expect(input.props().checked).to.be.ok;
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: nyplManager });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input = editableInputByName(role);
+        expect(input.props().checked).not.to.be.ok;
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: librarianAll });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input = editableInputByName(role);
+        expect(input.props().checked).to.be.ok;
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: bplManager });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input = editableInputByName(role);
+        expect(input.props().checked).to.be.ok;
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: nyplLibrarian });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input = editableInputByName(role);
+        expect(input.props().checked).not.to.be.ok;
+
+        adminDataWithRoles = Object.assign({}, adminData, { roles: bplLibrarian });
+        wrapper.setProps({ item: adminDataWithRoles });
+        input = editableInputByName(role);
+        expect(input.props().checked).to.be.ok;
+      });
     });
   });
 

--- a/src/components/__tests__/IndividualAdminEditForm-test.tsx
+++ b/src/components/__tests__/IndividualAdminEditForm-test.tsx
@@ -6,6 +6,7 @@ import { shallow, mount } from "enzyme";
 
 import IndividualAdminEditForm from "../IndividualAdminEditForm";
 import EditableInput from "../EditableInput";
+import Admin from "../../models/Admin";
 
 describe("IndividualAdminEditForm", () => {
   let wrapper;
@@ -48,7 +49,8 @@ describe("IndividualAdminEditForm", () => {
           editItem={editIndividualAdmin}
           urlBase="url base"
           listDataKey="admins"
-          />
+          />,
+        { context: { admin: new Admin(systemAdmin) }}
       );
     });
 
@@ -72,11 +74,12 @@ describe("IndividualAdminEditForm", () => {
     });
 
     describe("roles", () => {
-      const expectRole = (startingRoles, role, shouldBeChecked: boolean) => {
+      const expectRole = (startingRoles, role, shouldBeChecked: boolean, shouldBeEnabled: boolean = true) => {
         let adminDataWithRoles = Object.assign({}, adminData, { roles: startingRoles });
         wrapper.setProps({ item: adminDataWithRoles });
         let input = editableInputByName(role);
         expect(input.props().checked).to.equal(shouldBeChecked);
+        expect(input.props().disabled).to.equal(!shouldBeEnabled);
       };
 
       it("renders system admin role", () => {
@@ -84,6 +87,12 @@ describe("IndividualAdminEditForm", () => {
         expectRole(systemAdmin, "system", true);
         expectRole(managerAll, "system", false);
         expectRole(bothLibrarian, "system", false);
+
+        wrapper.setContext({ admin: new Admin(managerAll) });
+        expectRole([], "system", false, false);
+        expectRole(systemAdmin, "system", true, false);
+        expectRole(managerAll, "system", false, false);
+        expectRole(bothLibrarian, "system", false, false);
       });
 
       it("renders manager all role", () => {
@@ -93,6 +102,22 @@ describe("IndividualAdminEditForm", () => {
         expectRole(bothManager, "manager-all", false);
         expectRole(nyplManager, "manager-all", false);
         expectRole(librarianAll, "manager-all", false);
+
+        wrapper.setContext({ admin: new Admin(librarianAll) });
+        expectRole([], "manager-all", false, false);
+        expectRole(systemAdmin, "manager-all", true, false);
+        expectRole(managerAll, "manager-all", true, false);
+        expectRole(bothManager, "manager-all", false, false);
+        expectRole(nyplManager, "manager-all", false, false);
+        expectRole(librarianAll, "manager-all", false, false);
+
+        wrapper.setContext({ admin: new Admin(nyplManager) });
+        expectRole([], "manager-all", false, false);
+        expectRole(systemAdmin, "manager-all", true, false);
+        expectRole(managerAll, "manager-all", true, false);
+        expectRole(bothManager, "manager-all", false, false);
+        expectRole(nyplManager, "manager-all", false, false);
+        expectRole(librarianAll, "manager-all", false, false);
       });
 
       it("renders librarian all role", () => {
@@ -104,6 +129,26 @@ describe("IndividualAdminEditForm", () => {
         expectRole(librarianAll, "librarian-all", true);
         expectRole(bothLibrarian, "librarian-all", false);
         expectRole(nyplLibrarian, "librarian-all", false);
+
+        wrapper.setContext({ admin: new Admin(nyplManager) });
+        expectRole([], "librarian-all", false, false);
+        expectRole(systemAdmin, "librarian-all", true, false);
+        expectRole(managerAll, "librarian-all", true, false);
+        expectRole(bothManager, "librarian-all", false, false);
+        expectRole(nyplManager, "librarian-all", false, false);
+        expectRole(librarianAll, "librarian-all", true, false);
+        expectRole(bothLibrarian, "librarian-all", false, false);
+        expectRole(nyplLibrarian, "librarian-all", false, false);
+
+        wrapper.setContext({ admin: new Admin(librarianAll) });
+        expectRole([], "librarian-all", false, false);
+        expectRole(systemAdmin, "librarian-all", true, false);
+        expectRole(managerAll, "librarian-all", true, false);
+        expectRole(bothManager, "librarian-all", false, false);
+        expectRole(nyplManager, "librarian-all", false, false);
+        expectRole(librarianAll, "librarian-all", true, false);
+        expectRole(bothLibrarian, "librarian-all", false, false);
+        expectRole(nyplLibrarian, "librarian-all", false, false);
       });
 
       it("renders manager role for each library", () => {
@@ -123,6 +168,44 @@ describe("IndividualAdminEditForm", () => {
         expectRole(librarianAll, "manager-bpl", false);
         expectRole(bplManager, "manager-bpl", true);
         expectRole(nyplLibrarian, "manager-bpl", false);
+
+        wrapper.setContext({ admin: new Admin(nyplManager) });
+
+        expectRole([], "manager-nypl", false, true);
+        expectRole(systemAdmin, "manager-nypl", true, false);
+        expectRole(managerAll, "manager-nypl", true, false);
+        expectRole(bothManager, "manager-nypl", true, true);
+        expectRole(nyplManager, "manager-nypl", true, true);
+        expectRole(librarianAll, "manager-nypl", false, true);
+        expectRole(bplManager, "manager-nypl", false, true);
+        expectRole(nyplLibrarian, "manager-nypl", false, true);
+
+        expectRole(systemAdmin, "manager-bpl", true, false);
+        expectRole(managerAll, "manager-bpl", true, false);
+        expectRole(bothManager, "manager-bpl", true, false);
+        expectRole(nyplManager, "manager-bpl", false, false);
+        expectRole(librarianAll, "manager-bpl", false, false);
+        expectRole(bplManager, "manager-bpl", true, false);
+        expectRole(nyplLibrarian, "manager-bpl", false, false);
+
+        wrapper.setContext({ admin: new Admin(managerAll) });
+
+        expectRole([], "manager-nypl", false, true);
+        expectRole(systemAdmin, "manager-nypl", true, false);
+        expectRole(managerAll, "manager-nypl", true, true);
+        expectRole(bothManager, "manager-nypl", true, true);
+        expectRole(nyplManager, "manager-nypl", true, true);
+        expectRole(librarianAll, "manager-nypl", false, true);
+        expectRole(bplManager, "manager-nypl", false, true);
+        expectRole(nyplLibrarian, "manager-nypl", false, true);
+
+        expectRole(systemAdmin, "manager-bpl", true, false);
+        expectRole(managerAll, "manager-bpl", true, true);
+        expectRole(bothManager, "manager-bpl", true, true);
+        expectRole(nyplManager, "manager-bpl", false, true);
+        expectRole(librarianAll, "manager-bpl", false, true);
+        expectRole(bplManager, "manager-bpl", true, true);
+        expectRole(nyplLibrarian, "manager-bpl", false, true);
       });
 
       it("renders librarian role for each library", () => {
@@ -144,6 +227,48 @@ describe("IndividualAdminEditForm", () => {
         expectRole(bplManager, "librarian-bpl", true);
         expectRole(nyplLibrarian, "librarian-bpl", false);
         expectRole(bplLibrarian, "librarian-bpl", true);
+
+        wrapper.setContext({ admin: new Admin(nyplManager) });
+
+        expectRole([], "librarian-nypl", false, true);
+        expectRole(systemAdmin, "librarian-nypl", true, false);
+        expectRole(managerAll, "librarian-nypl", true, false);
+        expectRole(bothManager, "librarian-nypl", true, true);
+        expectRole(nyplManager, "librarian-nypl", true, true);
+        expectRole(librarianAll, "librarian-nypl", true, false);
+        expectRole(bplManager, "librarian-nypl", false, true);
+        expectRole(nyplLibrarian, "librarian-nypl", true, true);
+        expectRole(bplLibrarian, "librarian-nypl", false, true);
+
+        expectRole(systemAdmin, "librarian-bpl", true, false);
+        expectRole(managerAll, "librarian-bpl", true, false);
+        expectRole(bothManager, "librarian-bpl", true, false);
+        expectRole(nyplManager, "librarian-bpl", false, false);
+        expectRole(librarianAll, "librarian-bpl", true, false);
+        expectRole(bplManager, "librarian-bpl", true, false);
+        expectRole(nyplLibrarian, "librarian-bpl", false, false);
+        expectRole(bplLibrarian, "librarian-bpl", true, false);
+
+        wrapper.setContext({ admin: new Admin(managerAll) });
+
+        expectRole([], "librarian-nypl", false, true);
+        expectRole(systemAdmin, "librarian-nypl", true, false);
+        expectRole(managerAll, "librarian-nypl", true, true);
+        expectRole(bothManager, "librarian-nypl", true, true);
+        expectRole(nyplManager, "librarian-nypl", true, true);
+        expectRole(librarianAll, "librarian-nypl", true, true);
+        expectRole(bplManager, "librarian-nypl", false, true);
+        expectRole(nyplLibrarian, "librarian-nypl", true, true);
+        expectRole(bplLibrarian, "librarian-nypl", false, true);
+
+        expectRole(systemAdmin, "librarian-bpl", true, false);
+        expectRole(managerAll, "librarian-bpl", true, true);
+        expectRole(bothManager, "librarian-bpl", true, true);
+        expectRole(nyplManager, "librarian-bpl", false, true);
+        expectRole(librarianAll, "librarian-bpl", true, true);
+        expectRole(bplManager, "librarian-bpl", true, true);
+        expectRole(nyplLibrarian, "librarian-bpl", false, true);
+        expectRole(bplLibrarian, "librarian-bpl", true, true);
       });
     });
   });
@@ -158,7 +283,8 @@ describe("IndividualAdminEditForm", () => {
           editItem={editIndividualAdmin}
           urlBase="url base"
           listDataKey="admins"
-          />
+          />,
+        { context: { admin: new Admin(systemAdmin) }}
       );
     });
 

--- a/src/components/__tests__/LoggingServices-test.tsx
+++ b/src/components/__tests__/LoggingServices-test.tsx
@@ -91,7 +91,7 @@ describe("LoggingServices", () => {
   it("shows logging service list", () => {
     let loggingService = wrapper.find("li");
     expect(loggingService.length).to.equal(1);
-    expect(loggingService.at(0).text()).to.contain("logglyEdit<PencilIcon />Delete<TrashIcon />");
+    expect(loggingService.at(0).text()).to.contain("Edit<PencilIcon />logglyDelete<TrashIcon />");
     let editLink = loggingService.at(0).find("a");
     expect(editLink.props().href).to.equal("/admin/web/config/loggingServices/edit/1");
   });

--- a/src/components/__tests__/ProtocolFormField-test.tsx
+++ b/src/components/__tests__/ProtocolFormField-test.tsx
@@ -323,4 +323,37 @@ describe("ProtocolFormField", () => {
     let img = wrapper.find("img");
     expect(img.prop("src")).to.equal("image data");
   });
+
+  it("gets value of list setting without options", () => {
+    const setting = {
+      key: "setting",
+      label: "label",
+      description: "<p>description</p>",
+      type: "list"
+    };
+    let wrapper = mount(
+      <ProtocolFormField
+        setting={setting}
+        disabled={false}
+        value={["item 1", "item 2"]}
+        />
+    );
+    expect((wrapper.instance() as ProtocolFormField).getValue()).to.deep.equal(["item 1", "item 2"]);
+  });
+
+  it("gets value of text setting", () => {
+    const setting = {
+      key: "setting",
+      label: "label",
+      description: "<p>description</p>"
+    };
+    const wrapper = mount(
+      <ProtocolFormField
+        setting={setting}
+        disabled={true}
+        value="test"
+        />
+    );
+    expect((wrapper.instance() as ProtocolFormField).getValue()).to.equal("test");
+  });
 });

--- a/src/components/__tests__/ServiceEditForm-test.tsx
+++ b/src/components/__tests__/ServiceEditForm-test.tsx
@@ -312,7 +312,7 @@ describe("ServiceEditForm", () => {
       expect(input.props().value).to.equal("child setting");
     });
 
-    it("doesn't render libraries for sitewide protocol", () => {
+    it("doesn't render libraries for sitewide protocol without library settings", () => {
       let servicesDataSitewide = Object.assign({}, servicesData, {
         protocols: [servicesData.protocols[1]]
       });
@@ -344,6 +344,25 @@ describe("ServiceEditForm", () => {
       );
       library = wrapper.find(WithRemoveButton);
       expect(library.length).to.equal(0);
+    });
+
+    it("renders libraries for a sitewide protocol with library settings", () => {
+      let servicesDataSitewide = Object.assign({}, servicesData, {
+        protocols: [Object.assign({}, servicesData.protocols[1], { sitewide: true })]
+      });
+
+      wrapper = mount(
+        <TestServiceEditForm
+          disabled={false}
+          data={servicesDataSitewide}
+          editItem={editService}
+          item={serviceData}
+          urlBase={urlBase}
+          listDataKey="services"
+          />
+      );
+      let library = wrapper.find(WithRemoveButton);
+      expect(library.length).to.equal(1);
     });
 
     it("renders removable and editable libraries", () => {
@@ -422,7 +441,26 @@ describe("ServiceEditForm", () => {
       expect(select.length).to.equal(0);
     });
 
-    it("renders library add dropdown", () => {
+    it("renders library add dropdown for a sitewide protocol with library settings", () => {
+      let servicesDataSitewide = Object.assign({}, servicesData, {
+        protocols: [Object.assign({}, servicesData.protocols[1], { sitewide: true })]
+      });
+
+      wrapper = mount(
+        <TestServiceEditForm
+          disabled={false}
+          data={servicesDataSitewide}
+          editItem={editService}
+          item={serviceData}
+          urlBase={urlBase}
+          listDataKey="services"
+          />
+      );
+      let select = wrapper.find("select[name='add-library']");
+      expect(select.length).to.equal(1);
+    });
+
+    it("renders library add dropdown for a non-sitewide protocol", () => {
       let select = editableInputByName("add-library");
       expect(select.props().label).to.equal("Add Library");
 

--- a/src/components/__tests__/SetupPage-test.tsx
+++ b/src/components/__tests__/SetupPage-test.tsx
@@ -6,7 +6,6 @@ import { shallow } from "enzyme";
 
 import buildStore from "../../store";
 import SetupPage from "../SetupPage";
-import AdminAuthServices from "../AdminAuthServices";
 import IndividualAdmins from "../IndividualAdmins";
 
 describe("SetupPage", () => {
@@ -25,15 +24,6 @@ describe("SetupPage", () => {
       <SetupPage />,
       { context }
     );
-  });
-
-  it("shows admin auth services create form", () => {
-    let adminAuthServices = wrapper.find(AdminAuthServices);
-    expect(adminAuthServices).to.be.ok;
-    expect(adminAuthServices.props().store).to.equal(store);
-    expect(adminAuthServices.props().csrfToken).to.equal("token");
-    expect(adminAuthServices.props().editOrCreate).to.equal("create");
-    expect(adminAuthServices.props().identifier).to.be.undefined;
   });
 
   it("shows individual admins create form", () => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,6 +7,7 @@ import CustomListPage from "./components/CustomListPage";
 import LanePage from "./components/LanePage";
 import DashboardPage from "./components/DashboardPage";
 import ConfigPage from "./components/ConfigPage";
+import AccountPage from "./components/AccountPage";
 import SetupPage from "./components/SetupPage";
 
 interface ConfigurationSettings {
@@ -25,6 +26,9 @@ interface ConfigurationSettings {
       for configuring admin authentication. The admin will need to set that up
       and log in before accessing the rest of the interface. */
   settingUp: boolean;
+
+  /** `email` will be the email address of the currently logged in admin. */
+  email?: string;
 
   /** `roles` contains the logged in admin's roles: system admininstrator,
       or library manager or librarian for one or more libraries. */
@@ -62,6 +66,7 @@ class CirculationWeb {
             <Route path={lanePagePath} component={LanePage} />
             <Route path="/admin/web/dashboard" component={DashboardPage} />
             <Route path="/admin/web/config(/:tab)(/:editOrCreate)(/:identifier)" component={ConfigPage} />
+            <Route path="/admin/web/account" component={AccountPage} />
           </Router>
         </ContextProvider>,
         document.getElementById("opds-catalog")

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -25,6 +25,13 @@ interface ConfigurationSettings {
       for configuring admin authentication. The admin will need to set that up
       and log in before accessing the rest of the interface. */
   settingUp: boolean;
+
+  /** `roles` contains the logged in admin's roles: system admininstrator,
+      or library manager or librarian for one or more libraries. */
+  roles?: {
+    role: string;
+    library?: string;
+  }[];
 }
 
 /** The main admin interface application. Create an instance of this class

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -210,13 +210,20 @@ export interface AdminAuthServicesData extends ServicesData {
   admin_auth_services: AdminAuthServiceData[];
 }
 
+export interface AdminRoleData {
+  library?: string;
+  role: string;
+}
+
 export interface IndividualAdminData {
   email: string;
   password?: string;
+  roles?: AdminRoleData[];
 }
 
 export interface IndividualAdminsData {
   individualAdmins?: IndividualAdminData[];
+  allLibraries?: LibraryData[];
 }
 
 export interface PatronAuthServiceData extends ServiceData {}

--- a/src/models/Admin.ts
+++ b/src/models/Admin.ts
@@ -2,14 +2,16 @@ import { AdminRoleData } from "../interfaces";
 
 export default class Admin {
   roles: AdminRoleData[];
+  email: string | null = null;
   private systemAdmin: boolean = false;
   private sitewideLibraryManager: boolean = false;
   private sitewideLibrarian: boolean = false;
   private manager: boolean = false;
   private libraryRoles: {[library: string]: string} = {};
 
-  constructor(roles: AdminRoleData[]) {
+  constructor(roles: AdminRoleData[], email?: string) {
     this.roles = roles;
+    this.email = email;
     for (const role of roles) {
       switch (role.role) {
         case "system": {

--- a/src/models/Admin.ts
+++ b/src/models/Admin.ts
@@ -2,80 +2,64 @@ import { AdminRoleData } from "../interfaces";
 
 export default class Admin {
    roles: AdminRoleData[];
+   private systemAdmin: boolean = false;
+   private sitewideLibraryManager: boolean = false;
+   private sitewideLibrarian: boolean = false;
+   private manager: boolean = false;
+   private libraryRoles: {[library: string]: string} = {};
 
    constructor(roles: AdminRoleData[]) {
      this.roles = roles;
+     for (const role of this.roles) {
+       switch (role.role) {
+         case "system": {
+           this.systemAdmin = true;
+         }
+         case "manager-all": {
+           this.sitewideLibraryManager = true;
+           this.manager = true;
+         }
+         case "librarian-all": {
+           this.sitewideLibrarian = true;
+           break;
+         }
+         case "manager": {
+           this.manager = true;
+           this.libraryRoles[role.library] = "manager";
+           break;
+         }
+         case "librarian": {
+           this.libraryRoles[role.library] = "librarian";
+           break;
+         }
+         default: {
+           break;
+         }
+       }
+     }
    }
 
    isSystemAdmin() {
-     for (const role of this.roles) {
-       if (role.role === "system") {
-         return true;
-       }
-     }
-     return false;
+     return this.systemAdmin;
    }
 
    isSitewideLibraryManager() {
-     if (this.isSystemAdmin()) {
-       return true;
-     }
-     for (const role of this.roles) {
-       if (role.role === "manager-all") {
-         return true;
-       }
-     }
-     return false;
+     return this.sitewideLibraryManager;
    }
 
    isSitewideLibrarian() {
-     if (this.isSitewideLibraryManager()) {
-       return true;
-     }
-     for (const role of this.roles) {
-       if (role.role === "librarian-all") {
-         return true;
-       }
-     }
-     return false;
+     return this.sitewideLibrarian;
    }
 
    isLibraryManager(library: string) {
-     if (this.isSitewideLibraryManager()) {
-       return true;
-     }
-     for (const role of this.roles) {
-       if (role.role === "manager" && role.library === library) {
-         return true;
-       }
-     }
-     return false;
+     return this.sitewideLibraryManager || this.libraryRoles[library] === "manager";
    }
 
    isLibrarian(library: string) {
-     if (this.isSitewideLibrarian()) {
-       return true;
-     }
-     if (this.isLibraryManager(library)) {
-       return true;
-     }
-     for (const role of this.roles) {
-       if (role.role === "librarian" && role.library === library) {
-         return true;
-       }
-     }
-     return false;
+     return this.isLibraryManager(library) || this.sitewideLibrarian || this.libraryRoles[library] === "librarian";
    }
 
    isLibraryManagerOfSomeLibrary() {
-     if (this.isSitewideLibraryManager()) {
-       return true;
-     }
-     for (const role of this.roles) {
-       if (role.role === "manager") {
-         return true;
-       }
-     }
-     return false;
+     return this.manager;
    }
 };

--- a/src/models/Admin.ts
+++ b/src/models/Admin.ts
@@ -1,0 +1,81 @@
+import { AdminRoleData } from "../interfaces";
+
+export default class Admin {
+   roles: AdminRoleData[];
+
+   constructor(roles: AdminRoleData[]) {
+     this.roles = roles;
+   }
+
+   isSystemAdmin() {
+     for (const role of this.roles) {
+       if (role.role === "system") {
+         return true;
+       }
+     }
+     return false;
+   }
+
+   isSitewideLibraryManager() {
+     if (this.isSystemAdmin()) {
+       return true;
+     }
+     for (const role of this.roles) {
+       if (role.role === "manager-all") {
+         return true;
+       }
+     }
+     return false;
+   }
+
+   isSitewideLibrarian() {
+     if (this.isSitewideLibraryManager()) {
+       return true;
+     }
+     for (const role of this.roles) {
+       if (role.role === "librarian-all") {
+         return true;
+       }
+     }
+     return false;
+   }
+
+   isLibraryManager(library: string) {
+     if (this.isSitewideLibraryManager()) {
+       return true;
+     }
+     for (const role of this.roles) {
+       if (role.role === "manager" && role.library === library) {
+         return true;
+       }
+     }
+     return false;
+   }
+
+   isLibrarian(library: string) {
+     if (this.isSitewideLibrarian()) {
+       return true;
+     }
+     if (this.isLibraryManager(library)) {
+       return true;
+     }
+     for (const role of this.roles) {
+       if (role.role === "librarian" && role.library === library) {
+         return true;
+       }
+     }
+     return false;
+   }
+
+   isLibraryManagerOfSomeLibrary() {
+     if (this.isSitewideLibraryManager()) {
+       return true;
+     }
+     for (const role of this.roles) {
+       if (role.role === "manager") {
+         return true;
+       }
+     }
+     return false;
+   }
+};

--- a/src/models/Admin.ts
+++ b/src/models/Admin.ts
@@ -1,65 +1,84 @@
 import { AdminRoleData } from "../interfaces";
 
 export default class Admin {
-   roles: AdminRoleData[];
-   private systemAdmin: boolean = false;
-   private sitewideLibraryManager: boolean = false;
-   private sitewideLibrarian: boolean = false;
-   private manager: boolean = false;
-   private libraryRoles: {[library: string]: string} = {};
+  roles: AdminRoleData[];
+  private systemAdmin: boolean = false;
+  private sitewideLibraryManager: boolean = false;
+  private sitewideLibrarian: boolean = false;
+  private manager: boolean = false;
+  private libraryRoles: {[library: string]: string} = {};
 
-   constructor(roles: AdminRoleData[]) {
-     this.roles = roles;
-     for (const role of this.roles) {
-       switch (role.role) {
-         case "system": {
-           this.systemAdmin = true;
-         }
-         case "manager-all": {
-           this.sitewideLibraryManager = true;
-           this.manager = true;
-         }
-         case "librarian-all": {
-           this.sitewideLibrarian = true;
-           break;
-         }
-         case "manager": {
-           this.manager = true;
-           this.libraryRoles[role.library] = "manager";
-           break;
-         }
-         case "librarian": {
-           this.libraryRoles[role.library] = "librarian";
-           break;
-         }
-         default: {
-           break;
-         }
-       }
-     }
-   }
+  constructor(roles: AdminRoleData[]) {
+    this.roles = roles;
+    for (const role of roles) {
+      switch (role.role) {
+        case "system": {
+          this.systemAdmin = true;
+        }
+        case "manager-all": {
+          this.sitewideLibraryManager = true;
+          this.manager = true;
+        }
+        case "librarian-all": {
+          this.sitewideLibrarian = true;
+          break;
+        }
+        case "manager": {
+          this.manager = true;
+          this.libraryRoles[role.library] = "manager";
+          break;
+        }
+        case "librarian": {
+          this.libraryRoles[role.library] = "librarian";
+          break;
+        }
+        default: {
+          break;
+        }
+      }
+    }
+  }
 
-   isSystemAdmin() {
-     return this.systemAdmin;
-   }
+  hasRole(role: string, library?: string) {
+    if (this.isSystemAdmin()) {
+      return true;
+    }
+    if (role !== "system" && this.isSitewideLibraryManager()) {
+      return true;
+    }
+    if (role === "librarian-all" && this.isSitewideLibrarian()) {
+      return true;
+    }
+    if (role === "manager" && this.isLibraryManager(library)) {
+      return true;
+    }
+    if (role === "librarian" && this.isLibrarian(library)) {
+      return true;
+    }
+    return false;
+  }
 
-   isSitewideLibraryManager() {
-     return this.sitewideLibraryManager;
-   }
+  isSystemAdmin() {
+    return this.systemAdmin;
+  }
 
-   isSitewideLibrarian() {
-     return this.sitewideLibrarian;
-   }
+  isSitewideLibraryManager() {
+    return this.sitewideLibraryManager;
+  }
 
-   isLibraryManager(library: string) {
-     return this.sitewideLibraryManager || this.libraryRoles[library] === "manager";
-   }
+  isSitewideLibrarian() {
+    return this.sitewideLibrarian;
+  }
 
-   isLibrarian(library: string) {
-     return this.isLibraryManager(library) || this.sitewideLibrarian || this.libraryRoles[library] === "librarian";
-   }
+  isLibraryManager(library: string) {
+    return this.sitewideLibraryManager || this.libraryRoles[library] === "manager";
+  }
 
-   isLibraryManagerOfSomeLibrary() {
-     return this.manager;
-   }
+  isLibrarian(library: string) {
+    return this.isLibraryManager(library) || this.sitewideLibrarian || this.libraryRoles[library] === "librarian";
+  }
+
+  isLibraryManagerOfSomeLibrary() {
+    return this.manager;
+  }
 };

--- a/src/models/__tests__/Admin-test.ts
+++ b/src/models/__tests__/Admin-test.ts
@@ -16,6 +16,11 @@ describe("Admin", () => {
   const libraryManagerALibrarianB = new Admin([{ "role": "manager", "library": "a" },
                                                { "role": "librarian", "library": "b" }]);
 
+  it("stores email", () => {
+    expect((new Admin([], "email")).email).to.equal("email");
+    expect((new Admin([])).email).not.to.be.ok;
+  });
+
   it("identifies system admins", () => {
     expect(systemAdmin.isSystemAdmin()).to.be.ok;
     expect(sitewideLibraryManager.isSystemAdmin()).not.to.be.ok;

--- a/src/models/__tests__/Admin-test.ts
+++ b/src/models/__tests__/Admin-test.ts
@@ -1,0 +1,110 @@
+import { expect } from "chai";
+
+import Admin from "../Admin";
+
+describe("Admin", () => {
+
+  const systemAdmin = new Admin([{ "role": "system" }]);
+  const sitewideLibraryManager = new Admin([{ "role": "manager-all" }]);
+  const sitewideLibrarian = new Admin([{ "role": "librarian-all" }]);
+  const libraryManagerA = new Admin([{ "role": "manager", "library": "a" }]);
+  const librarianA = new Admin([{ "role": "librarian", "library": "a" }]);
+  const libraryManagerB = new Admin([{ "role": "manager", "library": "b" }]);
+  const librarianB = new Admin([{ "role": "librarian", "library": "b" }]);
+  const libraryManagerASitewideLibrarian = new Admin([{ "role": "librarian-all" },
+                                                      { "role": "manager", "library": "a" }]);
+  const libraryManagerALibrarianB = new Admin([{ "role": "manager", "library": "a" },
+                                               { "role": "librarian", "library": "b" }]);
+
+  it("identifies system admins", () => {
+    expect(systemAdmin.isSystemAdmin()).to.be.ok;
+    expect(sitewideLibraryManager.isSystemAdmin()).not.to.be.ok;
+    expect(sitewideLibrarian.isSystemAdmin()).not.to.be.ok;
+    expect(libraryManagerA.isSystemAdmin()).not.to.be.ok;
+    expect(librarianA.isSystemAdmin()).not.to.be.ok;
+    expect(libraryManagerB.isSystemAdmin()).not.to.be.ok;
+    expect(librarianB.isSystemAdmin()).not.to.be.ok;
+    expect(libraryManagerASitewideLibrarian.isSystemAdmin()).not.to.be.ok;
+    expect(libraryManagerALibrarianB.isSystemAdmin()).not.to.be.ok;
+  });
+
+  it("identifies sitewide library managers", () => {
+    expect(systemAdmin.isSitewideLibraryManager()).to.be.ok;
+    expect(sitewideLibraryManager.isSitewideLibraryManager()).to.be.ok;
+    expect(sitewideLibrarian.isSitewideLibraryManager()).not.to.be.ok;
+    expect(libraryManagerA.isSitewideLibraryManager()).not.to.be.ok;
+    expect(librarianA.isSitewideLibraryManager()).not.to.be.ok;
+    expect(libraryManagerB.isSitewideLibraryManager()).not.to.be.ok;
+    expect(librarianB.isSitewideLibraryManager()).not.to.be.ok;
+    expect(libraryManagerASitewideLibrarian.isSitewideLibraryManager()).not.to.be.ok;
+    expect(libraryManagerALibrarianB.isSitewideLibraryManager()).not.to.be.ok;
+  });
+
+  it("identifies sitewide librarians", () => {
+    expect(systemAdmin.isSitewideLibrarian()).to.be.ok;
+    expect(sitewideLibraryManager.isSitewideLibrarian()).to.be.ok;
+    expect(sitewideLibrarian.isSitewideLibrarian()).to.be.ok;
+    expect(libraryManagerA.isSitewideLibrarian()).not.to.be.ok;
+    expect(librarianA.isSitewideLibrarian()).not.to.be.ok;
+    expect(libraryManagerB.isSitewideLibrarian()).not.to.be.ok;
+    expect(librarianB.isSitewideLibrarian()).not.to.be.ok;
+    expect(libraryManagerASitewideLibrarian.isSitewideLibrarian()).to.be.ok;
+    expect(libraryManagerALibrarianB.isSitewideLibrarian()).not.to.be.ok;
+  });
+
+  it("identifies library managers", () => {
+    expect(systemAdmin.isLibraryManager("a")).to.be.ok;
+    expect(sitewideLibraryManager.isLibraryManager("a")).to.be.ok;
+    expect(sitewideLibrarian.isLibraryManager("a")).not.to.be.ok;
+    expect(libraryManagerA.isLibraryManager("a")).to.be.ok;
+    expect(librarianA.isLibraryManager("a")).not.to.be.ok;
+    expect(libraryManagerB.isLibraryManager("a")).not.to.be.ok;
+    expect(librarianB.isLibraryManager("a")).not.to.be.ok;
+    expect(libraryManagerASitewideLibrarian.isLibraryManager("a")).to.be.ok;
+    expect(libraryManagerALibrarianB.isLibraryManager("a")).to.be.ok;
+
+    expect(systemAdmin.isLibraryManager("b")).to.be.ok;
+    expect(sitewideLibraryManager.isLibraryManager("b")).to.be.ok;
+    expect(sitewideLibrarian.isLibraryManager("b")).not.to.be.ok;
+    expect(libraryManagerA.isLibraryManager("b")).not.to.be.ok;
+    expect(librarianA.isLibraryManager("b")).not.to.be.ok;
+    expect(libraryManagerB.isLibraryManager("b")).to.be.ok;
+    expect(librarianB.isLibraryManager("b")).not.to.be.ok;
+    expect(libraryManagerASitewideLibrarian.isLibraryManager("b")).not.to.be.ok;
+    expect(libraryManagerALibrarianB.isLibraryManager("b")).not.to.be.ok;
+  });
+
+  it("identifies librarians", () => {
+    expect(systemAdmin.isLibrarian("a")).to.be.ok;
+    expect(sitewideLibraryManager.isLibrarian("a")).to.be.ok;
+    expect(sitewideLibrarian.isLibrarian("a")).to.be.ok;
+    expect(libraryManagerA.isLibrarian("a")).to.be.ok;
+    expect(librarianA.isLibrarian("a")).to.be.ok;
+    expect(libraryManagerB.isLibrarian("a")).not.to.be.ok;
+    expect(librarianB.isLibrarian("a")).not.to.be.ok;
+    expect(libraryManagerASitewideLibrarian.isLibrarian("a")).to.be.ok;
+    expect(libraryManagerALibrarianB.isLibrarian("a")).to.be.ok;
+
+    expect(systemAdmin.isLibrarian("b")).to.be.ok;
+    expect(sitewideLibraryManager.isLibrarian("b")).to.be.ok;
+    expect(sitewideLibrarian.isLibrarian("b")).to.be.ok;
+    expect(libraryManagerA.isLibrarian("b")).not.to.be.ok;
+    expect(librarianA.isLibrarian("b")).not.to.be.ok;
+    expect(libraryManagerB.isLibrarian("b")).to.be.ok;
+    expect(librarianB.isLibrarian("b")).to.be.ok;
+    expect(libraryManagerASitewideLibrarian.isLibrarian("b")).to.be.ok;
+    expect(libraryManagerALibrarianB.isLibrarian("b")).to.be.ok;
+  });
+
+  it("identifies all library managers", () => {
+    expect(systemAdmin.isLibraryManagerOfSomeLibrary()).to.be.ok;
+    expect(sitewideLibraryManager.isLibraryManagerOfSomeLibrary()).to.be.ok;
+    expect(sitewideLibrarian.isLibraryManagerOfSomeLibrary()).not.to.be.ok;
+    expect(libraryManagerA.isLibraryManagerOfSomeLibrary()).to.be.ok;
+    expect(librarianA.isLibraryManagerOfSomeLibrary()).not.to.be.ok;
+    expect(libraryManagerB.isLibraryManagerOfSomeLibrary()).to.be.ok;
+    expect(librarianB.isLibraryManagerOfSomeLibrary()).not.to.be.ok;
+    expect(libraryManagerASitewideLibrarian.isLibraryManagerOfSomeLibrary()).to.be.ok;
+    expect(libraryManagerALibrarianB.isLibraryManagerOfSomeLibrary()).to.be.ok;
+  });
+});

--- a/src/models/__tests__/Admin-test.ts
+++ b/src/models/__tests__/Admin-test.ts
@@ -107,4 +107,78 @@ describe("Admin", () => {
     expect(libraryManagerASitewideLibrarian.isLibraryManagerOfSomeLibrary()).to.be.ok;
     expect(libraryManagerALibrarianB.isLibraryManagerOfSomeLibrary()).to.be.ok;
   });
+
+  it("checks for specific roles", () => {
+    expect(systemAdmin.hasRole("system")).to.be.ok;
+    expect(systemAdmin.hasRole("manager-all")).to.be.ok;
+    expect(systemAdmin.hasRole("librarian-all")).to.be.ok;
+    expect(systemAdmin.hasRole("manager", "a")).to.be.ok;
+    expect(systemAdmin.hasRole("librarian", "a")).to.be.ok;
+    expect(systemAdmin.hasRole("manager", "b")).to.be.ok;
+    expect(systemAdmin.hasRole("librarian", "b")).to.be.ok;
+
+    expect(sitewideLibraryManager.hasRole("system")).not.to.be.ok;
+    expect(sitewideLibraryManager.hasRole("manager-all")).to.be.ok;
+    expect(sitewideLibraryManager.hasRole("librarian-all")).to.be.ok;
+    expect(sitewideLibraryManager.hasRole("manager", "a")).to.be.ok;
+    expect(sitewideLibraryManager.hasRole("librarian", "a")).to.be.ok;
+    expect(sitewideLibraryManager.hasRole("manager", "b")).to.be.ok;
+    expect(sitewideLibraryManager.hasRole("librarian", "b")).to.be.ok;
+
+    expect(sitewideLibrarian.hasRole("system")).not.to.be.ok;
+    expect(sitewideLibrarian.hasRole("manager-all")).not.to.be.ok;
+    expect(sitewideLibrarian.hasRole("librarian-all")).to.be.ok;
+    expect(sitewideLibrarian.hasRole("manager", "a")).not.to.be.ok;
+    expect(sitewideLibrarian.hasRole("librarian", "a")).to.be.ok;
+    expect(sitewideLibrarian.hasRole("manager", "b")).not.to.be.ok;
+    expect(sitewideLibrarian.hasRole("librarian", "b")).to.be.ok;
+
+    expect(libraryManagerA.hasRole("system")).not.to.be.ok;
+    expect(libraryManagerA.hasRole("manager-all")).not.to.be.ok;
+    expect(libraryManagerA.hasRole("librarian-all")).not.to.be.ok;
+    expect(libraryManagerA.hasRole("manager", "a")).to.be.ok;
+    expect(libraryManagerA.hasRole("librarian", "a")).to.be.ok;
+    expect(libraryManagerA.hasRole("manager", "b")).not.to.be.ok;
+    expect(libraryManagerA.hasRole("librarian", "b")).not.to.be.ok;
+
+    expect(librarianA.hasRole("system")).not.to.be.ok;
+    expect(librarianA.hasRole("manager-all")).not.to.be.ok;
+    expect(librarianA.hasRole("librarian-all")).not.to.be.ok;
+    expect(librarianA.hasRole("manager", "a")).not.to.be.ok;
+    expect(librarianA.hasRole("librarian", "a")).to.be.ok;
+    expect(librarianA.hasRole("manager", "b")).not.to.be.ok;
+    expect(librarianA.hasRole("librarian", "b")).not.to.be.ok;
+
+    expect(libraryManagerB.hasRole("system")).not.to.be.ok;
+    expect(libraryManagerB.hasRole("manager-all")).not.to.be.ok;
+    expect(libraryManagerB.hasRole("librarian-all")).not.to.be.ok;
+    expect(libraryManagerB.hasRole("manager", "a")).not.to.be.ok;
+    expect(libraryManagerB.hasRole("librarian", "a")).not.to.be.ok;
+    expect(libraryManagerB.hasRole("manager", "b")).to.be.ok;
+    expect(libraryManagerB.hasRole("librarian", "b")).to.be.ok;
+
+    expect(librarianB.hasRole("system")).not.to.be.ok;
+    expect(librarianB.hasRole("manager-all")).not.to.be.ok;
+    expect(librarianB.hasRole("librarian-all")).not.to.be.ok;
+    expect(librarianB.hasRole("manager", "a")).not.to.be.ok;
+    expect(librarianB.hasRole("librarian", "a")).not.to.be.ok;
+    expect(librarianB.hasRole("manager", "b")).not.to.be.ok;
+    expect(librarianB.hasRole("librarian", "b")).to.be.ok;
+
+    expect(libraryManagerASitewideLibrarian.hasRole("system")).not.to.be.ok;
+    expect(libraryManagerASitewideLibrarian.hasRole("manager-all")).not.to.be.ok;
+    expect(libraryManagerASitewideLibrarian.hasRole("librarian-all")).to.be.ok;
+    expect(libraryManagerASitewideLibrarian.hasRole("manager", "a")).to.be.ok;
+    expect(libraryManagerASitewideLibrarian.hasRole("librarian", "a")).to.be.ok;
+    expect(libraryManagerASitewideLibrarian.hasRole("manager", "b")).not.to.be.ok;
+    expect(libraryManagerASitewideLibrarian.hasRole("librarian", "b")).to.be.ok;
+
+    expect(libraryManagerALibrarianB.hasRole("system")).not.to.be.ok;
+    expect(libraryManagerALibrarianB.hasRole("manager-all")).not.to.be.ok;
+    expect(libraryManagerALibrarianB.hasRole("librarian-all")).not.to.be.ok;
+    expect(libraryManagerALibrarianB.hasRole("manager", "a")).to.be.ok;
+    expect(libraryManagerALibrarianB.hasRole("librarian", "a")).to.be.ok;
+    expect(libraryManagerALibrarianB.hasRole("manager", "b")).not.to.be.ok;
+    expect(libraryManagerALibrarianB.hasRole("librarian", "b")).to.be.ok;
+  });
 });

--- a/src/reducers/changePassword.ts
+++ b/src/reducers/changePassword.ts
@@ -1,0 +1,4 @@
+import ActionCreator from "../actions";
+import createFetchEditReducer from "./createFetchEditReducer";
+
+export default createFetchEditReducer<void>(ActionCreator.CHANGE_PASSWORD);

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -31,6 +31,7 @@ import roles from "./roles";
 import media from "./media";
 import languages from "./languages";
 import collection, { CollectionState } from "opds-web-client/lib/reducers/collection";
+import changePassword from "./changePassword";
 import { FetchEditState } from "./createFetchEditReducer";
 import { RegisterLibraryState } from "./createRegisterLibraryReducer";
 import {
@@ -75,6 +76,7 @@ export interface State {
   roles: FetchEditState<RolesData>;
   media: FetchEditState<MediaData>;
   languages: FetchEditState<LanguagesData>;
+  changePassword: FetchEditState<void>;
 }
 
 export default combineReducers<State>({
@@ -109,5 +111,6 @@ export default combineReducers<State>({
   resetLanes,
   roles,
   media,
-  languages
+  languages,
+  changePassword
 });

--- a/src/stylesheets/app.scss
+++ b/src/stylesheets/app.scss
@@ -5,6 +5,7 @@
 @import "book_details_container";
 @import "book_details_tab_container";
 @import "button_form";
+@import "change_password_form";
 @import "circulation_events_download_form";
 @import "classifications";
 @import "classifications_form";

--- a/src/stylesheets/app.scss
+++ b/src/stylesheets/app.scss
@@ -23,6 +23,7 @@
 @import "genre_form";
 @import "header";
 @import "icon";
+@import "individual_admin_edit_form";
 @import "lane_editor";
 @import "lanes";
 @import "protocol_form_field";

--- a/src/stylesheets/change_password_form.scss
+++ b/src/stylesheets/change_password_form.scss
@@ -1,0 +1,3 @@
+.change-password-form {
+  margin: 20px;
+}

--- a/src/stylesheets/config_tab_container.scss
+++ b/src/stylesheets/config_tab_container.scss
@@ -1,3 +1,5 @@
+$dangercolor: #D9534F;
+
 .config {
   .tab-container {
     position: relative;
@@ -33,23 +35,25 @@
         li {
           display: flex;
           flex-direction: row;
+          justify-content: space-between;
+          align-items: center;
+          max-width: 600px;
           margin: 20px 0px;
           padding-bottom: 5px;
           border-bottom: 1px solid $pagetextcolor;
 
           h4 {
             margin-right: 20px;
+            flex-grow: 1;
           }
 
           .btn-default {
-            display: flex;
-            flex-direction: column;
             margin-right: 10px;
           }
         }
       }
 
-      a.btn-default, button.btn-default {
+      a.btn-default, button.btn-default, a.btn-danger, button.btn-danger {
         color: $pagecolor;
         svg {
           height: 0.7em;
@@ -62,6 +66,18 @@
           color: $pagetextcolor;
           svg {
             fill: $pagetextcolor;
+          }
+        }
+      }
+
+      a.btn-danger, button.btn-danger {
+        border-radius: 0;
+        &:hover {
+          background-color: white;
+          border-color: $dangercolor;
+          color: $dangercolor;
+          svg {
+            fill: $dangercolor;
           }
         }
       }

--- a/src/stylesheets/header.scss
+++ b/src/stylesheets/header.scss
@@ -23,6 +23,8 @@
 .navbar-nav .dropdown-menu {
   display: block;
   background-color: $dark;
+  left: auto;
+  right: 0;
 
   a {
     background-color: $dark;

--- a/src/stylesheets/header.scss
+++ b/src/stylesheets/header.scss
@@ -19,3 +19,23 @@
   display: inline-block;
   width: auto;
 }
+
+.navbar-nav .dropdown-menu {
+  display: block;
+  background-color: $dark;
+
+  a {
+    background-color: $dark;
+    color: $pagecolorlight;
+
+    &:hover, &:visited, &:active {
+      background-color: $dark;
+      color: $pagecolorlight;
+      text-decoration: underline;
+    }
+  }
+}
+
+.navbar-collapse.in {
+  overflow-y: visible;
+}

--- a/src/stylesheets/header.scss
+++ b/src/stylesheets/header.scss
@@ -28,10 +28,9 @@
     background-color: $dark;
     color: $pagecolorlight;
 
-    &:hover, &:visited, &:active {
-      background-color: $dark;
-      color: $pagecolorlight;
-      text-decoration: underline;
+    &:hover, &:visited, &:active, &:focus {
+      background-color: $pagecolorlight;
+      color: $dark;
     }
   }
 }

--- a/src/stylesheets/individual_admin_edit_form.scss
+++ b/src/stylesheets/individual_admin_edit_form.scss
@@ -1,0 +1,20 @@
+table.library-admin-roles {
+  width: 100%;
+  margin-bottom: 20px;
+
+  td, th {
+    text-align: center;
+
+    &:first-child {
+      text-align: left;
+    }
+  }
+
+  th {
+    padding-bottom: 25px;
+
+    .form-group {
+      margin-bottom: 0;
+    }
+  }
+}


### PR DESCRIPTION
This goes with https://github.com/NYPL-Simplified/circulation/pull/935. It adds an Admin object to the context that's used by various components to check the admin's roles and decide what to display. It also adds a bunch of checkboxes to the admin edit page for setting an admin's roles.