### PR TITLE
Checking if a setting configuration supports library staging registration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v0.0.83
+#### Fixed
+- Checking a flag to see if a setting configuration that supports library registration also supports a staging selection. If the configuration supports staging, the admin can choose between selecting a testing or production stage.
+
 ### v0.0.82
 #### Fixed
 - Fixed a bug involving submitting forms.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.0.82",
+  "version": "0.0.83",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/components/LibraryRegistration.tsx
+++ b/src/components/LibraryRegistration.tsx
@@ -24,7 +24,9 @@ export default class LibraryRegistration extends React.Component<LibraryRegistra
   }
 
   render() {
-    if (this.props.item && this.protocolSupportsRegistration() && this.props.data && this.props.data.allLibraries && this.props.data.allLibraries.length > 0) {
+    const supportsStaging = this.protocolSupportsType("supports_staging");
+    if (this.props.item && this.protocolSupportsType("supports_registration") &&
+      this.props.data && this.props.data.allLibraries && this.props.data.allLibraries.length > 0) {
       return (
         <div>
           <h2>Register libraries</h2>
@@ -38,28 +40,30 @@ export default class LibraryRegistration extends React.Component<LibraryRegistra
                 <div className="service-with-registrations-library" key={library.short_name}>
                   <div className="library-name">{ library.name }</div>
                   <div className="library-registration-info">
-                    <div className="current-stage">
-                      { (currentRegistryStage && libraryRegistrationStatus !== "failure") ?
-                        <span>Current Stage: {currentRegistryStage}</span> :
-                        <span>No current stage</span>
-                      }
-                      { currentRegistryStage !== "production" &&
-                        <EditableInput
-                          elementType="select"
-                          name="registration_stage"
-                          label="Stage"
-                          value={currentRegistryStage || "testing"}
-                          ref={`stage-${library.short_name}`}
-                          onChange={() => this.updateRegistrationStage(library)}
-                        >
-                          <option value="testing">Testing</option>
-                          <option value="production">Production</option>
-                        </EditableInput>
-                      }
-                    </div>
+                    { supportsStaging &&
+                      (<div className="current-stage">
+                        { (currentRegistryStage && libraryRegistrationStatus !== "failure") ?
+                          <span>Current Stage: {currentRegistryStage}</span> :
+                          <span>No current stage</span>
+                        }
+                        { currentRegistryStage !== "production" &&
+                          <EditableInput
+                            elementType="select"
+                            name="registration_stage"
+                            label="Stage"
+                            value={currentRegistryStage || "testing"}
+                            ref={`stage-${library.short_name}`}
+                            onChange={() => this.updateRegistrationStage(library)}
+                          >
+                            <option value="testing">Testing</option>
+                            <option value="production">Production</option>
+                          </EditableInput>
+                        }
+                      </div>)
+                    }
 
                     { libraryRegistrationStatus === "success" &&
-                      <div>
+                      <div className="registration-status">
                         <span className="bg-success">
                           Registered
                         </span>
@@ -67,7 +71,7 @@ export default class LibraryRegistration extends React.Component<LibraryRegistra
                       </div>
                     }
                     { libraryRegistrationStatus === "failure" &&
-                      <div>
+                      <div className="registration-status">
                         <span className="bg-danger">
                           Registration failed
                         </span>
@@ -75,7 +79,7 @@ export default class LibraryRegistration extends React.Component<LibraryRegistra
                       </div>
                     }
                     { libraryRegistrationStatus === null &&
-                      <div>
+                      <div className="registration-status">
                         <span className="bg-warning">
                           Not registered
                         </span>
@@ -137,11 +141,11 @@ export default class LibraryRegistration extends React.Component<LibraryRegistra
     return libraryInfo && libraryInfo[prop];
   }
 
-  protocolSupportsRegistration(): boolean {
+  protocolSupportsType(prop: string): boolean {
     if (this.state.protocol && this.props.data.protocols) {
       for (const protocol of this.props.data.protocols) {
         if (protocol.name === this.state.protocol) {
-          return !!protocol.supports_registration;
+          return !!protocol[prop];
         }
       }
     }

--- a/src/components/__tests__/LibraryRegistration-test.tsx
+++ b/src/components/__tests__/LibraryRegistration-test.tsx
@@ -20,6 +20,7 @@ describe("LibraryRegistration", () => {
     name: protocol,
     label: "protocol 1 label",
     supports_registration: true,
+    supports_staging: true,
     settings: [],
     library_settings: []
   }];
@@ -86,7 +87,7 @@ describe("LibraryRegistration", () => {
 
       let libraries = wrapper.find(".service-with-registrations-library");
       expect(libraries.length).to.equal(0);
-   });
+    });
 
     it("renders all libraries in edit form, with registration status", () => {
       wrapper.setProps({ item: serviceData });
@@ -117,6 +118,62 @@ describe("LibraryRegistration", () => {
           />
         );
       });
+
+      it("should not render the staging dropdown if it is not supported", () => {
+        servicesData.protocols[0].supports_staging = false;
+
+        wrapper = shallow(
+          <LibraryRegistration
+            disabled={false}
+            data={servicesData}
+            item={serviceData}
+            save={save}
+            urlBase="url base"
+            listDataKey="discovery_services"
+            registerLibrary={registerLibrary}
+            protocol={protocol}
+          />
+        );
+
+        let libraryRegistrationInfo = wrapper.find(".library-registration-info");
+        let nypl = libraryRegistrationInfo.at(0);
+        let bpl = libraryRegistrationInfo.at(1);
+        let qpl = libraryRegistrationInfo.at(2);
+
+        let nyplCurrentStage = nypl.find(".current-stage");
+        let bplCurrentStage = bpl.find(".current-stage");
+        let qplCurrentStage = qpl.find(".current-stage");
+        let nyplEditableInput = nypl.find(EditableInput);
+        let bplEditableInput = bpl.find(EditableInput);
+        let qplEditableInput = qpl.find(EditableInput);
+
+        // The dropdown to update the current staging level should not be rendered
+        expect(nyplCurrentStage.length).to.equal(0);
+        expect(bplCurrentStage.length).to.equal(0);
+        expect(qplCurrentStage.length).to.equal(0);
+        expect(nyplEditableInput.length).to.equal(0);
+        expect(bplEditableInput.length).to.equal(0);
+        expect(qplEditableInput.length).to.equal(0);
+
+        // Registration status and button should still appear
+        let nyplRegistrationStatus = nypl.find(".registration-status span");
+        let bplRegistrationStatus = bpl.find(".registration-status span");
+        let qplRegistrationStatus = bpl.find(".registration-status span");
+        let nyplRegistrationStatusBtn = nypl.find(".registration-status button");
+        let bplRegistrationStatusBtn = bpl.find(".registration-status button");
+        let qplRegistrationStatusBtn = bpl.find(".registration-status button");
+
+        expect(nyplRegistrationStatus.text()).to.equal("Registered");
+        expect(bplRegistrationStatus.text()).to.equal("Registration failed");
+        expect(qplRegistrationStatus.text()).to.equal("Registration failed");
+
+        expect(nyplRegistrationStatusBtn.length).to.equal(1);
+        expect(bplRegistrationStatusBtn.length).to.equal(1);
+        expect(qplRegistrationStatusBtn.length).to.equal(1);
+
+        servicesData.protocols[0].supports_staging = true;
+      });
+
       it("should render the current registration stage", () => {
         // Adding an additional library to display the currect stage when
         // they are in the "testing" stage and their registration was

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -187,6 +187,7 @@ export interface ProtocolData {
   instructions?: string;
   sitewide?: boolean;
   supports_registration?: boolean;
+  supports_staging?: boolean;
   settings: SettingData[];
   child_settings?: SettingData[];
   library_settings?: SettingData[];

--- a/src/stylesheets/discovery_service_edit_form.scss
+++ b/src/stylesheets/discovery_service_edit_form.scss
@@ -1,6 +1,6 @@
 .service-with-registrations-library {
   display: flex;
-  margin: 5px;
+  margin: 15px 0 5px;
   padding: 0 0 20px;
   align-items: center;
   border-bottom: 1px solid $dark-gray;
@@ -16,7 +16,7 @@
     flex-direction: column;
 
     .current-stage {
-      margin: 15px 0;
+      margin: 0 0 15px
     }
   }
 


### PR DESCRIPTION
Fixes [SIMPLY-1344](https://jira.nypl.org/browse/SIMPLY-1344).

The shared ODL collection registration for libraries should not have UI controls for selecting what type of staging level the library should be in. This checks to see if the library supports staging selection and renders the proper controls if it does.