### PR TITLE
Added tab for changing a book's cover.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.0.67",
+  "version": "0.0.68",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/__tests__/editorAdapter-test.ts
+++ b/src/__tests__/editorAdapter-test.ts
@@ -25,7 +25,9 @@ describe("editorAdapter", () => {
         { href: "restore", rel: "http://librarysimplified.org/terms/rel/restore", type: "type", title: "title" },
         { href: "refresh", rel: "http://librarysimplified.org/terms/rel/refresh", type: "type", title: "title" },
         { href: "edit", rel: "edit", type: "type", title: "title" },
-        { href: "issues", rel: "issues", type: "type", title: "title" }
+        { href: "issues", rel: "issues", type: "type", title: "title" },
+        { href: "change-cover", rel: "http://librarysimplified.org/terms/rel/change_cover", type: "type", title: "title" },
+        { href: "cover", rel: "http://opds-spec.org/image", type: "image/png", title: "title" },
       ],
       issued: "issued",
       language: "language",
@@ -63,6 +65,8 @@ describe("editorAdapter", () => {
     expect(adapted.refreshLink).to.deep.equal(entry.links[2]);
     expect(adapted.editLink).to.deep.equal(entry.links[3]);
     expect(adapted.issuesLink).to.deep.equal(entry.links[4]);
+    expect(adapted.changeCoverLink).to.deep.equal(entry.links[5]);
+    expect(adapted.coverUrl).to.equal(entry.links[6].href);
     expect(adapted.series).to.equal("series");
     expect(adapted.seriesPosition).to.equal(2);
     expect(adapted.medium).to.equal("medium");

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -8,7 +8,7 @@ import {
   CDNServicesData, SearchServicesData,
   DiscoveryServicesData, LibraryRegistrationsData,
   CustomListsData, CustomListDetailsData, LanesData,
-  RolesData, MediaData, LanguagesData,
+  RolesData, MediaData, LanguagesData, RightsStatusData,
   StorageServicesData, LoggingServicesData,
 } from "./interfaces";
 import DataFetcher from "opds-web-client/lib/DataFetcher";
@@ -23,12 +23,16 @@ export default class ActionCreator extends BaseActionCreator {
   static readonly ROLES = "ROLES";
   static readonly MEDIA = "MEDIA";
   static readonly LANGUAGES = "LANGUAGES";
+  static readonly RIGHTS_STATUSES = "RIGHTS_STATUSES";
   static readonly COMPLAINTS = "COMPLAINTS";
   static readonly POST_COMPLAINT = "POST_COMPLAINT";
   static readonly RESOLVE_COMPLAINTS = "RESOLVE_COMPLAINTS";
   static readonly GENRE_TREE = "GENRE_TREE";
   static readonly CLASSIFICATIONS = "CLASSIFICATIONS";
   static readonly EDIT_CLASSIFICATIONS = "EDIT_CLASSIFICATIONS";
+  static readonly BOOK_COVER = "BOOK_COVER";
+  static readonly EDIT_BOOK_COVER = "EDIT_BOOK_COVER";
+  static readonly PREVIEW_BOOK_COVER = "PREVIEW_BOOK_COVER";
   static readonly CUSTOM_LISTS_FOR_BOOK = "CUSTOM_LISTS_FOR_BOOK";
   static readonly EDIT_CUSTOM_LISTS_FOR_BOOK = "EDIT_CUSTOM_LISTS_FOR_BOOK";
   static readonly CIRCULATION_EVENTS = "CIRCULATION_EVENTS";
@@ -143,7 +147,7 @@ export default class ActionCreator extends BaseActionCreator {
   }
 
 
-  postForm(type: string, url: string, data: FormData | null, method?: string) {
+  postForm(type: string, url: string, data: FormData | null, method?: string, defaultErrorMessage?: string) {
     let err: RequestError;
 
     return (dispatch => {
@@ -181,7 +185,7 @@ export default class ActionCreator extends BaseActionCreator {
             }).catch(parseError => {
               err = {
                 status: response.status,
-                response: "Failed to save changes",
+                response: defaultErrorMessage || "Failed to save changes",
                 url: url
               };
               dispatch(this.failure(type, err));
@@ -277,6 +281,11 @@ export default class ActionCreator extends BaseActionCreator {
     return this.fetchJSON<LanguagesData>(ActionCreator.LANGUAGES, url).bind(this);
   }
 
+  fetchRightsStatuses() {
+    let url = "/admin/rights_status";
+    return this.fetchJSON<RightsStatusData>(ActionCreator.RIGHTS_STATUSES, url).bind(this);
+  }
+
   fetchComplaints(url: string) {
     return this.fetchJSON<ComplaintsData>(ActionCreator.COMPLAINTS, url).bind(this);
   }
@@ -299,6 +308,22 @@ export default class ActionCreator extends BaseActionCreator {
 
   fetchClassifications(url: string) {
     return this.fetchJSON<{ classifications: ClassificationData[] }>(ActionCreator.CLASSIFICATIONS, url).bind(this);
+  }
+
+  fetchBookCover(url: string) {
+    return null;
+  }
+
+  editBookCover(url: string, data: FormData) {
+    return this.postForm(ActionCreator.EDIT_BOOK_COVER, url, data).bind(this);
+  }
+
+  fetchBookCoverPreview(url: string, data: FormData) {
+    return this.postForm(ActionCreator.PREVIEW_BOOK_COVER, url, data, "POST", "Could not load preview").bind(this);
+  }
+
+  clearBookCoverPreview() {
+    return this.clear(ActionCreator.PREVIEW_BOOK_COVER);
   }
 
   fetchCustomListsForBook(url: string) {

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -310,10 +310,6 @@ export default class ActionCreator extends BaseActionCreator {
     return this.fetchJSON<{ classifications: ClassificationData[] }>(ActionCreator.CLASSIFICATIONS, url).bind(this);
   }
 
-  fetchBookCover(url: string) {
-    return null;
-  }
-
   editBookCover(url: string, data: FormData) {
     return this.postForm(ActionCreator.EDIT_BOOK_COVER, url, data).bind(this);
   }

--- a/src/components/BookCoverEditor.tsx
+++ b/src/components/BookCoverEditor.tsx
@@ -147,6 +147,7 @@ export class BookCoverEditor extends React.Component<BookCoverEditorProps, void>
                         }
                       )
                     }
+                    <option value="http://librarysimplified.org/terms/rights-status/in-copyright">In Copyright</option>
                     <option value="http://librarysimplified.org/terms/rights-status/unknown">Other</option>
                   </EditableInput>
                   <EditableInput

--- a/src/components/BookCoverEditor.tsx
+++ b/src/components/BookCoverEditor.tsx
@@ -147,6 +147,7 @@ export class BookCoverEditor extends React.Component<BookCoverEditorProps, void>
                         }
                       )
                     }
+                    <option value="http://librarysimplified.org/terms/rights-status/unknown">Other</option>
                   </EditableInput>
                   <EditableInput
                     elementType="textarea"

--- a/src/components/BookCoverEditor.tsx
+++ b/src/components/BookCoverEditor.tsx
@@ -1,0 +1,253 @@
+import * as React from "react";
+import { Store } from "redux";
+import { connect } from "react-redux";
+import editorAdapter from "../editorAdapter";
+import DataFetcher from "opds-web-client/lib/DataFetcher";
+import ActionCreator from "../actions";
+import ErrorMessage from "./ErrorMessage";
+import EditableInput from "./EditableInput";
+import { BookData, RightsStatusData } from "../interfaces";
+import { FetchErrorData } from "opds-web-client/lib/interfaces";
+import { State } from "../reducers/index";
+
+export interface BookCoverEditorStateProps {
+  bookAdminUrl?: string;
+  preview?: string;
+  rightsStatuses?: RightsStatusData;
+  fetchError?: FetchErrorData;
+  isFetching?: boolean;
+  previewFetchError?: FetchErrorData;
+  isFetchingPreview?: boolean;
+}
+
+export interface BookCoverEditorDispatchProps {
+  fetchBook?: (url: string) => Promise<any>;
+  fetchPreview?: (url: string, data: FormData) => Promise<any>;
+  clearPreview?: () => Promise<any>;
+  editCover?: (url: string, data: FormData) => Promise<any>;
+  fetchRightsStatuses?: () => Promise<RightsStatusData>;
+}
+
+export interface BookCoverEditorOwnProps {
+  store?: Store<State>;
+  csrfToken: string;
+  bookUrl: string;
+  book: BookData;
+  refreshCatalog: () => Promise<any>;
+}
+
+export interface BookCoverEditorProps extends BookCoverEditorStateProps, BookCoverEditorDispatchProps, BookCoverEditorOwnProps {};
+
+/** Tab on the book details page for uploading a new book cover. */
+export class BookCoverEditor extends React.Component<BookCoverEditorProps, void> {
+  constructor(props) {
+    super(props);
+    this.refresh = this.refresh.bind(this);
+    this.preview = this.preview.bind(this);
+    this.save = this.save.bind(this);
+  }
+
+  render(): JSX.Element {
+    return (
+      <div>
+        { this.props.book &&
+          <div>
+            <h2>
+              {this.props.book.title}
+            </h2>
+            { this.props.isFetching &&
+              <div className="cover-fetching-container">
+                <h4>
+                  Updating
+                  <i className="fa fa-spinner fa-spin"></i>
+                </h4>
+              </div>
+            }
+            <div>
+              <h3>Current cover:</h3>
+              <img
+                src={this.props.book.coverUrl}
+                className="book-cover current-cover"
+                alt="Current book cover"
+                />
+            </div>
+            <div>
+              <h3>Change cover:</h3>
+              <p>Cover must be at least 600px x 900px and in PNG, JPG, or GIF format.</p>
+              <form ref="cover">
+                <EditableInput
+                  elementType="input"
+                  type="text"
+                  disabled={this.props.isFetching}
+                  name="cover_url"
+                  label="URL for cover image"
+                  onChange={this.preview}
+                  ref="cover_url"
+                  />
+                <EditableInput
+                  elementType="input"
+                  type="file"
+                  disabled={this.props.isFetching}
+                  name="cover_file"
+                  label="Or upload cover image"
+                  accept="image/*"
+                  onChange={this.preview}
+                  ref="cover_file"
+                  />
+                <EditableInput
+                  elementType="select"
+                  disabled={this.props.isFetching}
+                  name="title_position"
+                  label="Title and Author Position"
+                  onChange={this.preview}
+                  value="none"
+                  >
+                  <option value="none">None</option>
+                  <option value="top">Top</option>
+                  <option value="center">Center</option>
+                  <option value="bottom">Bottom</option>
+                </EditableInput>
+              </form>
+              { this.props.previewFetchError &&
+                <ErrorMessage error={this.props.previewFetchError} />
+              }
+              { this.props.isFetchingPreview &&
+                <h5 className="cover-fetching-preview-container">
+                  Updating Preview&nbsp;
+                  <i className="fa fa-spinner fa-spin"></i>
+                </h5>
+              }
+              { this.props.preview &&
+                <div>
+                  <h4>Preview:</h4>
+                  <img
+                    src={this.props.preview}
+                    className="book-cover preview-cover"
+                    alt="Preview of new cover"
+                    />
+                </div>
+              }
+              { this.props.rightsStatuses &&
+                <form ref="rights">
+                  <h4>Rights:</h4>
+                  <EditableInput
+                    elementType="select"
+                    disabled={this.props.isFetching}
+                    name="rights_status"
+                    label="License"
+                    >
+                    { Object.keys(this.props.rightsStatuses).map(uri => {
+                          let status = this.props.rightsStatuses[uri];
+                          if (status.allows_derivatives) {
+                            return (
+                              <option value={uri} key={uri}>{status.name}</option>
+                            );
+                          }
+                          return null;
+                        }
+                      )
+                    }
+                  </EditableInput>
+                  <EditableInput
+                    elementType="textarea"
+                    disabled={this.props.isFetching}
+                    name="rights_explanation"
+                    label="Explanation of rights"
+                    />
+                </form>
+              }
+              <button
+                className="btn btn-default"
+                type="submit"
+                onClick={this.save}
+                disabled={this.props.isFetching || !this.props.preview}
+                >Save this cover</button>
+            </div>
+          </div>
+        }
+
+        { this.props.fetchError &&
+          <ErrorMessage error={this.props.fetchError} />
+        }
+
+      </div>
+    );
+  }
+
+  componentWillMount() {
+    if (this.props.clearPreview) {
+      this.props.clearPreview();
+    }
+    if (this.props.fetchRightsStatuses) {
+      this.props.fetchRightsStatuses();
+    }
+  }
+
+  previewUrl() {
+    return this.props.bookAdminUrl + "/preview_book_cover";
+  }
+
+  preview() {
+    const coverForm = (this.refs["cover"] as any);
+    const formData = new (window as any).FormData(coverForm);
+    const file = (this.refs["cover_file"] as any).getValue();
+    const url = (this.refs["cover_url"] as any).getValue();
+    if (!file && !url && this.props.clearPreview) {
+      this.props.clearPreview();
+    }
+    if ((file || url) && this.props.fetchPreview) {
+      this.props.fetchPreview(this.previewUrl(), formData);
+    }
+  }
+
+  refresh() {
+    this.props.fetchBook(this.props.bookAdminUrl);
+    this.props.refreshCatalog();
+  }
+
+  save () {
+    const editUrl = this.props.book && this.props.book.changeCoverLink && this.props.book.changeCoverLink.href;
+    const coverForm = (this.refs["cover"] as any);
+    const formData = new (window as any).FormData(coverForm);
+    const coverFile = (this.refs["cover_file"] as any).getValue();
+    const coverUrl = (this.refs["cover_url"] as any).getValue();
+    const rightsForm = (this.refs["rights"] as any);
+    const rightsFormData = new (window as any).FormData(rightsForm);
+    formData.append("rights_status", rightsFormData.get("rights_status"));
+    formData.append("rights_explanation", rightsFormData.get("rights_explanation"));
+    if (editUrl && this.props.preview && this.props.editCover) {
+      this.props.editCover(editUrl, formData).then(this.refresh);
+    }
+  }
+}
+
+function mapStateToProps(state, ownProps) {
+  return {
+    bookAdminUrl: state.editor.book.url,
+    preview: state.editor.bookCoverPreview.data,
+    rightsStatuses: state.editor.rightsStatuses.data,
+    isFetching: state.editor.book.isFetching || state.editor.bookCover.isFetching || state.editor.rightsStatuses.isFetching || state.editor.bookCover.isEditing,
+    fetchError: state.editor.book.fetchError || state.editor.bookCover.fetchError || state.editor.rightsStatuses.fetchError,
+    isFetchingPreview: state.editor.bookCoverPreview.isFetching,
+    previewFetchError: state.editor.bookCoverPreview.fetchError
+  };
+}
+
+function mapDispatchToProps(dispatch, ownProps) {
+  let fetcher = new DataFetcher({ adapter: editorAdapter });
+  let actions = new ActionCreator(fetcher, ownProps.csrfToken);
+  return {
+    fetchBook: (url: string) => dispatch(actions.fetchBookAdmin(url)),
+    fetchPreview: (url: string, data: FormData) => dispatch(actions.fetchBookCoverPreview(url, data)),
+    clearPreview: () => dispatch(actions.clearBookCoverPreview()),
+    editCover: (url: string, data: FormData) => dispatch(actions.editBookCover(url, data)),
+    fetchRightsStatuses: () => dispatch(actions.fetchRightsStatuses())
+  };
+}
+
+const ConnectedBookCoverEditor = connect<BookCoverEditorStateProps, BookCoverEditorDispatchProps, BookCoverEditorOwnProps>(
+  mapStateToProps,
+  mapDispatchToProps
+)(BookCoverEditor);
+
+export default ConnectedBookCoverEditor;

--- a/src/components/BookDetailsTabContainer.tsx
+++ b/src/components/BookDetailsTabContainer.tsx
@@ -5,6 +5,7 @@ import ActionCreator from "../actions";
 import { connect } from "react-redux";
 import BookDetailsEditor from "./BookDetailsEditor";
 import Classifications from "./Classifications";
+import BookCoverEditor from "./BookCoverEditor";
 import Complaints from "./Complaints";
 import CustomListsForBook from "./CustomListsForBook";
 import { BookData } from "../interfaces";
@@ -35,49 +36,60 @@ export class BookDetailsTabContainer extends TabContainer<BookDetailsTabContaine
   }
 
   tabs() {
-    return {
-      details: (
-        <div className="details">
-          { this.props.children }
-        </div>
-      ),
-      edit: (
-        <BookDetailsEditor
-          store={this.props.store}
-          csrfToken={this.props.csrfToken}
-          bookUrl={this.props.bookUrl}
-          refreshCatalog={this.props.refreshCatalog}
-          />
-      ),
-      classifications: (
-        <Classifications
-          store={this.props.store}
-          csrfToken={this.props.csrfToken}
-          bookUrl={this.props.bookUrl}
-          book={this.props.bookData}
-          refreshCatalog={this.props.refreshCatalog}
-          />
-      ),
-      complaints: (
-        <Complaints
-          store={this.props.store}
-          csrfToken={this.props.csrfToken}
-          bookUrl={this.props.bookUrl}
-          book={this.props.bookData}
-          refreshCatalog={this.props.refreshCatalog}
-          />
-      ),
-      lists: (
-        <CustomListsForBook
+    const tabs = {};
+    tabs["details"] = (
+      <div className="details">
+        { this.props.children }
+      </div>
+    );
+    tabs["edit"] = (
+      <BookDetailsEditor
+        store={this.props.store}
+        csrfToken={this.props.csrfToken}
+        bookUrl={this.props.bookUrl}
+        refreshCatalog={this.props.refreshCatalog}
+        />
+    );
+    tabs["classifications"] = (
+      <Classifications
+        store={this.props.store}
+        csrfToken={this.props.csrfToken}
+        bookUrl={this.props.bookUrl}
+        book={this.props.bookData}
+        refreshCatalog={this.props.refreshCatalog}
+        />
+    );
+    if (this.props.bookData && this.props.bookData.changeCoverLink) {
+      tabs["cover"] = (
+        <BookCoverEditor
           store={this.props.store}
           csrfToken={this.props.csrfToken}
           bookUrl={this.props.bookUrl}
           book={this.props.bookData}
           refreshCatalog={this.props.refreshCatalog}
-          library={this.props.library(this.props.collectionUrl, this.props.bookUrl)}
           />
-      )
-    };
+      );
+    }
+    tabs["complaints"] = (
+      <Complaints
+        store={this.props.store}
+        csrfToken={this.props.csrfToken}
+        bookUrl={this.props.bookUrl}
+        book={this.props.bookData}
+        refreshCatalog={this.props.refreshCatalog}
+        />
+    );
+    tabs["lists"] = (
+      <CustomListsForBook
+        store={this.props.store}
+        csrfToken={this.props.csrfToken}
+        bookUrl={this.props.bookUrl}
+        book={this.props.bookData}
+        refreshCatalog={this.props.refreshCatalog}
+        library={this.props.library(this.props.collectionUrl, this.props.bookUrl)}
+        />
+    );
+    return tabs;
   }
 
   handleSelect(event) {

--- a/src/components/__tests__/BookCoverEditor-test.tsx
+++ b/src/components/__tests__/BookCoverEditor-test.tsx
@@ -1,0 +1,291 @@
+import { expect } from "chai";
+import { stub } from "sinon";
+
+import * as React from "react";
+import { shallow, mount } from "enzyme";
+
+import { BookCoverEditor } from "../BookCoverEditor";
+import EditableInput from "../EditableInput";
+import ErrorMessage from "../ErrorMessage";
+import { BookData, RightsStatusData } from "../../interfaces";
+
+describe("BookCoverEditor", () => {
+  let rightsStatuses: RightsStatusData = {
+    "http://creativecommons.org/licenses/by/4.0/": {
+      "allows_derivatives": true,
+      "name": "Creative Commons Attribution (CC BY)",
+      "open_access": true
+    },
+    "http://librarysimplified.org/terms/rights-status/in-copyright": {
+      "allows_derivatives": false,
+      "name": "In Copyright",
+      "open_access": false
+    },
+    "https://creativecommons.org/licenses/by-nd/4.0": {
+      "allows_derivatives": false,
+      "name": "Creative Commons Attribution-NoDerivs (CC BY-ND)",
+      "open_access": true
+    }
+  };
+
+  let bookData: BookData = {
+    title: "title",
+    coverUrl: "/cover",
+    changeCoverLink: {
+      href: "/change_cover",
+      rel: "http://librarysimplified.org/terms/rel/change_cover"
+    }
+  };
+
+  let wrapper;
+  let editableInputByName = (name) => {
+    let inputs = wrapper.find(EditableInput);
+    return inputs.filterWhere(input => input.props().name === name);
+  };
+
+  describe("rendering", () => {
+    beforeEach(() => {
+      wrapper = shallow(
+        <BookCoverEditor
+          bookAdminUrl="/admin/book"
+          rightsStatuses={rightsStatuses}
+          bookUrl="/book"
+          book={bookData}
+          refreshCatalog={stub()}
+          csrfToken="token"
+        />
+      );
+    });
+
+    it("shows book title", () => {
+      let title = wrapper.find("h2");
+      expect(title.text()).to.equal(bookData.title);
+    });
+
+    it("shows updating message", () => {
+      let updating = wrapper.find(".cover-fetching-container");
+      expect(updating.length).to.equal(0);
+
+      wrapper.setProps({ isFetching: true });
+      updating = wrapper.find(".cover-fetching-container");
+      expect(updating.length).to.equal(1);
+      expect(updating.text()).to.contain("Updating");
+    });
+
+    it("shows current cover", () => {
+      let cover = wrapper.find(".current-cover");
+      expect(cover.length).to.equal(1);
+      expect(cover.props().src).to.equal(bookData.coverUrl);
+      expect(cover.props().alt).to.equal("Current book cover");
+    });
+
+    it("shows cover URL and cover file inputs", () => {
+      let coverUrl = editableInputByName("cover_url");
+      expect(coverUrl.props().label).to.equal("URL for cover image");
+
+      let coverFile = editableInputByName("cover_file");
+      expect(coverFile.props().label).to.equal("Or upload cover image");
+      expect(coverFile.props().type).to.equal("file");
+      expect(coverFile.props().accept).to.equal("image/*");
+    });
+
+    it("shows title position input", () => {
+      let input = editableInputByName("title_position");
+      expect(input.props().elementType).to.equal("select");
+      expect(input.props().label).to.equal("Title and Author Position");
+      let options = input.children();
+      expect(options.length).to.equal(4);
+      expect(options.at(0).props().value).to.equal("none");
+      expect(options.at(1).props().value).to.equal("top");
+      expect(options.at(2).props().value).to.equal("center");
+      expect(options.at(3).props().value).to.equal("bottom");
+    });
+
+    it("shows preview updating message", () => {
+      let updating = wrapper.find(".cover-fetching-preview-container");
+      expect(updating.length).to.equal(0);
+
+      wrapper.setProps({ isFetchingPreview: true });
+      updating = wrapper.find(".cover-fetching-preview-container");
+      expect(updating.length).to.equal(1);
+      expect(updating.text()).to.contain("Updating Preview");
+    });
+
+    it("shows preview", () => {
+      let preview = wrapper.find(".preview-cover");
+      expect(preview.length).to.equal(0);
+
+      wrapper.setProps({ preview: "image data" });
+      preview = wrapper.find(".preview-cover");
+      expect(preview.length).to.equal(1);
+      expect(preview.props().src).to.equal("image data");
+      expect(preview.props().alt).to.equal("Preview of new cover");
+    });
+
+    it("shows rights inputs", () => {
+      let rightsStatusInput = editableInputByName("rights_status");
+      expect(rightsStatusInput.length).to.equal(1);
+      expect(rightsStatusInput.props().elementType).to.equal("select");
+      expect(rightsStatusInput.props().label).to.equal("License");
+
+      let child = rightsStatusInput.children();
+      expect(child.length).to.equal(1);
+      expect(child.props().value).to.equal("http://creativecommons.org/licenses/by/4.0/");
+      expect(child.text()).to.equal("Creative Commons Attribution (CC BY)");
+
+      let explanationInput = editableInputByName("rights_explanation");
+      expect(explanationInput.length).to.equal(1);
+      expect(explanationInput.props().label).to.equal("Explanation of rights");
+    });
+
+    it("shows fetch error", () => {
+      let error = wrapper.find(ErrorMessage);
+      expect(error.length).to.equal(0);
+
+      let errorData = { status: 500, url: "url", response: "error" };
+      wrapper.setProps({ fetchError: errorData });
+      error = wrapper.find(ErrorMessage);
+      expect(error.props().error).to.equal(errorData);
+    });
+
+    it("shows preview fetch error", () => {
+      let error = wrapper.find(ErrorMessage);
+      expect(error.length).to.equal(0);
+
+      let errorData = { status: 500, url: "url", response: "error" };
+      wrapper.setProps({ previewFetchError: errorData });
+      error = wrapper.find(ErrorMessage);
+      expect(error.props().error).to.equal(errorData);
+    });
+
+    it("shows save button", () => {
+      let save = wrapper.find("button");
+      expect(save.length).to.equal(1);
+      expect(save.props().disabled).to.be.ok;
+
+      wrapper.setProps({ preview: "image data" });
+      save = wrapper.find("button");
+      expect(save.props().disabled).not.to.be.ok;
+    });
+  });
+
+  describe("behavior", () => {
+    let fetchBook;
+    let fetchPreview;
+    let clearPreview;
+    let editCover;
+    let fetchRightsStatuses;
+    let refreshCatalog;
+
+    beforeEach(() => {
+      fetchBook = stub();
+      fetchPreview = stub();
+      clearPreview = stub();
+      editCover = stub().returns(new Promise<void>(resolve => resolve()));
+      fetchRightsStatuses = stub();
+      refreshCatalog = stub();
+      wrapper = mount(
+        <BookCoverEditor
+          bookAdminUrl="/admin/book"
+          rightsStatuses={rightsStatuses}
+          bookUrl="/book"
+          book={bookData}
+          csrfToken="token"
+          fetchBook={fetchBook}
+          fetchPreview={fetchPreview}
+          clearPreview={clearPreview}
+          editCover={editCover}
+          fetchRightsStatuses={fetchRightsStatuses}
+          refreshCatalog={refreshCatalog}
+        />
+      );
+    });
+
+    it("clears preview on mount", () => {
+      expect(clearPreview.callCount).to.equal(1);
+    });
+
+    it("fetches rights status on mount", () => {
+      expect(fetchRightsStatuses.callCount).to.equal(1);
+    });
+
+    it("previews cover when relevant inputs change", () => {
+      expect(fetchPreview.callCount).to.equal(0);
+      expect(clearPreview.callCount).to.equal(1);
+
+      let coverUrl = editableInputByName("cover_url");
+      coverUrl.get(0).setState({ value: "http://example.com" });
+      coverUrl.props().onChange();
+
+      expect(fetchPreview.callCount).to.equal(1);
+      expect(fetchPreview.args[0][0]).to.equal("/admin/book/preview_book_cover");
+      let formData = fetchPreview.args[0][1];
+      expect(formData.get("cover_url")).to.equal("http://example.com");
+      expect(formData.get("title_position")).to.equal("none");
+
+      let titlePosition = editableInputByName("title_position");
+      titlePosition.get(0).setState({ value: "center" });
+      titlePosition.props().onChange();
+
+      expect(fetchPreview.callCount).to.equal(2);
+      expect(fetchPreview.args[1][0]).to.equal("/admin/book/preview_book_cover");
+      formData = fetchPreview.args[1][1];
+      expect(formData.get("cover_url")).to.equal("http://example.com");
+      expect(formData.get("cover_file")).to.equal("");
+      expect(formData.get("title_position")).to.equal("center");
+
+      coverUrl.get(0).setState({ value: "" });
+      coverUrl.props().onChange();
+      expect(fetchPreview.callCount).to.equal(2);
+      expect(clearPreview.callCount).to.equal(2);
+
+      let coverFile = editableInputByName("cover_file");
+      coverFile.get(0).setState({ value: "c://file.png" });
+      coverFile.props().onChange();
+
+      expect(fetchPreview.callCount).to.equal(3);
+      expect(fetchPreview.args[2][0]).to.equal("/admin/book/preview_book_cover");
+      formData = fetchPreview.args[2][1];
+      expect(formData.get("cover_url")).to.equal("");
+      expect(formData.get("title_position")).to.equal("center");
+    });
+
+    it("saves", async () => {
+      expect(editCover.callCount).to.equal(0);
+      expect(fetchBook.callCount).to.equal(0);
+      expect(refreshCatalog.callCount).to.equal(0);
+      wrapper.setProps({ preview: "image data" });
+
+      let coverUrl = editableInputByName("cover_url");
+      coverUrl.get(0).setState({ value: "http://example.com" });
+
+      let titlePosition = editableInputByName("title_position");
+      titlePosition.get(0).setState({ value: "center" });
+
+      let rightsStatus = editableInputByName("rights_status");
+      rightsStatus.get(0).setState({ value: "http://creativecommons.org/licenses/by/4.0/" });
+
+      let rightsExplanation = editableInputByName("rights_explanation");
+      rightsExplanation.get(0).setState({ value: "explanation" });
+
+      let saveButton = wrapper.find("button");
+      saveButton.simulate("click");
+
+      expect(editCover.callCount).to.equal(1);
+      expect(editCover.args[0][0]).to.equal("/change_cover");
+      let formData = editCover.args[0][1];
+      expect(formData.get("cover_url")).to.equal("http://example.com");
+      expect(formData.get("title_position")).to.equal("center");
+      expect(formData.get("rights_status")).to.equal("http://creativecommons.org/licenses/by/4.0/");
+      expect(formData.get("rights_explanation")).to.equal("explanation");
+
+      const pause = (): Promise<void> => {
+        return new Promise<void>(resolve => setTimeout(resolve, 0));
+      };
+      await pause();
+
+      expect(fetchBook.callCount).to.equal(1);
+      expect(refreshCatalog.callCount).to.equal(1);
+   });
+  });
+});

--- a/src/components/__tests__/BookCoverEditor-test.tsx
+++ b/src/components/__tests__/BookCoverEditor-test.tsx
@@ -128,10 +128,12 @@ describe("BookCoverEditor", () => {
       expect(rightsStatusInput.props().elementType).to.equal("select");
       expect(rightsStatusInput.props().label).to.equal("License");
 
-      let child = rightsStatusInput.children();
-      expect(child.length).to.equal(1);
-      expect(child.props().value).to.equal("http://creativecommons.org/licenses/by/4.0/");
-      expect(child.text()).to.equal("Creative Commons Attribution (CC BY)");
+      let children = rightsStatusInput.children();
+      expect(children.length).to.equal(2);
+      expect(children.at(0).props().value).to.equal("http://creativecommons.org/licenses/by/4.0/");
+      expect(children.at(0).text()).to.equal("Creative Commons Attribution (CC BY)");
+      expect(children.at(1).props().value).to.equal("http://librarysimplified.org/terms/rights-status/unknown");
+      expect(children.at(1).text()).to.equal("Other");
 
       let explanationInput = editableInputByName("rights_explanation");
       expect(explanationInput.length).to.equal(1);

--- a/src/components/__tests__/BookCoverEditor-test.tsx
+++ b/src/components/__tests__/BookCoverEditor-test.tsx
@@ -129,11 +129,13 @@ describe("BookCoverEditor", () => {
       expect(rightsStatusInput.props().label).to.equal("License");
 
       let children = rightsStatusInput.children();
-      expect(children.length).to.equal(2);
+      expect(children.length).to.equal(3);
       expect(children.at(0).props().value).to.equal("http://creativecommons.org/licenses/by/4.0/");
       expect(children.at(0).text()).to.equal("Creative Commons Attribution (CC BY)");
-      expect(children.at(1).props().value).to.equal("http://librarysimplified.org/terms/rights-status/unknown");
-      expect(children.at(1).text()).to.equal("Other");
+      expect(children.at(1).props().value).to.equal("http://librarysimplified.org/terms/rights-status/in-copyright");
+      expect(children.at(1).text()).to.equal("In Copyright");
+      expect(children.at(2).props().value).to.equal("http://librarysimplified.org/terms/rights-status/unknown");
+      expect(children.at(2).text()).to.equal("Other");
 
       let explanationInput = editableInputByName("rights_explanation");
       expect(explanationInput.length).to.equal(1);

--- a/src/components/__tests__/BookDetailsTabContainer-test.tsx
+++ b/src/components/__tests__/BookDetailsTabContainer-test.tsx
@@ -53,6 +53,24 @@ describe("BookDetailsTabContainer", () => {
     expect(linkTexts).to.contain("Complaints");
   });
 
+  it("only shows cover tab when the book data has a change cover link", () => {
+    let links = wrapper.find("ul.nav-tabs").find("a");
+    let linkTexts = links.map(link => link.text());
+    expect(linkTexts).not.to.contain("Cover");
+
+    let bookData = {
+      title: "title",
+      changeCoverLink: {
+        href: "/change-cover",
+        rel: "http://librarysimplified.org/terms/rel/change_cover"
+      }
+    };
+    wrapper.setProps({ bookData });
+    links = wrapper.find("ul.nav-tabs").find("a");
+    linkTexts = links.map(link => link.text());
+    expect(linkTexts).to.contain("Cover");
+  });
+
   it("shows editor", () => {
     let editor = wrapper.find(BookDetailsEditor);
     expect(editor.props().csrfToken).to.equal("token");

--- a/src/editorAdapter.ts
+++ b/src/editorAdapter.ts
@@ -24,6 +24,10 @@ export default function adapter(data: OPDSEntry): BookData {
     return link.rel === "issues";
   });
 
+  let changeCoverLink = data.links.find(link => {
+    return link.rel === "http://librarysimplified.org/terms/rel/change_cover";
+  });
+
   let audience = data.categories.find(category => {
     return category.scheme === "http://schema.org/audience";
   });
@@ -85,6 +89,14 @@ export default function adapter(data: OPDSEntry): BookData {
     rating = null;
   }
 
+  let imageLink = data.links.find(link => {
+    return link.rel === "http://opds-spec.org/image";
+  });
+  let coverUrl;
+  if (imageLink) {
+    coverUrl = imageLink.href;
+  }
+
   return {
     title: data.title,
     authors: authors,
@@ -100,6 +112,7 @@ export default function adapter(data: OPDSEntry): BookData {
     refreshLink: refreshLink,
     editLink: editLink,
     issuesLink: issuesLink,
+    changeCoverLink: changeCoverLink,
     series: data.series && data.series.name,
     seriesPosition: data.series && data.series.position,
     medium: medium,
@@ -107,6 +120,7 @@ export default function adapter(data: OPDSEntry): BookData {
     publisher: data.publisher,
     imprint: imprint,
     issued: data.issued,
-    rating: rating
+    rating: rating,
+    coverUrl: coverUrl
   };
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -35,11 +35,13 @@ export interface BookData {
   refreshLink?: LinkData;
   editLink?: LinkData;
   issuesLink?: LinkData;
+  changeCoverLink?: LinkData;
   categories?: string[];
   series?: string;
   seriesPosition?: number;
   issued?: string;
   rating?: number;
+  coverUrl?: string;
 }
 
 export interface RolesData {
@@ -52,6 +54,14 @@ export interface MediaData {
 
 export interface LanguagesData {
   [key: string]: string[];
+}
+
+export interface RightsStatusData {
+  [key: string]: {
+    name: string,
+    open_access: boolean,
+    allows_derivatives: boolean
+  };
 }
 
 export interface BookLink {

--- a/src/reducers/__tests__/bookCoverPreview-test.ts
+++ b/src/reducers/__tests__/bookCoverPreview-test.ts
@@ -1,0 +1,70 @@
+import { expect } from "chai";
+
+import reducer, { BookCoverPreviewState } from "../bookCoverPreview";
+import ActionCreator from "../../actions";
+
+describe("book cover preview reducer", () => {
+  let preview = "image data";
+
+  let initState: BookCoverPreviewState = {
+    data: null,
+    isFetching: false,
+    fetchError: null
+  };
+
+  let errorState: BookCoverPreviewState = {
+    data: null,
+    isFetching: false,
+    fetchError: { status: 401, response: "test error", url: "test url" }
+  };
+
+  let loadedState = Object.assign({}, initState, {
+    data: preview,
+  });
+
+  it("returns initial state for unrecognized action", () => {
+    expect(reducer(undefined, {})).to.deep.equal(initState);
+  });
+
+  it("handles PREVIEW_BOOK_COVER_REQUEST", () => {
+    let action = { type: `${ActionCreator.PREVIEW_BOOK_COVER}_${ActionCreator.REQUEST}`, url: "test url" };
+
+    // start with empty state
+    let newState = Object.assign({}, initState, {
+      isFetching: true
+    });
+    expect(reducer(initState, action)).to.deep.equal(newState);
+
+    // start with error state
+    newState = Object.assign({}, errorState, {
+      isFetching: true,
+      fetchError: null
+    });
+    expect(reducer(errorState, action)).to.deep.equal(newState);
+  });
+
+  it("handles PREVIEW_BOOK_COVER_FAILURE", () => {
+    let action = { type: `${ActionCreator.PREVIEW_BOOK_COVER}_${ActionCreator.FAILURE}`, error: "test error" };
+    let oldState = Object.assign({}, initState, { isFetching: true });
+    let newState = Object.assign({}, oldState, {
+      fetchError: "test error",
+      isFetching: false
+    });
+    expect(reducer(oldState, action)).to.deep.equal(newState);
+  });
+
+  it("handles PREVIEW_BOOK_COVER_LOAD", () => {
+    let action = { type: `${ActionCreator.PREVIEW_BOOK_COVER}_${ActionCreator.LOAD}`, data: preview };
+    let newState = Object.assign({}, initState, {
+      data: preview,
+      isFetching: false
+    });
+    expect(reducer(initState, action)).to.deep.equal(newState);
+  });
+
+  it("handles PREVIEW_BOOK_COVER_CLEAR", () => {
+    let action = { type: `${ActionCreator.PREVIEW_BOOK_COVER}_${ActionCreator.CLEAR}` };
+    expect(reducer(loadedState, action)).to.deep.equal(initState);
+    expect(reducer(errorState, action)).to.deep.equal(initState);
+  });
+});

--- a/src/reducers/bookCover.ts
+++ b/src/reducers/bookCover.ts
@@ -1,0 +1,4 @@
+import ActionCreator from "../actions";
+import createFetchEditReducer from "./createFetchEditReducer";
+
+export default createFetchEditReducer<string>(ActionCreator.BOOK_COVER, ActionCreator.EDIT_BOOK_COVER);

--- a/src/reducers/bookCoverPreview.ts
+++ b/src/reducers/bookCoverPreview.ts
@@ -1,0 +1,49 @@
+import { RequestError } from "opds-web-client/lib/DataFetcher";
+import ActionCreator from "../actions";
+
+export interface BookCoverPreviewState {
+  data: string;
+  isFetching: boolean;
+  fetchError: RequestError;
+}
+
+const initialState: BookCoverPreviewState = {
+  data: null,
+  isFetching: false,
+  fetchError: null
+};
+
+export default (state: BookCoverPreviewState = initialState, action): BookCoverPreviewState => {
+  switch (action.type) {
+    case `${ActionCreator.PREVIEW_BOOK_COVER}_${ActionCreator.REQUEST}`:
+      return Object.assign({}, state, {
+        data: null,
+        isFetching: true,
+        fetchError: null
+      });
+
+    case `${ActionCreator.PREVIEW_BOOK_COVER}_${ActionCreator.FAILURE}`:
+      return Object.assign({}, state, {
+        data: null,
+        isFetching: false,
+        fetchError: action.error
+      });
+
+    case `${ActionCreator.PREVIEW_BOOK_COVER}_${ActionCreator.LOAD}`:
+      return Object.assign({}, state, {
+        data: action.data,
+        isFetching: false,
+        fetchError: null
+      });
+
+    case `${ActionCreator.PREVIEW_BOOK_COVER}_${ActionCreator.CLEAR}`:
+      return Object.assign({}, state, {
+        data: null,
+        isFetching: false,
+        fetchError: null
+      });
+
+    default:
+      return state;
+  }
+};

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -2,6 +2,8 @@ import { combineReducers } from "redux";
 import book, { BookState } from "./book";
 import complaints, { ComplaintsState } from "./complaints";
 import classifications, { ClassificationsState } from "./classifications";
+import bookCoverPreview, { BookCoverPreviewState } from "./bookCoverPreview";
+import bookCover from "./bookCover";
 import customListsForBook from "./customListsForBook";
 import circulationEvents, { CirculationEventsState } from "./circulationEvents";
 import stats, { StatsState } from "./stats";
@@ -30,6 +32,7 @@ import resetLanes from "./resetLanes";
 import roles from "./roles";
 import media from "./media";
 import languages from "./languages";
+import rightsStatuses from "./rightsStatuses";
 import collection, { CollectionState } from "opds-web-client/lib/reducers/collection";
 import changePassword from "./changePassword";
 import { FetchEditState } from "./createFetchEditReducer";
@@ -39,7 +42,8 @@ import {
   PatronAuthServicesData, SitewideSettingsData, LoggingServicesData, MetadataServicesData,
   AnalyticsServicesData, CDNServicesData, SearchServicesData, StorageServicesData,
   DiscoveryServicesData, LibraryRegistrationsData, CustomListsData,
-  CustomListDetailsData, LanesData, RolesData, MediaData, LanguagesData
+  CustomListDetailsData, LanesData, RolesData, MediaData, LanguagesData,
+  RightsStatusData
 } from "../interfaces";
 
 
@@ -47,6 +51,8 @@ export interface State {
   book: BookState;
   complaints: ComplaintsState;
   classifications: ClassificationsState;
+  bookCoverPreview: BookCoverPreviewState;
+  bookCover: FetchEditState<string>;
   customListsForBook: FetchEditState<CustomListsData>;
   circulationEvents: CirculationEventsState;
   stats: StatsState;
@@ -76,6 +82,7 @@ export interface State {
   roles: FetchEditState<RolesData>;
   media: FetchEditState<MediaData>;
   languages: FetchEditState<LanguagesData>;
+  rightsStatuses: FetchEditState<RightsStatusData>;
   changePassword: FetchEditState<void>;
 }
 
@@ -83,6 +90,8 @@ export default combineReducers<State>({
   book,
   complaints,
   classifications,
+  bookCoverPreview,
+  bookCover,
   customListsForBook,
   circulationEvents,
   stats,
@@ -112,5 +121,6 @@ export default combineReducers<State>({
   roles,
   media,
   languages,
+  rightsStatuses,
   changePassword
 });

--- a/src/reducers/rightsStatuses.ts
+++ b/src/reducers/rightsStatuses.ts
@@ -1,0 +1,5 @@
+import { RightsStatusData } from "../interfaces";
+import ActionCreator from "../actions";
+import createFetchEditReducer from "./createFetchEditReducer";
+
+export default createFetchEditReducer<RightsStatusData>(ActionCreator.RIGHTS_STATUSES);


### PR DESCRIPTION
This branch goes with https://github.com/NYPL-Simplified/circulation/pull/968. It adds a tab to the book details page for uploading a new open-access image to use as a book cover.