### PR TITLE
Different sources book list

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.0.66",
+  "version": "0.0.67",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/components/CustomListEntriesEditor.tsx
+++ b/src/components/CustomListEntriesEditor.tsx
@@ -238,7 +238,7 @@ export default class CustomListEntriesEditor extends React.Component<CustomListE
 
   getDataSource(book) {
     if (!book.raw || !book.raw["bibframe:distribution"] ||
-      !book.raw["bibframe:distribution"].length || book.raw["bibframe:distribution"][0]["$"] ||
+      !book.raw["bibframe:distribution"].length || !book.raw["bibframe:distribution"][0]["$"] ||
       !book.raw["bibframe:distribution"][0]["$"]["bibframe:ProviderName"]) {
       return "";
     }
@@ -306,7 +306,7 @@ export default class CustomListEntriesEditor extends React.Component<CustomListE
       if (this.getPwid(result) === pwid) {
         const medium = this.getMedium(result);
         const language = this.getLanguage(result);
-        const data_source_id = this.getDataSource(result);
+        const data_source = this.getDataSource(result);
         entries.unshift({
           pwid: pwid,
           title: result.title,
@@ -314,7 +314,7 @@ export default class CustomListEntriesEditor extends React.Component<CustomListE
           url: result.url,
           medium,
           language,
-          data_source_id,
+          data_source,
         });
       }
     }
@@ -339,7 +339,7 @@ export default class CustomListEntriesEditor extends React.Component<CustomListE
     for (const result of this.searchResultsNotInEntries()) {
       const medium = this.getMedium(result);
       const language = this.getLanguage(result);
-      const data_source_id = this.getDataSource(result);
+      const data_source = this.getDataSource(result);
       entries.push({
         pwid: this.getPwid(result),
         title: result.title,
@@ -347,7 +347,7 @@ export default class CustomListEntriesEditor extends React.Component<CustomListE
         url: result.url,
         medium,
         language,
-        data_source_id,
+        data_source,
       });
     }
 

--- a/src/components/CustomListEntriesEditor.tsx
+++ b/src/components/CustomListEntriesEditor.tsx
@@ -236,6 +236,16 @@ export default class CustomListEntriesEditor extends React.Component<CustomListE
     return svgMediumTypes[medium] || null;
   }
 
+  getDataSource(book) {
+    if (!book.raw || !book.raw["bibframe:distribution"] ||
+      !book.raw["bibframe:distribution"].length || book.raw["bibframe:distribution"][0]["$"] ||
+      !book.raw["bibframe:distribution"][0]["$"]["bibframe:ProviderName"]) {
+      return "";
+    }
+
+    return book.raw["bibframe:distribution"][0]["$"]["bibframe:ProviderName"].value;
+  }
+
   getEntries(): CustomListEntryData[] {
     return this.state.entries;
   }
@@ -296,13 +306,15 @@ export default class CustomListEntriesEditor extends React.Component<CustomListE
       if (this.getPwid(result) === pwid) {
         const medium = this.getMedium(result);
         const language = this.getLanguage(result);
+        const data_source_id = this.getDataSource(result);
         entries.unshift({
           pwid: pwid,
           title: result.title,
           authors: result.authors,
           url: result.url,
           medium,
-          language
+          language,
+          data_source_id,
         });
       }
     }
@@ -327,13 +339,15 @@ export default class CustomListEntriesEditor extends React.Component<CustomListE
     for (const result of this.searchResultsNotInEntries()) {
       const medium = this.getMedium(result);
       const language = this.getLanguage(result);
+      const data_source_id = this.getDataSource(result);
       entries.push({
         pwid: this.getPwid(result),
         title: result.title,
         authors: result.authors,
         url: result.url,
         medium,
-        language
+        language,
+        data_source_id,
       });
     }
 

--- a/src/components/__tests__/CustomListEntriesEditor-test.tsx
+++ b/src/components/__tests__/CustomListEntriesEditor-test.tsx
@@ -30,7 +30,11 @@ describe("CustomListEntriesEditor", () => {
     navigationLinks: [],
     books: [
       { id: "1", title: "result 1", authors: ["author 1"], url: "/some/url1", language: "eng",
-        raw: { "simplified:pwid": [{ "_": "pwid1"}], "$": { "schema:additionalType": { "value": "http://schema.org/EBook" } } }},
+        raw: {
+          "simplified:pwid": [{ "_": "pwid1"}], "$": { "schema:additionalType": { "value": "http://schema.org/EBook" } },
+          "bibframe:distribution": [{ "$": { "bibframe:ProviderName": { value: "Standard eBooks" } } }],
+        }
+      },
       { id: "2", title: "result 2", authors: ["author 2a", "author 2b"], url: "/some/url2", language: "eng",
         raw: { "simplified:pwid": [{ "_": "pwid2"}], "$": { "schema:additionalType": { "value": "http://bib.schema.org/Audiobook" } } }},
       { id: "3", title: "result 3", authors: ["author 3"], url: "/some/url3", language: "eng",
@@ -39,8 +43,8 @@ describe("CustomListEntriesEditor", () => {
   };
 
   let entriesData = [
-    { pwid: "pwidA", title: "entry A", authors: ["author A"], medium: "http://schema.org/EBook", url: "/some/urlA", },
-    { pwid: "pwidB", title: "entry B", authors: ["author B1", "author B2"], medium: "http://bib.schema.org/Audiobook", url: "/some/urlB", }
+    { pwid: "pwidA", title: "entry A", authors: ["author A"], medium: "http://schema.org/EBook", url: "/some/urlA", data_source_id: "34" },
+    { pwid: "pwidB", title: "entry B", authors: ["author B1", "author B2"], medium: "http://bib.schema.org/Audiobook", url: "/some/urlB", data_source_id: "34" }
   ];
 
   beforeEach(() => {
@@ -343,6 +347,7 @@ describe("CustomListEntriesEditor", () => {
       medium: "http://schema.org/EBook",
       language: "eng",
       url: "/some/url1",
+      data_source_id: "",
     };
     const expectedEntries = [newEntry, entriesData[0], entriesData[1]];
     expect(onUpdate.args[0][0]).to.deep.equal(expectedEntries);
@@ -464,6 +469,7 @@ describe("CustomListEntriesEditor", () => {
       medium: "http://schema.org/EBook",
       language: "eng",
       url: "/some/url1",
+      data_source_id: "",
     };
     const expectedEntries = [newEntry, entriesData[0], entriesData[1]];
     expect(onUpdate.args[0][0]).to.deep.equal(expectedEntries);

--- a/src/components/__tests__/CustomListEntriesEditor-test.tsx
+++ b/src/components/__tests__/CustomListEntriesEditor-test.tsx
@@ -43,8 +43,8 @@ describe("CustomListEntriesEditor", () => {
   };
 
   let entriesData = [
-    { pwid: "pwidA", title: "entry A", authors: ["author A"], medium: "http://schema.org/EBook", url: "/some/urlA", data_source_id: "34" },
-    { pwid: "pwidB", title: "entry B", authors: ["author B1", "author B2"], medium: "http://bib.schema.org/Audiobook", url: "/some/urlB", data_source_id: "34" }
+    { pwid: "pwidA", title: "entry A", authors: ["author A"], medium: "http://schema.org/EBook", url: "/some/urlA", data_source: "Standard ebooks" },
+    { pwid: "pwidB", title: "entry B", authors: ["author B1", "author B2"], medium: "http://bib.schema.org/Audiobook", url: "/some/urlB", data_source: "Standard ebooks" }
   ];
 
   beforeEach(() => {
@@ -347,7 +347,7 @@ describe("CustomListEntriesEditor", () => {
       medium: "http://schema.org/EBook",
       language: "eng",
       url: "/some/url1",
-      data_source_id: "",
+      data_source: "Standard eBooks",
     };
     const expectedEntries = [newEntry, entriesData[0], entriesData[1]];
     expect(onUpdate.args[0][0]).to.deep.equal(expectedEntries);
@@ -469,7 +469,7 @@ describe("CustomListEntriesEditor", () => {
       medium: "http://schema.org/EBook",
       language: "eng",
       url: "/some/url1",
-      data_source_id: "",
+      data_source: "Standard eBooks",
     };
     const expectedEntries = [newEntry, entriesData[0], entriesData[1]];
     expect(onUpdate.args[0][0]).to.deep.equal(expectedEntries);

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -305,6 +305,7 @@ export interface CustomListEntryData {
   medium?: string;
   url?: string;
   language?: string;
+  data_source_id?: string;
 }
 
 export interface CustomListData {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -305,7 +305,7 @@ export interface CustomListEntryData {
   medium?: string;
   url?: string;
   language?: string;
-  data_source_id?: string;
+  data_source?: string;
 }
 
 export interface CustomListData {


### PR DESCRIPTION
Helps fix [circulation 938](https://github.com/NYPL-Simplified/circulation/issues/938).

Extracting the data source value from each search result item's opds feed object and passing it as `data_source_id` in the respective entry object when it gets added to a list. The `data_source_id` value of an entry object is an id number, but the value from the opds feed is a string. I'm looking that value up in the circulation manager and converting it to correct id before making a query. That's the only thing that bothers me about this since the value from a search result item to an entry will change from something like `"Standard eBooks"` to `"34"`.