### PR TITLE
Added distributor, publisher, and audience to book details tab.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.0.69",
+  "version": "0.0.70",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/components/BookDetails.tsx
+++ b/src/components/BookDetails.tsx
@@ -1,0 +1,107 @@
+import * as React from "react";
+import DefaultBookDetails, { BookDetailsProps as DefaultBookDetailsProps } from "opds-web-client/lib/components/BookDetails";
+
+export default class BookDetails extends DefaultBookDetails<DefaultBookDetailsProps> {
+
+  fieldNames() {
+    return ["Published", "Publisher", "Audience", "Categories", "Distributed By"];
+  }
+
+  fields() {
+    let fields = super.fields();
+    let categoriesIndex = fields.findIndex(field => field.name === "Categories");
+    fields[categoriesIndex].value = this.categories();
+    fields.push({
+      name: "Audience",
+      value: this.audience()
+    });
+    fields.push({
+      name: "Distributed By",
+      value: this.distributor()
+    });
+    return fields;
+  }
+
+  audience() {
+    if (!this.props.book) {
+      return null;
+    }
+
+    let categories = this.props.book.raw.category;
+
+    if (!categories) {
+      return null;
+    }
+
+    let audience = categories.find(category =>
+      category["$"]["scheme"] && category["$"]["scheme"]["value"] === "http://schema.org/audience"
+    );
+
+    if (!audience) {
+      return null;
+    }
+
+    let audienceStr = audience["$"]["label"] && audience["$"]["label"]["value"];
+
+    if (["Adult", "Adults Only"].indexOf(audienceStr) !== -1) {
+      return audienceStr;
+    }
+
+    let targetAge = categories.find(category =>
+      category["$"]["scheme"] && category["$"]["scheme"]["value"] === "http://schema.org/typicalAgeRange"
+    );
+
+    if (targetAge) {
+      let targetAgeStr = targetAge["$"]["label"] && targetAge["$"]["label"]["value"];
+      audienceStr += " (age " + targetAgeStr + ")";
+    }
+
+    return audienceStr;
+  }
+
+  categories() {
+    if (!this.props.book) {
+      return null;
+    }
+
+    let audienceSchemas = [
+      "http://schema.org/audience",
+      "http://schema.org/typicalAgeRange"
+    ];
+    let fictionScheme = "http://librarysimplified.org/terms/fiction/";
+    let rawCategories = this.props.book.raw.category;
+
+    let categories = rawCategories.filter(category =>
+      category["$"]["label"] && category["$"]["scheme"] &&
+          audienceSchemas.concat([fictionScheme])
+              .indexOf(category["$"]["scheme"]["value"]) === -1
+    ).map(category => category["$"]["label"]["value"]);
+
+    if (!categories.length) {
+      categories = rawCategories.filter(category =>
+        category["$"]["label"] && category["$"]["scheme"] &&
+            category["$"]["scheme"]["value"] === fictionScheme
+      ).map(category => category["$"]["label"]["value"]);
+    }
+
+    return categories.length > 0 ? categories.join(", ") : null;
+  }
+
+  distributor() {
+    if (!this.props.book) {
+      return null;
+    }
+
+    let rawDistributionTags = this.props.book.raw["bibframe:distribution"];
+    if (!rawDistributionTags || rawDistributionTags.length < 1) {
+      return null;
+    }
+
+    let distributor = rawDistributionTags[0]["$"]["bibframe:ProviderName"];
+    if (!distributor) {
+      return null;
+    }
+
+    return distributor.value;
+  }
+}

--- a/src/components/BookDetailsContainer.tsx
+++ b/src/components/BookDetailsContainer.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { Store } from "redux";
 import BookDetailsTabContainer from "./BookDetailsTabContainer";
+import BookDetails from "./BookDetails";
 import { BookDetailsContainerProps } from "opds-web-client/lib/components/Root";
 import { Navigate } from "../interfaces";
 import { State } from "../reducers/index";
@@ -26,6 +27,9 @@ export default class BookDetailsContainer extends React.Component<BookDetailsCon
   };
 
   render(): JSX.Element {
+    let child = React.Children.only(this.props.children);
+    let book = React.createElement(BookDetails, child.props);
+
     return (
       <div className="book-details-container">
         <BookDetailsTabContainer
@@ -36,7 +40,7 @@ export default class BookDetailsContainer extends React.Component<BookDetailsCon
           library={this.context.library}
           store={this.context.editorStore}
           csrfToken={this.context.csrfToken}>
-          { this.props.children }
+          { book }
         </BookDetailsTabContainer>
       </div>
     );

--- a/src/components/__tests__/BookDetails-test.tsx
+++ b/src/components/__tests__/BookDetails-test.tsx
@@ -1,0 +1,118 @@
+import { expect } from "chai";
+import { stub } from "sinon";
+
+import * as React from "react";
+import { shallow } from "enzyme";
+
+import BookDetails from "../BookDetails";
+
+let book = {
+  id: "urn:librarysimplified.org/terms/id/3M%20ID/crrmnr9",
+  url: "http://circulation.librarysimplified.org/works/3M/crrmnr9",
+  title: "The Mayan Secrets",
+  authors: ["Clive Cussler", "Thomas Perry"],
+  contributors: ["contributor 1"],
+  summary: "&lt;b&gt;Sam and Remi Fargo race for treasure&#8212;and survival&#8212;in this lightning-paced new adventure from #1&lt;i&gt; New York Times&lt;/i&gt; bestselling author Clive Cussler.&lt;/b&gt;&lt;br /&gt;&lt;br /&gt;Husband-and-wife team Sam and Remi Fargo are in Mexico when they come upon a remarkable discovery&#8212;the mummified remainsof a man clutching an ancient sealed pot. Within the pot is a Mayan book larger than any known before.&lt;br /&gt;&lt;br /&gt;The book contains astonishing information about the Mayans, their cities, and about mankind itself. The secrets are so powerful that some people would do anything to possess them&#8212;as the Fargos are about to find out. Many men and women are going to die for that book.",
+  imageUrl: "https://dlotdqc6pnwqb.cloudfront.net/3M/crrmnr9/cover.jpg",
+  borrowUrl: "borrow url",
+  openAccessLinks: [{ url: "secrets.epub", type: "epub" }],
+  publisher: "Penguin Publishing Group",
+  published: "February 29, 2016",
+  categories: ["Children", "10-12", "Fiction", "Adventure", "Fantasy"],
+  raw: {
+    category: [
+      {
+        $: {
+          scheme: { value: "http://schema.org/audience" },
+          label: { value: "Children" }
+        }
+      },
+      {
+        $: {
+          scheme: { value: "http://schema.org/typicalAgeRange" },
+          label: { value: "10-12" }
+        }
+      },
+      {
+        $: {
+          scheme: { value: "http://librarysimplified.org/terms/fiction/" },
+          label: { value: "Fiction" }
+        }
+      },
+      {
+        $: {
+          scheme: { value: "http://librarysimplified.org/terms/genres/Simplified/" },
+          label: { value: "Adventure" }
+        }
+      },
+      {
+        $: {
+          scheme: { value: "http://librarysimplified.org/terms/genres/Simplified/" },
+          label: { value: "Fantasy" }
+        }
+      }
+    ],
+    "bibframe:distribution": [
+      {
+        $: {
+          "bibframe:ProviderName": {
+            value: "Overdrive"
+          }
+        }
+      }
+    ],
+    link: [{
+      $: {
+        rel: { value: "issues" },
+        href: { value: "http://example.com/report" }
+      }
+    },
+    {
+      $: {
+        rel: { value: "http://librarysimplified.org/terms/rel/revoke" },
+        href: { value: "http://example.com/revoke" }
+      }
+    }]
+  }
+};
+
+describe("BookDetails", () => {
+  let wrapper;
+  let noop = stub().returns(new Promise((resolve, reject) => resolve()));
+  let fetchComplaintTypes = noop;
+  let postComplaint = noop;
+  let problemTypes = ["type1", "type2"];
+
+  beforeEach(() => {
+    wrapper = shallow(
+      <BookDetails
+        book={book}
+        updateBook={noop}
+        fulfillBook={noop}
+        indirectFulfillBook={noop}
+        />
+    );
+  });
+
+  it("shows audience and target age", () => {
+    let audience = wrapper.find(".audience");
+    expect(audience.text()).to.equal("Audience: Children (age 10-12)");
+  });
+
+  it("shows categories", () => {
+    let categories = wrapper.find(".categories");
+    expect(categories.text()).to.equal("Categories: Adventure, Fantasy");
+  });
+
+  it("doesn't show categories when there aren't any", () => {
+    let bookCopy = Object.assign({}, book, { raw: { category: [], link: [ ]} });
+    wrapper.setProps({ book: bookCopy });
+    let categories = wrapper.find(".categories");
+    expect(categories.length).to.equal(0);
+  });
+
+  it("shows distributor", () => {
+    let distributor = wrapper.find(".distributed-by");
+    expect(distributor.text()).to.equal("Distributed By: Overdrive");
+  });
+});

--- a/src/components/__tests__/BookDetailsContainer-test.tsx
+++ b/src/components/__tests__/BookDetailsContainer-test.tsx
@@ -7,6 +7,13 @@ import { shallow } from "enzyme";
 import buildStore from "../../store";
 import BookDetailsContainer from "../BookDetailsContainer";
 import BookDetailsTabContainer from "../BookDetailsTabContainer";
+import BookDetails from "../BookDetails";
+
+class DefaultBookDetails extends React.Component<any, any> {
+  render() {
+    return <div></div>;
+  }
+}
 
 describe("BookDetailsContainer", () => {
   let wrapper;
@@ -35,10 +42,19 @@ describe("BookDetailsContainer", () => {
         bookUrl="book url"
         collectionUrl="collection url"
         refreshCatalog={refreshCatalog}>
-        <div className="bookDetails">Moby Dick</div>
-      </BookDetailsContainer>,
+        <DefaultBookDetails
+         book={bookData}
+         anotherProp="anotherProp"
+         />
+     </BookDetailsContainer>,
       { context }
     );
+  });
+
+  it("renders BookDetails with its child's props", () => {
+    let bookDetails = wrapper.find(BookDetails);
+    expect(bookDetails.prop("book")).to.equal(bookData);
+    expect(bookDetails.prop("anotherProp")).to.equal("anotherProp");
   });
 
   it("shows a tab container with initial tab", () => {
@@ -51,6 +67,5 @@ describe("BookDetailsContainer", () => {
     expect(tabContainer.props().csrfToken).to.equal("token");
     expect(tabContainer.props().refreshCatalog).to.equal(refreshCatalog);
     expect(tabContainer.props().store).to.equal(store);
-    expect(tabContainer.children()).to.deep.equal(tabContainer.children());
   });
 });


### PR DESCRIPTION
This stuff was already in circulation-patron-web but is also useful for admins so I copied it over. It adds a subclass of BookDetails from opds-web-client so it can include some additional info on that tab.

Might be worth figuring out how to reuse but I'm not sure what the future of circulation-patron-web is.