### PR TITLE
Enable ErrorMessage to parse non-JSON problem detail strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.0.74",
+  "version": "0.0.75",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -185,8 +185,7 @@ export default class ActionCreator extends BaseActionCreator {
               };
               dispatch(this.failure(type, err));
               reject(err);
-            })
-            .catch(parseError => {
+            }).catch(parseError => {
               err = {
                 status: response.status,
                 response: defaultErrorMessage || "Failed to save changes",

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -185,7 +185,8 @@ export default class ActionCreator extends BaseActionCreator {
               };
               dispatch(this.failure(type, err));
               reject(err);
-            }).catch(parseError => {
+            })
+            .catch(parseError => {
               err = {
                 status: response.status,
                 response: defaultErrorMessage || "Failed to save changes",

--- a/src/components/__tests__/ErrorMessage-test.tsx
+++ b/src/components/__tests__/ErrorMessage-test.tsx
@@ -46,6 +46,23 @@ describe("ErrorMessage", () => {
     expect(alert.text()).to.contain("response");
   });
 
+  it("parses non-JSON problem detail string", () => {
+    let pd = "Remote service returned a problem detail document: {\"status\": 502, \"detail\": problem text, \"title\": problem title}";
+    let error = {
+      status: 500,
+      response: pd,
+      url: ""
+    };
+    let message = "Remote service returned a problem detail document with status 502: problem text";
+    let wrapper = mount(
+      <ErrorMessage error={error} />
+    );
+    let alert = wrapper.find(".alert-danger");
+    let title = wrapper.find("b");
+    expect(alert.text()).to.contain(message);
+    expect(title.text()).to.equal("problem title");
+  });
+
   it("shows try again button", () => {
     let error = {
       status: 500,

--- a/src/components/__tests__/ErrorMessage-test.tsx
+++ b/src/components/__tests__/ErrorMessage-test.tsx
@@ -47,7 +47,7 @@ describe("ErrorMessage", () => {
   });
 
   it("parses non-JSON problem detail string", () => {
-    let pd = "Remote service returned a problem detail document: {\"status\": 502, \"detail\": problem text, \"title\": problem title}";
+    let pd = "Remote service returned a problem detail document: {\"status\": 502, \"detail\": problem text, \"title\": TITLE}";
     let error = {
       status: 500,
       response: pd,
@@ -60,7 +60,58 @@ describe("ErrorMessage", () => {
     let alert = wrapper.find(".alert-danger");
     let title = wrapper.find("b");
     expect(alert.text()).to.contain(message);
-    expect(title.text()).to.equal("problem title");
+    expect(title.text()).to.equal("TITLE");
+  });
+
+  it("can handle missing detail property in non-JSON problem detail string", () => {
+    let pd = "Remote service returned a problem detail document: {\"status\": 502, \"title\": TITLE}";
+    let error = {
+      status: 500,
+      response: pd,
+      url: ""
+    };
+    let message = "Remote service returned a problem detail document with status 502: ";
+    let wrapper = mount(
+      <ErrorMessage error={error} />
+    );
+    let alert = wrapper.find(".alert-danger");
+    let title = wrapper.find("b");
+    expect(alert.text()).to.contain(message);
+    expect(title.text()).to.equal("TITLE");
+  });
+
+  it("can handle missing status property in non-JSON problem detail string", () => {
+    let pd = "Remote service returned a problem detail document:  {\"detail\": problem text, \"title\": TITLE}";
+    let error = {
+      status: 500,
+      response: pd,
+      url: ""
+    };
+    let message = "Remote service returned a problem detail document: ";
+    let wrapper = mount(
+      <ErrorMessage error={error} />
+    );
+    let alert = wrapper.find(".alert-danger");
+    let title = wrapper.find("b");
+    expect(alert.text()).to.contain(message);
+    expect(title.text()).to.equal("TITLE");
+  });
+
+  it("can handle missing title property in non-JSON problem detail string", () => {
+    let pd = "Remote service returned a problem detail document:  {\"status\": 502, \"detail\": problem text}";
+    let error = {
+      status: 500,
+      response: pd,
+      url: ""
+    };
+    let message = "Remote service returned a problem detail document with status 502: ";
+    let wrapper = mount(
+      <ErrorMessage error={error} />
+    );
+    let alert = wrapper.find(".alert-danger");
+    let title = wrapper.find("b");
+    expect(alert.text()).to.contain(message);
+    expect(title.text()).to.equal("Error");
   });
 
   it("shows try again button", () => {


### PR DESCRIPTION
Resolves https://jira.nypl.org/browse/SIMPLY-1150

ErrorMessage can now parse problem detail strings so as to show all of the relevant information, rather than a) showing a less-helpful default error message or b) showing the entire problem detail document in a hard-to-read format.