### PR TITLE
Improved ambiguous and overly long message.

### DIFF
--- a/src/components/Complaints.tsx
+++ b/src/components/Complaints.tsx
@@ -122,7 +122,7 @@ export class Complaints extends React.Component<ComplaintsProps, void> {
     return this.props.bookUrl.replace("works", "admin/works") + "/resolve_complaints";
   }
 
-  readableComplaintType(type) {
+  readableComplaintType(type: string) {
     let match = type.match(/\/terms\/problem\/(.+)$/);
     if (match) {
       return match[1].replace("-", " ");
@@ -137,7 +137,8 @@ export class Complaints extends React.Component<ComplaintsProps, void> {
   };
 
   resolve(type: string) {
-    if (window.confirm("Are you sure you want to resolve all complaints of this type?")) {
+    let readableType = this.readableComplaintType(type);
+    if (window.confirm(`Resolve all "${readableType}" complaints for this book?`)) {
       let url = this.resolveComplaintsUrl();
       let data = new (window as any).FormData();
       data.append("type", type);

--- a/src/components/__tests__/Complaints-test.tsx
+++ b/src/components/__tests__/Complaints-test.tsx
@@ -157,7 +157,7 @@ describe("Complaints", () => {
 
     it("should fetch and refresh Catalog when resolve() is called", (done) => {
       let resolveUrl = instance.resolveComplaintsUrl();
-      instance.resolve().then(() => {
+      instance.resolve("wrong-author").then(() => {
         expect(resolveComplaints.callCount).to.equal(1);
         expect(resolveComplaints.args[0][0]).to.equal(resolveUrl);
         expect(fetchComplaints.callCount).to.equal(2); // it also fetched on mount


### PR DESCRIPTION
It was unclear from the previous message whether it would resolve all complaints of this type for the book or across the library, and it didn't include the complaint type so you wouldn't know if you accidentally clicked the wrong button. I also took out the "Are you sure" since I've heard it's better to have shorter messages.