### PR TITLE
Changed list edit page to use identifiers instead of pwids.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.0.68",
+  "version": "0.0.69",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/components/CustomListEditor.tsx
+++ b/src/components/CustomListEditor.tsx
@@ -165,10 +165,10 @@ export default class CustomListEditor extends React.Component<CustomListEditorPr
     if (this.props.list && this.props.list.entries.length !== this.state.entries.length) {
       entriesChanged = true;
     } else {
-      let propsPwids = ((this.props.list && this.props.list.entries) || []).map(entry => entry.pwid).sort();
-      let statePwids = this.state.entries.map(entry => entry.pwid).sort();
-      for (let i = 0; i < propsPwids.length; i++) {
-        if (propsPwids[i] !== statePwids[i]) {
+      let propsUrns = ((this.props.list && this.props.list.entries) || []).map(entry => entry.identifier_urn).sort();
+      let stateUrns = this.state.entries.map(entry => entry.identifier_urn).sort();
+      for (let i = 0; i < propsUrns.length; i++) {
+        if (propsUrns[i] !== stateUrns[i]) {
           entriesChanged = true;
           break;
         }

--- a/src/components/__tests__/BookCoverEditor-test.tsx
+++ b/src/components/__tests__/BookCoverEditor-test.tsx
@@ -29,6 +29,7 @@ describe("BookCoverEditor", () => {
   };
 
   let bookData: BookData = {
+    id: "id",
     title: "title",
     coverUrl: "/cover",
     changeCoverLink: {

--- a/src/components/__tests__/BookDetailsEditor-test.tsx
+++ b/src/components/__tests__/BookDetailsEditor-test.tsx
@@ -66,7 +66,7 @@ describe("BookDetailsEditor", () => {
   it("shows title", () => {
     let wrapper = shallow(
       <BookDetailsEditor
-        bookData={{ title: "title" }}
+        bookData={{ id: "id", title: "title" }}
         bookUrl="url"
         csrfToken="token"
         {...dispatchProps}
@@ -83,7 +83,7 @@ describe("BookDetailsEditor", () => {
     };
     let wrapper = shallow(
       <BookDetailsEditor
-        bookData={{ title: "title", hideLink: hideLink }}
+        bookData={{ id: "id",  title: "title", hideLink: hideLink }}
         bookUrl="url"
         csrfToken="token"
         {...dispatchProps}
@@ -102,7 +102,7 @@ describe("BookDetailsEditor", () => {
     };
     let wrapper = shallow(
       <BookDetailsEditor
-        bookData={{ title: "title", restoreLink: restoreLink }}
+        bookData={{ id: "id", title: "title", restoreLink: restoreLink }}
         bookUrl="url"
         csrfToken="token"
         {...dispatchProps}
@@ -121,7 +121,7 @@ describe("BookDetailsEditor", () => {
     };
     let wrapper = shallow(
       <BookDetailsEditor
-        bookData={{ title: "title", refreshLink: refreshLink }}
+        bookData={{ id: "id", title: "title", refreshLink: refreshLink }}
         bookUrl="url"
         csrfToken="token"
         {...dispatchProps}
@@ -142,7 +142,7 @@ describe("BookDetailsEditor", () => {
     };
     let wrapper = shallow(
       <BookDetailsEditor
-        bookData={{ title: "title" }}
+        bookData={{ id: "id", title: "title" }}
         bookUrl="url" csrfToken="token"
         fetchError={fetchError}
         {...dispatchProps}
@@ -166,7 +166,7 @@ describe("BookDetailsEditor", () => {
     };
     let wrapper = shallow(
       <BookDetailsEditor
-        bookData={{ title: "title", editLink: editLink }}
+        bookData={{ id: "id", title: "title", editLink: editLink }}
         bookUrl="url"
         csrfToken="token"
         editError={editError}
@@ -198,7 +198,7 @@ describe("BookDetailsEditor", () => {
     };
     let wrapper = shallow(
       <BookDetailsEditor
-        bookData={{ title: "title", editLink }}
+        bookData={{ id: "id", title: "title", editLink }}
         bookUrl="url"
         csrfToken="token"
         {...dispatchProps}

--- a/src/components/__tests__/BookEditForm-test.tsx
+++ b/src/components/__tests__/BookEditForm-test.tsx
@@ -27,6 +27,7 @@ describe("BookEditForm", () => {
   };
 
   let bookData: BookData = {
+    id: "id",
     title: "title",
     subtitle: "subtitle",
     authors: [{ name: "An Author", role: "aut" }],

--- a/src/components/__tests__/Complaints-test.tsx
+++ b/src/components/__tests__/Complaints-test.tsx
@@ -15,6 +15,7 @@ describe("Complaints", () => {
     let complaintsData;
     let wrapper;
     let bookData = {
+      id: "id",
       title: "test title",
       issuesLink: {
         href: "issues url",
@@ -85,7 +86,7 @@ describe("Complaints", () => {
         <Complaints
           csrfToken="token"
           bookUrl="book url"
-          book={{ title: "test book" }}
+          book={{ id: "id", title: "test book" }}
           fetchError={fetchError}
           fetchComplaints={fetchComplaints}
           postComplaint={stub()}
@@ -122,7 +123,7 @@ describe("Complaints", () => {
       wrapper = mount(
         <Complaints
           csrfToken="token"
-          book={{ title: "test book" }}
+          book={{ id: "id", title: "test book" }}
           bookUrl="http://example.com/works/fakeid"
           complaints={complaintsData}
           fetchComplaints={fetchComplaints}

--- a/src/components/__tests__/CustomListEditor-test.tsx
+++ b/src/components/__tests__/CustomListEditor-test.tsx
@@ -21,8 +21,8 @@ describe("CustomListEditor", () => {
     id: 1,
     name: "list",
     entries: [
-      { pwid: "1", title: "title 1", authors: ["author 1"] },
-      { pwid: "2", title: "title 2", authors: ["author 2a", "author 2b"] }
+      { identifier_urn: "1", title: "title 1", authors: ["author 1"] },
+      { identifier_urn: "2", title: "title 2", authors: ["author 2a", "author 2b"] }
     ],
     collections: [
       { id: 2, name: "collection 2", protocol: "protocol" }
@@ -149,7 +149,7 @@ describe("CustomListEditor", () => {
     );
     let getTextStub = stub(TextWithEditMode.prototype, "getText").returns("new list name");
     let newEntries = [
-      { pwid: "pwid1" }, { pwid: "pwid2" }
+      { identifier_urn: "urn1" }, { identifier_urn: "urn2" }
     ];
     let getEntriesStub = stub(CustomListEntriesEditor.prototype, "getEntries").returns(newEntries);
     let saveButton = wrapper.find(".save-list");
@@ -187,7 +187,7 @@ describe("CustomListEditor", () => {
     );
     let getTextStub = stub(TextWithEditMode.prototype, "getText").returns("new list name");
     let newEntries = [
-      { pwid: "pwid1" }, { pwid: "pwid2" }
+      { identifier_urn: "urn1" }, { identifier_urn: "urn2" }
     ];
     let getEntriesStub = stub(CustomListEntriesEditor.prototype, "getEntries").returns(newEntries);
     let saveButton = wrapper.find(".save-list");
@@ -264,7 +264,7 @@ describe("CustomListEditor", () => {
       />,
       { context: fullContext, childContextTypes }
     );
-    (wrapper.instance() as CustomListEditor).changeEntries([{ pwid: "1234", title: "a", authors: [] }]);
+    (wrapper.instance() as CustomListEditor).changeEntries([{ identifier_urn: "1234", title: "a", authors: [] }]);
     cancelButton = wrapper.find(".cancel-changes");
     expect(cancelButton.length).to.equal(1);
     cancelButton.simulate("click");

--- a/src/components/__tests__/CustomListEntriesEditor-test.tsx
+++ b/src/components/__tests__/CustomListEntriesEditor-test.tsx
@@ -31,20 +31,19 @@ describe("CustomListEntriesEditor", () => {
     books: [
       { id: "1", title: "result 1", authors: ["author 1"], url: "/some/url1", language: "eng",
         raw: {
-          "simplified:pwid": [{ "_": "pwid1"}], "$": { "schema:additionalType": { "value": "http://schema.org/EBook" } },
-          "bibframe:distribution": [{ "$": { "bibframe:ProviderName": { value: "Standard eBooks" } } }],
+          "$": { "schema:additionalType": { "value": "http://schema.org/EBook" } },
         }
       },
       { id: "2", title: "result 2", authors: ["author 2a", "author 2b"], url: "/some/url2", language: "eng",
-        raw: { "simplified:pwid": [{ "_": "pwid2"}], "$": { "schema:additionalType": { "value": "http://bib.schema.org/Audiobook" } } }},
+        raw: { "$": { "schema:additionalType": { "value": "http://bib.schema.org/Audiobook" } } }},
       { id: "3", title: "result 3", authors: ["author 3"], url: "/some/url3", language: "eng",
-        raw: { "simplified:pwid": [{ "_": "pwid3"}], "$": { "schema:additionalType": { "value": "http://schema.org/EBook" } } }},
+        raw: { "$": { "schema:additionalType": { "value": "http://schema.org/EBook" } } }},
     ]
   };
 
   let entriesData = [
-    { pwid: "pwidA", title: "entry A", authors: ["author A"], medium: "http://schema.org/EBook", url: "/some/urlA", data_source: "Standard ebooks" },
-    { pwid: "pwidB", title: "entry B", authors: ["author B1", "author B2"], medium: "http://bib.schema.org/Audiobook", url: "/some/urlB", data_source: "Standard ebooks" }
+    { identifier_urn: "A", title: "entry A", authors: ["author A"], medium: "http://schema.org/EBook", url: "/some/urlA" },
+    { identifier_urn: "B", title: "entry B", authors: ["author B1", "author B2"], medium: "http://bib.schema.org/Audiobook", url: "/some/urlB" }
   ];
 
   beforeEach(() => {
@@ -226,7 +225,7 @@ describe("CustomListEntriesEditor", () => {
 
   it("doesn't include search results that are already in the list", () => {
     let entriesData = [
-      { pwid: "pwid1", title: "result 1", authors: ["author 1"], language: "eng" }
+      { identifier_urn: "1", title: "result 1", authors: ["author 1"], language: "eng" }
     ];
 
     let wrapper = mount(
@@ -266,7 +265,7 @@ describe("CustomListEntriesEditor", () => {
 
     // simulate starting a drag from search results
     (wrapper.instance() as CustomListEntriesEditor).onDragStart({
-      draggableId: "pwid1",
+      draggableId: "1",
       source: {
         droppableId: "search-results"
       }
@@ -289,7 +288,7 @@ describe("CustomListEntriesEditor", () => {
 
     // simulate starting a drag from list entries
     (wrapper.instance() as CustomListEntriesEditor).onDragStart({
-      draggableId: "pwidA",
+      draggableId: "A",
       source: {
         droppableId: "custom-list-entries"
       }
@@ -314,7 +313,7 @@ describe("CustomListEntriesEditor", () => {
 
     // simulate starting a drag from search results
     (wrapper.instance() as CustomListEntriesEditor).onDragStart({
-      draggableId: "pwid1",
+      draggableId: "1",
       source: {
         droppableId: "search-results"
       }
@@ -326,7 +325,7 @@ describe("CustomListEntriesEditor", () => {
 
     // simulate dropping on the entries
     (wrapper.instance() as CustomListEntriesEditor).onDragEnd({
-      draggableId: "pwid1",
+      draggableId: "1",
       source: {
         droppableId: "search-results"
       },
@@ -341,13 +340,12 @@ describe("CustomListEntriesEditor", () => {
     expect(entries.at(0).text()).to.contain("result 1");
     expect(onUpdate.callCount).to.equal(1);
     const newEntry = {
-      pwid: "pwid1",
+      identifier_urn: "1",
       title: "result 1",
       authors: ["author 1"],
       medium: "http://schema.org/EBook",
       language: "eng",
-      url: "/some/url1",
-      data_source: "Standard eBooks",
+      url: "/some/url1"
     };
     const expectedEntries = [newEntry, entriesData[0], entriesData[1]];
     expect(onUpdate.args[0][0]).to.deep.equal(expectedEntries);
@@ -365,7 +363,7 @@ describe("CustomListEntriesEditor", () => {
 
     // simulate starting a drag from list entries
     (wrapper.instance() as CustomListEntriesEditor).onDragStart({
-      draggableId: "pwidA",
+      draggableId: "A",
       source: {
         droppableId: "custom-list-entries"
       }
@@ -381,7 +379,7 @@ describe("CustomListEntriesEditor", () => {
     // if you drop anywhere on the page, the message goes away.
     // simulate dropping outside a droppable (no destination)
     (wrapper.instance() as CustomListEntriesEditor).onDragEnd({
-      draggableId: "pwidA",
+      draggableId: "A",
       source: {
         droppableId: "custom-list-entries"
       }
@@ -408,7 +406,7 @@ describe("CustomListEntriesEditor", () => {
 
     // simulate starting a drag from entries
     (wrapper.instance() as CustomListEntriesEditor).onDragStart({
-      draggableId: "pwidA",
+      draggableId: "A",
       source: {
         droppableId: "custom-list-entries"
       }
@@ -420,7 +418,7 @@ describe("CustomListEntriesEditor", () => {
 
     // simulate dropping on the search results
     (wrapper.instance() as CustomListEntriesEditor).onDragEnd({
-      draggableId: "pwidA",
+      draggableId: "A",
       source: {
         droppableId: "custom-list-entries"
       },
@@ -463,13 +461,12 @@ describe("CustomListEntriesEditor", () => {
     expect(entries.at(0).text()).to.contain("result 1");
     expect(onUpdate.callCount).to.equal(1);
     const newEntry = {
-      pwid: "pwid1",
+      identifier_urn: "1",
       title: "result 1",
       authors: ["author 1"],
       medium: "http://schema.org/EBook",
       language: "eng",
-      url: "/some/url1",
-      data_source: "Standard eBooks",
+      url: "/some/url1"
     };
     const expectedEntries = [newEntry, entriesData[0], entriesData[1]];
     expect(onUpdate.args[0][0]).to.deep.equal(expectedEntries);
@@ -514,7 +511,7 @@ describe("CustomListEntriesEditor", () => {
 
     // simulate dropping a search result on entries
     (wrapper.instance() as CustomListEntriesEditor).onDragEnd({
-      draggableId: "pwid1",
+      draggableId: "1",
       source: {
         droppableId: "search-results"
       },
@@ -541,7 +538,7 @@ describe("CustomListEntriesEditor", () => {
 
     // simulate dropping an entry on search results
     (wrapper.instance() as CustomListEntriesEditor).onDragEnd({
-      draggableId: "pwidA",
+      draggableId: "A",
       source: {
         droppableId: "custom-list-entries"
       },

--- a/src/components/__tests__/CustomListsForBook-test.tsx
+++ b/src/components/__tests__/CustomListsForBook-test.tsx
@@ -15,6 +15,7 @@ describe("CustomListsForBook", () => {
   let editCustomListsForBook;
   let refreshCatalog;
   let bookData = {
+    id: "id",
     title: "test title"
   };
   let allCustomLists = [

--- a/src/editorAdapter.ts
+++ b/src/editorAdapter.ts
@@ -98,6 +98,7 @@ export default function adapter(data: OPDSEntry): BookData {
   }
 
   return {
+    id: data.id,
     title: data.title,
     authors: authors,
     contributors: data.contributors,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -18,6 +18,7 @@ export interface ContributorData {
 }
 
 export interface BookData {
+  id: string;
   title: string;
   authors?: ContributorData[];
   contributors?: ContributorData[];
@@ -309,13 +310,12 @@ export interface LibraryRegistrationsData {
 }
 
 export interface CustomListEntryData {
-  pwid: string;
+  identifier_urn: string;
   title: string;
   authors: string[];
   medium?: string;
   url?: string;
   language?: string;
-  data_source?: string;
 }
 
 export interface CustomListData {

--- a/src/reducers/__tests__/book-test.ts
+++ b/src/reducers/__tests__/book-test.ts
@@ -15,6 +15,7 @@ describe("book reducer", () => {
   let fetchedState = {
     url: "test url",
     data: {
+      id: "id",
       title: "test book"
     },
     isFetching: false,


### PR DESCRIPTION
This is the front-end part of https://github.com/NYPL-Simplified/circulation/pull/974