### PR TITLE
Fix minor bug

### DIFF
--- a/src/components/ProtocolFormField.tsx
+++ b/src/components/ProtocolFormField.tsx
@@ -227,7 +227,7 @@ export default class ProtocolFormField extends React.Component<ProtocolFormField
 
   clear() {
     const element = (this.refs["element"] as any);
-    if (element) {
+    if (element && element.clear) {
       element.clear();
     }
     this.setState({ listItems: [] });


### PR DESCRIPTION
I discovered that creating a library was suddenly failing; turned out to be because ProtocolFormField was trying to call `clear()` on each element upon submitting the form (as per my success message branch), but it now has the ColorPicker element, which doesn't have a `clear()` function.  Very easy fix.  (And I checked--when you submit the create form, the ColorPicker does correctly restore itself to its default settings even though it's not being explicitly cleared!) 