### PR TITLE
Fixed bar chart overflowing

### DIFF
--- a/src/stylesheets/stats.scss
+++ b/src/stylesheets/stats.scss
@@ -9,6 +9,7 @@
     background-color: $pagecolorlight;
     border-radius: 20px;
     padding: 10px;    
+    overflow-x: scroll;
 
     &.stat-group-wide {
       grid-column-start: 1;


### PR DESCRIPTION
Tiny change to make the collections bar chart scroll horizontally within its container when there are a lot of collections.