### PR TITLE
Fixed exception when a book has no categories.

### DIFF
--- a/src/components/BookDetails.tsx
+++ b/src/components/BookDetails.tsx
@@ -69,7 +69,7 @@ export default class BookDetails extends DefaultBookDetails<DefaultBookDetailsPr
       "http://schema.org/typicalAgeRange"
     ];
     let fictionScheme = "http://librarysimplified.org/terms/fiction/";
-    let rawCategories = this.props.book.raw.category;
+    let rawCategories = this.props.book.raw.category || [];
 
     let categories = rawCategories.filter(category =>
       category["$"]["label"] && category["$"]["scheme"] &&


### PR DESCRIPTION
Due to https://github.com/NYPL-Simplified/server_core/pull/889 and https://github.com/NYPL-Simplified/server_core/pull/888, the circ manager no longer assumes books with no classification info are adult nonfiction. This means it is now possible for an opds entry to have no categories and we need to handle that case.