### PR TITLE
Revert "Update to 0.0.82"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## Changelog
 
+### v0.0.82
+#### Fixed
+- Fixed a bug involving submitting forms.
+
 ### v0.0.81
+#### Note: this version contains a bug.  Please upgrade directly to v0.0.82.
 #### Added
 - Added success messages to configuration forms.
 #### Updated

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.0.81",
+  "version": "0.0.82",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.0.82",
+  "version": "0.0.81",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",


### PR DESCRIPTION
In the change log: skip straight from 0.0.80 to 0.0.82, or list changes for 0.0.82 just as "bug fix" or something?