### PR TITLE
Group fields by type

### DIFF
--- a/src/components/BookCoverEditor.tsx
+++ b/src/components/BookCoverEditor.tsx
@@ -52,9 +52,10 @@ export class BookCoverEditor extends React.Component<BookCoverEditorProps, void>
   renderCoverForm() {
     return (
       <div>
+        <p>Cover must be at least 600px x 900px and in PNG, JPG, or GIF format.</p>
         <form ref="cover">
           <fieldset>
-            <legend className="visuallyHidden">Cover Metadata</legend>
+            <legend className="visuallyHidden">Cover Image</legend>
             <EditableInput
               elementType="input"
               type="text"
@@ -140,7 +141,6 @@ export class BookCoverEditor extends React.Component<BookCoverEditorProps, void>
             </div>
             <div>
               <h3>Change cover:</h3>
-              <p>Cover must be at least 600px x 900px and in PNG, JPG, or GIF format.</p>
               <Collapsible
                 title="Cover Metadata"
                 openByDefault={true}

--- a/src/components/BookCoverEditor.tsx
+++ b/src/components/BookCoverEditor.tsx
@@ -46,14 +46,15 @@ export class BookCoverEditor extends React.Component<BookCoverEditorProps, void>
     this.refresh = this.refresh.bind(this);
     this.preview = this.preview.bind(this);
     this.save = this.save.bind(this);
-    this.renderForm = this.renderForm.bind(this);
+    this.renderCoverForm = this.renderCoverForm.bind(this);
   }
 
-  renderForm() {
+  renderCoverForm() {
     return (
       <div>
         <form ref="cover">
           <fieldset>
+            <legend className="visuallyHidden">Cover Metadata</legend>
             <EditableInput
               elementType="input"
               type="text"
@@ -109,40 +110,6 @@ export class BookCoverEditor extends React.Component<BookCoverEditorProps, void>
               />
           </div>
         }
-        { this.props.rightsStatuses &&
-          <form ref="rights">
-            <fieldset>
-              <legend><h4>Rights:</h4></legend>
-              <EditableInput
-                elementType="select"
-                disabled={this.props.isFetching}
-                name="rights_status"
-                label="License"
-                >
-                { Object.keys(this.props.rightsStatuses).map(uri => {
-                      let status = this.props.rightsStatuses[uri];
-                      if (status.allows_derivatives) {
-                        return (
-                          <option value={uri} key={uri}>{status.name}</option>
-                        );
-                      }
-                      return null;
-                    }
-                  )
-                }
-                <option value="http://librarysimplified.org/terms/rights-status/in-copyright">In Copyright</option>
-                <option value="http://librarysimplified.org/terms/rights-status/unknown">Other</option>
-              </EditableInput>
-              <EditableInput
-                elementType="textarea"
-                disabled={this.props.isFetching}
-                name="rights_explanation"
-                label="Explanation of rights"
-                optionalText={false}
-              />
-            </fieldset>
-          </form>
-        }
       </div>
     );
   }
@@ -175,10 +142,50 @@ export class BookCoverEditor extends React.Component<BookCoverEditorProps, void>
               <h3>Change cover:</h3>
               <p>Cover must be at least 600px x 900px and in PNG, JPG, or GIF format.</p>
               <Collapsible
-                title="Required Fields"
-                collapsible={false}
-                body={this.renderForm()}
+                title="Cover Metadata"
+                openByDefault={true}
+                body={this.renderCoverForm()}
               />
+              { this.props.rightsStatuses &&
+                <Collapsible
+                  title="Rights"
+                  openByDefault={true}
+                  body={
+                    <form ref="rights">
+                      <fieldset>
+                        <legend className="visuallyHidden">Rights:</legend>
+                        <EditableInput
+                          elementType="select"
+                          disabled={this.props.isFetching}
+                          name="rights_status"
+                          label="License"
+                          >
+                          { Object.keys(this.props.rightsStatuses).map(uri => {
+                                let status = this.props.rightsStatuses[uri];
+                                if (status.allows_derivatives) {
+                                  return (
+                                    <option value={uri} key={uri}>{status.name}</option>
+                                  );
+                                }
+                                return null;
+                              }
+                            )
+                          }
+                          <option value="http://librarysimplified.org/terms/rights-status/in-copyright">In Copyright</option>
+                          <option value="http://librarysimplified.org/terms/rights-status/unknown">Other</option>
+                        </EditableInput>
+                        <EditableInput
+                          elementType="textarea"
+                          disabled={this.props.isFetching}
+                          name="rights_explanation"
+                          label="Explanation of rights"
+                          optionalText={false}
+                        />
+                      </fieldset>
+                    </form>
+                  }
+                />
+              }
               <button
                 className="btn btn-default"
                 type="submit"

--- a/src/components/BookCoverEditor.tsx
+++ b/src/components/BookCoverEditor.tsx
@@ -9,6 +9,7 @@ import EditableInput from "./EditableInput";
 import { BookData, RightsStatusData } from "../interfaces";
 import { FetchErrorData } from "opds-web-client/lib/interfaces";
 import { State } from "../reducers/index";
+import Collapsible from "./Collapsible";
 
 export interface BookCoverEditorStateProps {
   bookAdminUrl?: string;
@@ -45,6 +46,105 @@ export class BookCoverEditor extends React.Component<BookCoverEditorProps, void>
     this.refresh = this.refresh.bind(this);
     this.preview = this.preview.bind(this);
     this.save = this.save.bind(this);
+    this.renderForm = this.renderForm.bind(this);
+  }
+
+  renderForm() {
+    return (
+      <div>
+        <form ref="cover">
+          <fieldset>
+            <EditableInput
+              elementType="input"
+              type="text"
+              disabled={this.props.isFetching}
+              name="cover_url"
+              label="URL for cover image"
+              onChange={this.preview}
+              ref="cover_url"
+              optionalText={false}
+              />
+            <EditableInput
+              elementType="input"
+              type="file"
+              disabled={this.props.isFetching}
+              name="cover_file"
+              label="Or upload cover image"
+              accept="image/*"
+              onChange={this.preview}
+              ref="cover_file"
+              optionalText={false}
+              />
+            <EditableInput
+              elementType="select"
+              disabled={this.props.isFetching}
+              name="title_position"
+              label="Title and Author Position"
+              onChange={this.preview}
+              value="none"
+              >
+              <option value="none">None</option>
+              <option value="top">Top</option>
+              <option value="center">Center</option>
+              <option value="bottom">Bottom</option>
+            </EditableInput>
+          </fieldset>
+        </form>
+        { this.props.previewFetchError &&
+          <ErrorMessage error={this.props.previewFetchError} />
+        }
+        { this.props.isFetchingPreview &&
+          <h5 className="cover-fetching-preview-container">
+            Updating Preview&nbsp;
+            <i className="fa fa-spinner fa-spin"></i>
+          </h5>
+        }
+        { this.props.preview &&
+          <div>
+            <h4>Preview:</h4>
+            <img
+              src={this.props.preview}
+              className="book-cover preview-cover"
+              alt="Preview of new cover"
+              />
+          </div>
+        }
+        { this.props.rightsStatuses &&
+          <form ref="rights">
+            <fieldset>
+              <legend><h4>Rights:</h4></legend>
+              <EditableInput
+                elementType="select"
+                disabled={this.props.isFetching}
+                name="rights_status"
+                label="License"
+                >
+                { Object.keys(this.props.rightsStatuses).map(uri => {
+                      let status = this.props.rightsStatuses[uri];
+                      if (status.allows_derivatives) {
+                        return (
+                          <option value={uri} key={uri}>{status.name}</option>
+                        );
+                      }
+                      return null;
+                    }
+                  )
+                }
+                <option value="http://librarysimplified.org/terms/rights-status/in-copyright">In Copyright</option>
+                <option value="http://librarysimplified.org/terms/rights-status/unknown">Other</option>
+              </EditableInput>
+              <EditableInput
+                elementType="textarea"
+                disabled={this.props.isFetching}
+                name="rights_explanation"
+                label="Explanation of rights"
+                optionalText={false}
+              />
+            </fieldset>
+          </form>
+        }
+      </div>
+    );
   }
 
   render(): JSX.Element {
@@ -74,97 +174,11 @@ export class BookCoverEditor extends React.Component<BookCoverEditorProps, void>
             <div>
               <h3>Change cover:</h3>
               <p>Cover must be at least 600px x 900px and in PNG, JPG, or GIF format.</p>
-              <form ref="cover">
-                <fieldset>
-                  <EditableInput
-                    elementType="input"
-                    type="text"
-                    disabled={this.props.isFetching}
-                    name="cover_url"
-                    label="URL for cover image"
-                    onChange={this.preview}
-                    ref="cover_url"
-                    optionalText={false}
-                    />
-                  <EditableInput
-                    elementType="input"
-                    type="file"
-                    disabled={this.props.isFetching}
-                    name="cover_file"
-                    label="Or upload cover image"
-                    accept="image/*"
-                    onChange={this.preview}
-                    ref="cover_file"
-                    optionalText={false}
-                    />
-                  <EditableInput
-                    elementType="select"
-                    disabled={this.props.isFetching}
-                    name="title_position"
-                    label="Title and Author Position"
-                    onChange={this.preview}
-                    value="none"
-                    >
-                    <option value="none">None</option>
-                    <option value="top">Top</option>
-                    <option value="center">Center</option>
-                    <option value="bottom">Bottom</option>
-                  </EditableInput>
-                </fieldset>
-              </form>
-              { this.props.previewFetchError &&
-                <ErrorMessage error={this.props.previewFetchError} />
-              }
-              { this.props.isFetchingPreview &&
-                <h5 className="cover-fetching-preview-container">
-                  Updating Preview&nbsp;
-                  <i className="fa fa-spinner fa-spin"></i>
-                </h5>
-              }
-              { this.props.preview &&
-                <div>
-                  <h4>Preview:</h4>
-                  <img
-                    src={this.props.preview}
-                    className="book-cover preview-cover"
-                    alt="Preview of new cover"
-                    />
-                </div>
-              }
-              { this.props.rightsStatuses &&
-                <form ref="rights">
-                  <fieldset>
-                    <legend><h4>Rights:</h4></legend>
-                    <EditableInput
-                      elementType="select"
-                      disabled={this.props.isFetching}
-                      name="rights_status"
-                      label="License"
-                      >
-                      { Object.keys(this.props.rightsStatuses).map(uri => {
-                            let status = this.props.rightsStatuses[uri];
-                            if (status.allows_derivatives) {
-                              return (
-                                <option value={uri} key={uri}>{status.name}</option>
-                              );
-                            }
-                            return null;
-                          }
-                        )
-                      }
-                      <option value="http://librarysimplified.org/terms/rights-status/in-copyright">In Copyright</option>
-                      <option value="http://librarysimplified.org/terms/rights-status/unknown">Other</option>
-                    </EditableInput>
-                    <EditableInput
-                      elementType="textarea"
-                      disabled={this.props.isFetching}
-                      name="rights_explanation"
-                      label="Explanation of rights"
-                      optionalText={false}
-                    />
-                  </fieldset>
-                </form>
-              }
+              <Collapsible
+                title="Required Fields"
+                collapsible={false}
+                body={this.renderForm()}
+              />
               <button
                 className="btn btn-default"
                 type="submit"

--- a/src/components/BookEditForm.tsx
+++ b/src/components/BookEditForm.tsx
@@ -3,7 +3,6 @@ import EditableInput from "./EditableInput";
 import { BookData, ContributorData, RolesData, MediaData, LanguagesData } from "../interfaces";
 import WithRemoveButton from "./WithRemoveButton";
 import Autocomplete from "./Autocomplete";
-import Collapsible from "./Collapsible";
 
 export interface BookEditFormProps extends BookData {
   roles: RolesData;
@@ -209,11 +208,7 @@ export default class BookEditForm extends React.Component<BookEditFormProps, Boo
   render(): JSX.Element {
     return (
       <form ref="form" onSubmit={this.save.bind(this)} className="edit-form">
-        <Collapsible
-          title="Required Fields"
-          collapsible={false}
-          body={this.renderForm()}
-        />
+        {this.renderForm()}
         <button
           className="btn btn-default"
           disabled={this.props.disabled}

--- a/src/components/BookEditForm.tsx
+++ b/src/components/BookEditForm.tsx
@@ -3,6 +3,7 @@ import EditableInput from "./EditableInput";
 import { BookData, ContributorData, RolesData, MediaData, LanguagesData } from "../interfaces";
 import WithRemoveButton from "./WithRemoveButton";
 import Autocomplete from "./Autocomplete";
+import Collapsible from "./Collapsible";
 
 export interface BookEditFormProps extends BookData {
   roles: RolesData;
@@ -26,182 +27,193 @@ export default class BookEditForm extends React.Component<BookEditFormProps, Boo
     };
     this.addContributor = this.addContributor.bind(this);
     this.removeContributor = this.removeContributor.bind(this);
+    this.renderForm = this.renderForm.bind(this);
+  }
+
+  renderForm() {
+    return (
+      <fieldset>
+        <legend className="visuallyHidden">Edit Book Metadata</legend>
+        <EditableInput
+          elementType="input"
+          type="text"
+          disabled={this.props.disabled}
+          name="title"
+          label="Title"
+          value={this.props.title}
+          optionalText={false}
+          />
+        <EditableInput
+          elementType="input"
+          type="text"
+          disabled={this.props.disabled}
+          name="subtitle"
+          label="Subtitle"
+          value={this.props.subtitle}
+          optionalText={false}
+          />
+        <div className="form-group">
+          <label>Authors and Contributors</label>
+          { this.state.contributors.map(contributor =>
+              <WithRemoveButton
+                key={contributor.name + contributor.role}
+                disabled={this.props.disabled}
+                onRemove={() => this.removeContributor(contributor)}
+                >
+                <span className="contributor-form">
+                  <EditableInput
+                    elementType="select"
+                    disabled={this.props.disabled}
+                    name="contributor-role"
+                    value={this.getContributorRole(contributor)}
+                    >
+                    { this.props.roles && Object.values(this.props.roles).map(role =>
+                        <option value={role} key={role}>{role}</option>
+                      )
+                    }
+                  </EditableInput>
+                  <EditableInput
+                    elementType="input"
+                    type="text"
+                    disabled={this.props.disabled}
+                    name="contributor-name"
+                    value={contributor.name}
+                    optionalText={false}
+                    />
+                </span>
+              </WithRemoveButton>
+            )
+          }
+          <span className="contributor-form">
+            <EditableInput
+              elementType="select"
+              disabled={this.props.disabled}
+              name="contributor-role"
+              value="Author"
+              ref="addContributorRole"
+              >
+              { this.props.roles && Object.values(this.props.roles).map(role =>
+                  <option value={role} key={role}>{role}</option>
+                )
+              }
+            </EditableInput>
+            <EditableInput
+              elementType="input"
+              type="text"
+              disabled={this.props.disabled}
+              name="contributor-name"
+              ref="addContributorName"
+              optionalText={false}
+              />
+            <button
+              type="button"
+              className="btn btn-default add-contributor"
+              disabled={this.props.disabled}
+              onClick={this.addContributor}
+              >Add</button>
+          </span>
+        </div>
+        <div className="form-group">
+          <label>Series</label>
+          <div className="form-inline">
+            <EditableInput
+              elementType="input"
+              type="text"
+              disabled={this.props.disabled}
+              name="series"
+              placeholder="Name"
+              value={this.props.series}
+              optionalText={false}
+              />
+            <span>&nbsp;&nbsp;</span>
+            <EditableInput
+              elementType="input"
+              type="text"
+              disabled={this.props.disabled}
+              name="series_position"
+              placeholder="#"
+              value={this.props.seriesPosition !== undefined && this.props.seriesPosition !== null && String(this.props.seriesPosition)}
+              optionalText={false}
+              />
+          </div>
+        </div>
+        <EditableInput
+          elementType="select"
+          disabled={this.props.disabled}
+          name="medium"
+          label="Medium"
+          value={this.getMedium(this.props.medium)}
+          >
+          { this.props.media && Object.values(this.props.media).map(medium =>
+              <option value={medium} key={medium}>{medium}</option>
+            )
+          }
+        </EditableInput>
+        <Autocomplete
+          autocompleteValues={this.uniqueLanguageNames()}
+          disabled={this.props.disabled}
+          name="language"
+          label="Language"
+          value={this.props.languages && this.props.languages[this.props.language] && this.props.languages[this.props.language][0]}
+          />
+        <EditableInput
+          elementType="input"
+          type="text"
+          disabled={this.props.disabled}
+          name="publisher"
+          label="Publisher"
+          value={this.props.publisher}
+          optionalText={false}
+          />
+        <EditableInput
+          elementType="input"
+          type="text"
+          disabled={this.props.disabled}
+          name="imprint"
+          label="Imprint"
+          value={this.props.imprint}
+          optionalText={false}
+          />
+        <EditableInput
+          elementType="input"
+          type="date"
+          disabled={this.props.disabled}
+          name="issued"
+          label="Publication Date"
+          value={this.props.issued}
+          optionalText={false}
+          />
+        <EditableInput
+          elementType="input"
+          type="number"
+          disabled={this.props.disabled}
+          name="rating"
+          label="Rating (1-5, higher is better)"
+          min={1}
+          max={5}
+          value={this.props.rating && String(Math.round(this.props.rating))}
+          optionalText={false}
+          />
+        <EditableInput
+          elementType="textarea"
+          disabled={this.props.disabled}
+          name="summary"
+          label="Summary"
+          value={this.props.summary}
+          optionalText={false}
+          />
+      </fieldset>
+    );
   }
 
   render(): JSX.Element {
     return (
       <form ref="form" onSubmit={this.save.bind(this)} className="edit-form">
-        <fieldset>
-          <legend className="visuallyHidden">Edit Book Metadata</legend>
-          <EditableInput
-            elementType="input"
-            type="text"
-            disabled={this.props.disabled}
-            name="title"
-            label="Title"
-            value={this.props.title}
-            optionalText={false}
-            />
-          <EditableInput
-            elementType="input"
-            type="text"
-            disabled={this.props.disabled}
-            name="subtitle"
-            label="Subtitle"
-            value={this.props.subtitle}
-            optionalText={false}
-            />
-          <div className="form-group">
-            <label>Authors and Contributors</label>
-            { this.state.contributors.map(contributor =>
-                <WithRemoveButton
-                  key={contributor.name + contributor.role}
-                  disabled={this.props.disabled}
-                  onRemove={() => this.removeContributor(contributor)}
-                  >
-                  <span className="contributor-form">
-                    <EditableInput
-                      elementType="select"
-                      disabled={this.props.disabled}
-                      name="contributor-role"
-                      value={this.getContributorRole(contributor)}
-                      >
-                      { this.props.roles && Object.values(this.props.roles).map(role =>
-                          <option value={role} key={role}>{role}</option>
-                        )
-                      }
-                    </EditableInput>
-                    <EditableInput
-                      elementType="input"
-                      type="text"
-                      disabled={this.props.disabled}
-                      name="contributor-name"
-                      value={contributor.name}
-                      optionalText={false}
-                      />
-                  </span>
-                </WithRemoveButton>
-              )
-            }
-            <span className="contributor-form">
-              <EditableInput
-                elementType="select"
-                disabled={this.props.disabled}
-                name="contributor-role"
-                value="Author"
-                ref="addContributorRole"
-                >
-                { this.props.roles && Object.values(this.props.roles).map(role =>
-                    <option value={role} key={role}>{role}</option>
-                  )
-                }
-              </EditableInput>
-              <EditableInput
-                elementType="input"
-                type="text"
-                disabled={this.props.disabled}
-                name="contributor-name"
-                ref="addContributorName"
-                optionalText={false}
-                />
-              <button
-                type="button"
-                className="btn btn-default add-contributor"
-                disabled={this.props.disabled}
-                onClick={this.addContributor}
-                >Add</button>
-            </span>
-          </div>
-          <div className="form-group">
-            <label>Series</label>
-            <div className="form-inline">
-              <EditableInput
-                elementType="input"
-                type="text"
-                disabled={this.props.disabled}
-                name="series"
-                placeholder="Name"
-                value={this.props.series}
-                optionalText={false}
-                />
-              <span>&nbsp;&nbsp;</span>
-              <EditableInput
-                elementType="input"
-                type="text"
-                disabled={this.props.disabled}
-                name="series_position"
-                placeholder="#"
-                value={this.props.seriesPosition !== undefined && this.props.seriesPosition !== null && String(this.props.seriesPosition)}
-                optionalText={false}
-                />
-            </div>
-          </div>
-          <EditableInput
-            elementType="select"
-            disabled={this.props.disabled}
-            name="medium"
-            label="Medium"
-            value={this.getMedium(this.props.medium)}
-            >
-            { this.props.media && Object.values(this.props.media).map(medium =>
-                <option value={medium} key={medium}>{medium}</option>
-              )
-            }
-          </EditableInput>
-          <Autocomplete
-            autocompleteValues={this.uniqueLanguageNames()}
-            disabled={this.props.disabled}
-            name="language"
-            label="Language"
-            value={this.props.languages && this.props.languages[this.props.language] && this.props.languages[this.props.language][0]}
-            />
-          <EditableInput
-            elementType="input"
-            type="text"
-            disabled={this.props.disabled}
-            name="publisher"
-            label="Publisher"
-            value={this.props.publisher}
-            optionalText={false}
-            />
-          <EditableInput
-            elementType="input"
-            type="text"
-            disabled={this.props.disabled}
-            name="imprint"
-            label="Imprint"
-            value={this.props.imprint}
-            optionalText={false}
-            />
-          <EditableInput
-            elementType="input"
-            type="date"
-            disabled={this.props.disabled}
-            name="issued"
-            label="Publication Date"
-            value={this.props.issued}
-            optionalText={false}
-            />
-          <EditableInput
-            elementType="input"
-            type="number"
-            disabled={this.props.disabled}
-            name="rating"
-            label="Rating (1-5, higher is better)"
-            min={1}
-            max={5}
-            value={this.props.rating && String(Math.round(this.props.rating))}
-            optionalText={false}
-            />
-          <EditableInput
-            elementType="textarea"
-            disabled={this.props.disabled}
-            name="summary"
-            label="Summary"
-            value={this.props.summary}
-            optionalText={false}
-            />
-        </fieldset>
+        <Collapsible
+          title="Required Fields"
+          collapsible={false}
+          body={this.renderForm()}
+        />
         <button
           className="btn btn-default"
           disabled={this.props.disabled}

--- a/src/components/Collapsible.tsx
+++ b/src/components/Collapsible.tsx
@@ -29,19 +29,15 @@ export default class Collapsible extends React.Component<CollapsibleProps, Colla
 
   renderHeader() {
     let icon = this.state.open ? "minus" : "plus";
-    const { type, title } = this.props;
-    let element = "div";
-    if (type === "instruction") {
-      element = "button";
-    }
-    const content = (<div>
+    const { title } = this.props;
+    const content = (
+      <div>
         <span>{title}</span>
         <Glyphicon glyph={icon} />
-      </div>);
-    return React.createElement(element, {
-      bsStyle: "default",
-      onClick: this.toggle,
-    }, content );
+      </div>
+    );
+
+    return (<button bsStyle="default" onClick={this.toggle}>{content}</button>);
   }
 
   renderSection() {

--- a/src/components/Collapsible.tsx
+++ b/src/components/Collapsible.tsx
@@ -3,10 +3,10 @@ import { Panel, Button, Glyphicon } from "react-bootstrap";
 
 export interface CollapsibleProps {
   title: string;
+  collapsible: boolean;
   text?: string;
-  elementType?: string;
+  type?: string;
   body?: JSX.Element;
-  collapsible?: boolean;
 }
 
 export interface CollapsibleState {
@@ -20,6 +20,7 @@ export default class Collapsible extends React.Component<CollapsibleProps, Colla
     this.state = { open: false };
     this.toggle = this.toggle.bind(this);
     this.renderHeader = this.renderHeader.bind(this);
+    this.renderSection = this.renderSection.bind(this);
   }
 
   toggle(e) {
@@ -29,44 +30,41 @@ export default class Collapsible extends React.Component<CollapsibleProps, Colla
 
   renderHeader() {
     let icon = this.state.open ? "minus" : "plus";
-    // return (
-    //   <button bsStyle="default" onClick={this.toggle}>
-    //     <span>{this.props.title}</span>
-    //     <Glyphicon glyph={icon} />
-    //   </button>
-    // );
-    const { elementType, text, body } = this.props;
-    const shouldBeButton = elementType === "button";
-    const content = (<span>
-        <span>{this.props.title}</span>
-        {this.props.collapsible ? <Glyphicon glyph={icon} /> : null}
-      </span>);
-    return React.createElement(elementType || "div", {
-      className: shouldBeButton ? "collapsible" : "",
+    const { type, collapsible, title } = this.props;
+    let element = "div";
+    if (type === "instruction") {
+      element = "button";
+    }
+    const content = (<div>
+        <span>{title}</span>
+        {collapsible ? <Glyphicon glyph={icon} /> : null}
+      </div>);
+    return React.createElement(element, {
       bsStyle: "default",
-      onClick: this.toggle,
+      onClick: collapsible ? this.toggle : null,
     }, content );
   }
 
-  render() {
-    const { elementType, body, text } = this.props;
-    let section;
-    let className = "";
-    if (elementType === "button") {
-      className = "collapsible";
-      section = <section dangerouslySetInnerHTML={{ __html: text }} />;
+  renderSection() {
+    const { body, text, type } = this.props;
+    if (text && type === "instruction") {
+      return <section dangerouslySetInnerHTML={{ __html: text }} />;
     } else if (body) {
-      section = <section>{body}</section>;
+      return <section>{body}</section>;
     }
+    return null;
+  }
 
+  render() {
+    const className = this.props.type === "instruction" ? "instruction" : "";
     return (
       <Panel
-        className={className}
+        className={`collapsible ${className}`}
         collapsible={this.props.collapsible}
         header={this.renderHeader()}
         expanded={this.state.open}
       >
-        {section}
+        {this.renderSection()}
       </Panel>
     );
   }

--- a/src/components/Collapsible.tsx
+++ b/src/components/Collapsible.tsx
@@ -41,7 +41,7 @@ export default class Collapsible extends React.Component<CollapsibleProps, Colla
         <span>{this.props.title}</span>
         {this.props.collapsible ? <Glyphicon glyph={icon} /> : null}
       </span>);
-    return React.createElement("div", {
+    return React.createElement(elementType || "div", {
       className: shouldBeButton ? "collapsible" : "",
       bsStyle: "default",
       onClick: this.toggle,
@@ -60,7 +60,12 @@ export default class Collapsible extends React.Component<CollapsibleProps, Colla
     }
 
     return (
-      <Panel className={className} collapsible={this.props.collapsible} header={this.renderHeader()} expanded={this.state.open}>
+      <Panel
+        className={className}
+        collapsible={this.props.collapsible}
+        header={this.renderHeader()}
+        expanded={this.state.open}
+      >
         {section}
       </Panel>
     );

--- a/src/components/Collapsible.tsx
+++ b/src/components/Collapsible.tsx
@@ -7,6 +7,7 @@ export interface CollapsibleProps {
   type?: string;
   body?: JSX.Element;
   openByDefault?: boolean;
+  collapsible?: boolean;
 }
 
 export interface CollapsibleState {
@@ -14,6 +15,10 @@ export interface CollapsibleState {
 }
 
 export default class Collapsible extends React.Component<CollapsibleProps, CollapsibleState> {
+  static defaultProps = {
+    collapsible: true,
+  };
+
   constructor(props) {
     super(props);
     this.state = { open: this.props.openByDefault || false };
@@ -29,15 +34,22 @@ export default class Collapsible extends React.Component<CollapsibleProps, Colla
 
   renderHeader() {
     let icon = this.state.open ? "minus" : "plus";
-    const { title } = this.props;
+    const { collapsible, title } = this.props;
     const content = (
       <div>
         <span>{title}</span>
-        <Glyphicon glyph={icon} />
+        { collapsible ? <Glyphicon glyph={icon} /> : null}
       </div>
     );
+    let element = "div";
+    if (collapsible) {
+      element = "button";
+    }
 
-    return (<button bsStyle="default" onClick={this.toggle}>{content}</button>);
+    return React.createElement(element, {
+      bsStyle: "default",
+      onClick: this.toggle,
+    }, content );
   }
 
   renderSection() {
@@ -52,10 +64,11 @@ export default class Collapsible extends React.Component<CollapsibleProps, Colla
 
   render() {
     const className = this.props.type === "instruction" ? "instruction" : "";
+    const staticPanel = !this.props.collapsible ? "staticPanel" : "";
     return (
       <Panel
-        className={`collapsible ${className}`}
-        collapsible={true}
+        className={`collapsible ${className} ${staticPanel}`}
+        collapsible={this.props.collapsible}
         header={this.renderHeader()}
         expanded={this.state.open}
       >

--- a/src/components/Collapsible.tsx
+++ b/src/components/Collapsible.tsx
@@ -3,7 +3,10 @@ import { Panel, Button, Glyphicon } from "react-bootstrap";
 
 export interface CollapsibleProps {
   title: string;
-  body: string;
+  text?: string;
+  elementType?: string;
+  body?: JSX.Element;
+  collapsible?: boolean;
 }
 
 export interface CollapsibleState {
@@ -26,18 +29,39 @@ export default class Collapsible extends React.Component<CollapsibleProps, Colla
 
   renderHeader() {
     let icon = this.state.open ? "minus" : "plus";
-    return (
-      <button bsStyle="default" onClick={this.toggle}>
+    // return (
+    //   <button bsStyle="default" onClick={this.toggle}>
+    //     <span>{this.props.title}</span>
+    //     <Glyphicon glyph={icon} />
+    //   </button>
+    // );
+    const { elementType, text, body } = this.props;
+    const shouldBeButton = elementType === "button";
+    const content = (<span>
         <span>{this.props.title}</span>
-        <Glyphicon glyph={icon} />
-      </button>
-    );
+        {this.props.collapsible ? <Glyphicon glyph={icon} /> : null}
+      </span>);
+    return React.createElement("div", {
+      className: shouldBeButton ? "collapsible" : "",
+      bsStyle: "default",
+      onClick: this.toggle,
+    }, content );
   }
 
   render() {
+    const { elementType, body, text } = this.props;
+    let section;
+    let className = "";
+    if (elementType === "button") {
+      className = "collapsible";
+      section = <section dangerouslySetInnerHTML={{ __html: text }} />;
+    } else if (body) {
+      section = <section>{body}</section>;
+    }
+
     return (
-      <Panel className="collapsible" collapsible={true} header={this.renderHeader()} expanded={this.state.open}>
-        <section dangerouslySetInnerHTML={{__html: this.props.body}}></section>
+      <Panel className={className} collapsible={this.props.collapsible} header={this.renderHeader()} expanded={this.state.open}>
+        {section}
       </Panel>
     );
   }

--- a/src/components/Collapsible.tsx
+++ b/src/components/Collapsible.tsx
@@ -3,10 +3,10 @@ import { Panel, Button, Glyphicon } from "react-bootstrap";
 
 export interface CollapsibleProps {
   title: string;
-  collapsible: boolean;
   text?: string;
   type?: string;
   body?: JSX.Element;
+  openByDefault?: boolean;
 }
 
 export interface CollapsibleState {
@@ -14,10 +14,9 @@ export interface CollapsibleState {
 }
 
 export default class Collapsible extends React.Component<CollapsibleProps, CollapsibleState> {
-
   constructor(props) {
     super(props);
-    this.state = { open: false };
+    this.state = { open: this.props.openByDefault || false };
     this.toggle = this.toggle.bind(this);
     this.renderHeader = this.renderHeader.bind(this);
     this.renderSection = this.renderSection.bind(this);
@@ -30,18 +29,18 @@ export default class Collapsible extends React.Component<CollapsibleProps, Colla
 
   renderHeader() {
     let icon = this.state.open ? "minus" : "plus";
-    const { type, collapsible, title } = this.props;
+    const { type, title } = this.props;
     let element = "div";
     if (type === "instruction") {
       element = "button";
     }
     const content = (<div>
         <span>{title}</span>
-        {collapsible ? <Glyphicon glyph={icon} /> : null}
+        <Glyphicon glyph={icon} />
       </div>);
     return React.createElement(element, {
       bsStyle: "default",
-      onClick: collapsible ? this.toggle : null,
+      onClick: this.toggle,
     }, content );
   }
 
@@ -60,7 +59,7 @@ export default class Collapsible extends React.Component<CollapsibleProps, Colla
     return (
       <Panel
         className={`collapsible ${className}`}
-        collapsible={this.props.collapsible}
+        collapsible={true}
         header={this.renderHeader()}
         expanded={this.state.open}
       >

--- a/src/components/CustomListEditor.tsx
+++ b/src/components/CustomListEditor.tsx
@@ -115,7 +115,7 @@ export default class CustomListEditor extends React.Component<CustomListEditorPr
           <form className="form-inline" onSubmit={this.search}>
             <Collapsible
               title="Search"
-              collapsible={false}
+              openByDefault={true}
               body={
                 <fieldset>
                   <legend><h4>Search for titles</h4></legend>

--- a/src/components/CustomListEditor.tsx
+++ b/src/components/CustomListEditor.tsx
@@ -6,6 +6,7 @@ import EditableInput from "./EditableInput";
 import CustomListEntriesEditor, { Entry } from "./CustomListEntriesEditor";
 import XCloseIcon from "./icons/XCloseIcon";
 import SearchIcon from "./icons/SearchIcon";
+import Collapsible from "./Collapsible";
 
 export interface CustomListEditorProps extends React.Props<CustomListEditor> {
   library: string;
@@ -112,29 +113,35 @@ export default class CustomListEditor extends React.Component<CustomListEditorPr
         </div>
         <div className="custom-list-editor-body">
           <form className="form-inline" onSubmit={this.search}>
-            <fieldset>
-              <legend><h4>Search for titles</h4></legend>
-              {
-                this.props.entryPoints.length ? (
-                  <div className="entry-points">
-                    <span>Select the entry point to search for:</span>
-                    <div className="entry-points-selection">
-                      {this.getEntryPointsElms(this.props.entryPoints)}
-                    </div>
-                  </div>
-                ) : null
+            <Collapsible
+              title="Search"
+              collapsible={false}
+              body={
+                <fieldset>
+                  <legend><h4>Search for titles</h4></legend>
+                  {
+                    this.props.entryPoints.length ? (
+                      <div className="entry-points">
+                        <span>Select the entry point to search for:</span>
+                        <div className="entry-points-selection">
+                          {this.getEntryPointsElms(this.props.entryPoints)}
+                        </div>
+                      </div>
+                    ) : null
+                  }
+                  <input
+                    className="form-control"
+                    ref="searchTerms"
+                    type="text"
+                    />&nbsp;
+                  <button
+                    className="btn btn-default"
+                    type="submit">Search
+                      <SearchIcon />
+                  </button>
+                </fieldset>
               }
-              <input
-                className="form-control"
-                ref="searchTerms"
-                type="text"
-                />&nbsp;
-              <button
-                className="btn btn-default"
-                type="submit">Search
-                  <SearchIcon />
-              </button>
-            </fieldset>
+            />
           </form>
 
           <CustomListEntriesEditor

--- a/src/components/CustomListEditor.tsx
+++ b/src/components/CustomListEditor.tsx
@@ -74,25 +74,6 @@ export default class CustomListEditor extends React.Component<CustomListEditorPr
             { listId &&
               <h4>ID-{listId}</h4>
             }
-            { this.props.collections && this.props.collections.length > 0 &&
-              <div className="custom-list-filters">
-                <span>Automatically add new books from these collections to this list:</span>
-                <div className="collections">
-                  { this.props.collections.map(collection =>
-                      <EditableInput
-                        key={collection.id}
-                        type="checkbox"
-                        name="collection"
-                        checked={this.hasCollection(collection)}
-                        label={collection.name}
-                        value={String(collection.id)}
-                        onChange={() => {this.changeCollection(collection);}}
-                        />
-                    )
-                  }
-                </div>
-              </div>
-            }
           </div>
           <span>
             <button
@@ -112,13 +93,37 @@ export default class CustomListEditor extends React.Component<CustomListEditorPr
           </span>
         </div>
         <div className="custom-list-editor-body">
+          { this.props.collections && this.props.collections.length > 0 &&
+            <div className="custom-list-filters">
+              <Collapsible
+                title="Add from collections"
+                body={
+                  <div className="collections">
+                    <div>Automatically add new books from these collections to this list:</div>
+                    { this.props.collections.map(collection =>
+                        <EditableInput
+                          key={collection.id}
+                          type="checkbox"
+                          name="collection"
+                          checked={this.hasCollection(collection)}
+                          label={collection.name}
+                          value={String(collection.id)}
+                          onChange={() => {this.changeCollection(collection);}}
+                          />
+                      )
+                    }
+                  </div>
+                }
+              />
+            </div>
+          }
           <form className="form-inline" onSubmit={this.search}>
             <Collapsible
-              title="Search"
+              title="Search for titles"
               openByDefault={true}
               body={
                 <fieldset>
-                  <legend><h4>Search for titles</h4></legend>
+                  <legend className="visuallyHidden">Search for titles</legend>
                   {
                     this.props.entryPoints.length ? (
                       <div className="entry-points">

--- a/src/components/IndividualAdminEditForm.tsx
+++ b/src/components/IndividualAdminEditForm.tsx
@@ -4,6 +4,7 @@ import SaveButton from "./SaveButton";
 import { handleSubmit, clearForm } from "./sharedFunctions";
 import { IndividualAdminsData, IndividualAdminData } from "../interfaces";
 import Admin from "../models/Admin";
+import Collapsible from "./Collapsible";
 import { FetchErrorData } from "opds-web-client/lib/interfaces";
 
 export interface IndividualAdminEditFormProps {
@@ -49,112 +50,116 @@ export default class IndividualAdminEditForm extends React.Component<IndividualA
   render(): JSX.Element {
     return (
       <form ref="form" onSubmit={this.submit} className="edit-form">
-        <fieldset>
-          <legend><h4>Required admin information</h4></legend>
-          <EditableInput
-            elementType="input"
-            type="text"
-            disabled={this.props.disabled}
-            required={true}
-            readOnly={!!(this.props.item && this.props.item.email)}
-            name="email"
-            label="Email"
-            ref="email"
-            value={this.props.item && this.props.item.email}
-            error={this.props.error}
-            />
-          { this.canChangePassword() &&
-            <EditableInput
-              elementType="input"
-              type="text"
-              disabled={this.props.disabled}
-              required={true}
-              name="password"
-              label="Password"
-              ref="password"
-              error={this.props.error}
-              />
-          }
-        </fieldset>
-        { !this.context.settingUp &&
-          <fieldset>
-            <legend><h4>Roles</h4></legend>
-            <EditableInput
-              elementType="input"
-              type="checkbox"
-              disabled={this.isDisabled("system")}
-              name="system"
-              ref="system"
-              label="System Admin"
-              checked={this.isSelected("system")}
-              onChange={() => this.handleRoleChange("system")}
-              />
-            <table className="library-admin-roles">
-              <thead>
-                <tr>
-                  <th></th>
-                  <th>
-                    <EditableInput
-                       elementType="input"
-                       type="checkbox"
-                       disabled={this.isDisabled("manager-all")}
-                       name="manager-all"
-                       ref="manager-all"
-                       label="Library Manager"
-                       checked={this.isSelected("manager-all")}
-                       onChange={() => this.handleRoleChange("manager-all")}
-                    />
-                  </th>
-                  <th>
-                    <EditableInput
-                      elementType="input"
-                      type="checkbox"
-                      disabled={this.isDisabled("librarian-all")}
-                      name="librarian-all"
-                      ref="librarian-all"
-                      label="Librarian"
-                      checked={this.isSelected("librarian-all")}
-                      onChange={() => this.handleRoleChange("librarian-all")}
-                      />
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                { this.props.data && this.props.data.allLibraries && this.props.data.allLibraries.map(library =>
-                  <tr key={library.short_name}>
-                    <td>
-                      {library.name}
-                    </td>
-                    <td>
-                      <EditableInput
-                        elementType="input"
-                        type="checkbox"
-                        disabled={this.isDisabled("manager", library.short_name)}
-                        name={"manager-" + library.short_name}
-                        ref={"manager-" + library.short_name}
-                        label=""
-                        checked={this.isSelected("manager", library.short_name)}
-                        onChange={() => this.handleRoleChange("manager", library.short_name)}
+        <Collapsible title="Admin Information" collapsible={false} body={
+          <span>
+            <fieldset>
+              <legend className="visuallyHidden">Admin information</legend>
+              <EditableInput
+                elementType="input"
+                type="text"
+                disabled={this.props.disabled}
+                required={true}
+                readOnly={!!(this.props.item && this.props.item.email)}
+                name="email"
+                label="Email"
+                ref="email"
+                value={this.props.item && this.props.item.email}
+                error={this.props.error}
+                />
+              { this.canChangePassword() &&
+                <EditableInput
+                  elementType="input"
+                  type="text"
+                  disabled={this.props.disabled}
+                  required={true}
+                  name="password"
+                  label="Password"
+                  ref="password"
+                  error={this.props.error}
+                  />
+              }
+            </fieldset>
+            { !this.context.settingUp &&
+              <fieldset>
+                <legend><h4>Roles</h4></legend>
+                <EditableInput
+                  elementType="input"
+                  type="checkbox"
+                  disabled={this.isDisabled("system")}
+                  name="system"
+                  ref="system"
+                  label="System Admin"
+                  checked={this.isSelected("system")}
+                  onChange={() => this.handleRoleChange("system")}
+                  />
+                <table className="library-admin-roles">
+                  <thead>
+                    <tr>
+                      <th></th>
+                      <th>
+                        <EditableInput
+                           elementType="input"
+                           type="checkbox"
+                           disabled={this.isDisabled("manager-all")}
+                           name="manager-all"
+                           ref="manager-all"
+                           label="Library Manager"
+                           checked={this.isSelected("manager-all")}
+                           onChange={() => this.handleRoleChange("manager-all")}
                         />
-                    </td>
-                    <td>
-                      <EditableInput
-                        elementType="input"
-                        type="checkbox"
-                        disabled={this.isDisabled("librarian", library.short_name)}
-                        name={"librarian-" + library.short_name}
-                        ref={"librarian-" + library.short_name}
-                        label=""
-                        checked={this.isSelected("librarian", library.short_name)}
-                        onChange={() => this.handleRoleChange("librarian", library.short_name)}
-                        />
-                    </td>
-                  </tr>
-                ) }
-              </tbody>
-            </table>
-          </fieldset>
-        }
+                      </th>
+                      <th>
+                        <EditableInput
+                          elementType="input"
+                          type="checkbox"
+                          disabled={this.isDisabled("librarian-all")}
+                          name="librarian-all"
+                          ref="librarian-all"
+                          label="Librarian"
+                          checked={this.isSelected("librarian-all")}
+                          onChange={() => this.handleRoleChange("librarian-all")}
+                          />
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    { this.props.data && this.props.data.allLibraries && this.props.data.allLibraries.map(library =>
+                      <tr key={library.short_name}>
+                        <td>
+                          {library.name}
+                        </td>
+                        <td>
+                          <EditableInput
+                            elementType="input"
+                            type="checkbox"
+                            disabled={this.isDisabled("manager", library.short_name)}
+                            name={"manager-" + library.short_name}
+                            ref={"manager-" + library.short_name}
+                            label=""
+                            checked={this.isSelected("manager", library.short_name)}
+                            onChange={() => this.handleRoleChange("manager", library.short_name)}
+                            />
+                        </td>
+                        <td>
+                          <EditableInput
+                            elementType="input"
+                            type="checkbox"
+                            disabled={this.isDisabled("librarian", library.short_name)}
+                            name={"librarian-" + library.short_name}
+                            ref={"librarian-" + library.short_name}
+                            label=""
+                            checked={this.isSelected("librarian", library.short_name)}
+                            onChange={() => this.handleRoleChange("librarian", library.short_name)}
+                            />
+                        </td>
+                      </tr>
+                    ) }
+                  </tbody>
+                </table>
+              </fieldset>
+            }
+          </span>}
+        />
         <SaveButton
           disabled={this.props.disabled}
           submit={this.submit}

--- a/src/components/IndividualAdminEditForm.tsx
+++ b/src/components/IndividualAdminEditForm.tsx
@@ -70,7 +70,6 @@ export default class IndividualAdminEditForm extends React.Component<IndividualA
               elementType="input"
               type="text"
               disabled={this.props.disabled}
-              required={true}
               name="password"
               label="Password"
               ref="password"

--- a/src/components/IndividualAdminEditForm.tsx
+++ b/src/components/IndividualAdminEditForm.tsx
@@ -45,120 +45,129 @@ export default class IndividualAdminEditForm extends React.Component<IndividualA
     this.handleRoleChange = this.handleRoleChange.bind(this);
     this.handleData = this.handleData.bind(this);
     this.submit = this.submit.bind(this);
+    this.renderForm = this.renderForm.bind(this);
+  }
+
+  renderForm() {
+    return (
+      <span>
+        <fieldset>
+          <legend className="visuallyHidden">Admin information</legend>
+          <EditableInput
+            elementType="input"
+            type="text"
+            disabled={this.props.disabled}
+            required={true}
+            readOnly={!!(this.props.item && this.props.item.email)}
+            name="email"
+            label="Email"
+            ref="email"
+            value={this.props.item && this.props.item.email}
+            error={this.props.error}
+            />
+          { this.canChangePassword() &&
+            <EditableInput
+              elementType="input"
+              type="text"
+              disabled={this.props.disabled}
+              required={true}
+              name="password"
+              label="Password"
+              ref="password"
+              error={this.props.error}
+              />
+          }
+        </fieldset>
+        { !this.context.settingUp &&
+          <fieldset>
+            <legend><h4>Roles</h4></legend>
+            <EditableInput
+              elementType="input"
+              type="checkbox"
+              disabled={this.isDisabled("system")}
+              name="system"
+              ref="system"
+              label="System Admin"
+              checked={this.isSelected("system")}
+              onChange={() => this.handleRoleChange("system")}
+              />
+            <table className="library-admin-roles">
+              <thead>
+                <tr>
+                  <th></th>
+                  <th>
+                    <EditableInput
+                       elementType="input"
+                       type="checkbox"
+                       disabled={this.isDisabled("manager-all")}
+                       name="manager-all"
+                       ref="manager-all"
+                       label="Library Manager"
+                       checked={this.isSelected("manager-all")}
+                       onChange={() => this.handleRoleChange("manager-all")}
+                    />
+                  </th>
+                  <th>
+                    <EditableInput
+                      elementType="input"
+                      type="checkbox"
+                      disabled={this.isDisabled("librarian-all")}
+                      name="librarian-all"
+                      ref="librarian-all"
+                      label="Librarian"
+                      checked={this.isSelected("librarian-all")}
+                      onChange={() => this.handleRoleChange("librarian-all")}
+                      />
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                { this.props.data && this.props.data.allLibraries && this.props.data.allLibraries.map(library =>
+                  <tr key={library.short_name}>
+                    <td>
+                      {library.name}
+                    </td>
+                    <td>
+                      <EditableInput
+                        elementType="input"
+                        type="checkbox"
+                        disabled={this.isDisabled("manager", library.short_name)}
+                        name={"manager-" + library.short_name}
+                        ref={"manager-" + library.short_name}
+                        label=""
+                        checked={this.isSelected("manager", library.short_name)}
+                        onChange={() => this.handleRoleChange("manager", library.short_name)}
+                        />
+                    </td>
+                    <td>
+                      <EditableInput
+                        elementType="input"
+                        type="checkbox"
+                        disabled={this.isDisabled("librarian", library.short_name)}
+                        name={"librarian-" + library.short_name}
+                        ref={"librarian-" + library.short_name}
+                        label=""
+                        checked={this.isSelected("librarian", library.short_name)}
+                        onChange={() => this.handleRoleChange("librarian", library.short_name)}
+                        />
+                    </td>
+                  </tr>
+                ) }
+              </tbody>
+            </table>
+          </fieldset>
+        }
+      </span>
+    );
   }
 
   render(): JSX.Element {
     return (
       <form ref="form" onSubmit={this.submit} className="edit-form">
-        <Collapsible title="Admin Information" collapsible={false} body={
-          <span>
-            <fieldset>
-              <legend className="visuallyHidden">Admin information</legend>
-              <EditableInput
-                elementType="input"
-                type="text"
-                disabled={this.props.disabled}
-                required={true}
-                readOnly={!!(this.props.item && this.props.item.email)}
-                name="email"
-                label="Email"
-                ref="email"
-                value={this.props.item && this.props.item.email}
-                error={this.props.error}
-                />
-              { this.canChangePassword() &&
-                <EditableInput
-                  elementType="input"
-                  type="text"
-                  disabled={this.props.disabled}
-                  required={true}
-                  name="password"
-                  label="Password"
-                  ref="password"
-                  error={this.props.error}
-                  />
-              }
-            </fieldset>
-            { !this.context.settingUp &&
-              <fieldset>
-                <legend><h4>Roles</h4></legend>
-                <EditableInput
-                  elementType="input"
-                  type="checkbox"
-                  disabled={this.isDisabled("system")}
-                  name="system"
-                  ref="system"
-                  label="System Admin"
-                  checked={this.isSelected("system")}
-                  onChange={() => this.handleRoleChange("system")}
-                  />
-                <table className="library-admin-roles">
-                  <thead>
-                    <tr>
-                      <th></th>
-                      <th>
-                        <EditableInput
-                           elementType="input"
-                           type="checkbox"
-                           disabled={this.isDisabled("manager-all")}
-                           name="manager-all"
-                           ref="manager-all"
-                           label="Library Manager"
-                           checked={this.isSelected("manager-all")}
-                           onChange={() => this.handleRoleChange("manager-all")}
-                        />
-                      </th>
-                      <th>
-                        <EditableInput
-                          elementType="input"
-                          type="checkbox"
-                          disabled={this.isDisabled("librarian-all")}
-                          name="librarian-all"
-                          ref="librarian-all"
-                          label="Librarian"
-                          checked={this.isSelected("librarian-all")}
-                          onChange={() => this.handleRoleChange("librarian-all")}
-                          />
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    { this.props.data && this.props.data.allLibraries && this.props.data.allLibraries.map(library =>
-                      <tr key={library.short_name}>
-                        <td>
-                          {library.name}
-                        </td>
-                        <td>
-                          <EditableInput
-                            elementType="input"
-                            type="checkbox"
-                            disabled={this.isDisabled("manager", library.short_name)}
-                            name={"manager-" + library.short_name}
-                            ref={"manager-" + library.short_name}
-                            label=""
-                            checked={this.isSelected("manager", library.short_name)}
-                            onChange={() => this.handleRoleChange("manager", library.short_name)}
-                            />
-                        </td>
-                        <td>
-                          <EditableInput
-                            elementType="input"
-                            type="checkbox"
-                            disabled={this.isDisabled("librarian", library.short_name)}
-                            name={"librarian-" + library.short_name}
-                            ref={"librarian-" + library.short_name}
-                            label=""
-                            checked={this.isSelected("librarian", library.short_name)}
-                            onChange={() => this.handleRoleChange("librarian", library.short_name)}
-                            />
-                        </td>
-                      </tr>
-                    ) }
-                  </tbody>
-                </table>
-              </fieldset>
-            }
-          </span>}
+        <Collapsible
+          title="Admin Information"
+          collapsible={false}
+          body={this.renderForm()}
         />
         <SaveButton
           disabled={this.props.disabled}

--- a/src/components/IndividualAdminEditForm.tsx
+++ b/src/components/IndividualAdminEditForm.tsx
@@ -46,119 +46,121 @@ export default class IndividualAdminEditForm extends React.Component<IndividualA
     this.handleData = this.handleData.bind(this);
     this.submit = this.submit.bind(this);
     this.renderForm = this.renderForm.bind(this);
+    this.renderRoleForm = this.renderRoleForm.bind(this);
   }
 
   renderForm() {
     return (
-      <span>
-        <fieldset>
-          <legend className="visuallyHidden">Admin information</legend>
+      <fieldset>
+        <legend className="visuallyHidden">Admin information</legend>
+        <EditableInput
+          elementType="input"
+          type="text"
+          disabled={this.props.disabled}
+          required={true}
+          readOnly={!!(this.props.item && this.props.item.email)}
+          name="email"
+          label="Email"
+          ref="email"
+          value={this.props.item && this.props.item.email}
+          error={this.props.error}
+          />
+        { this.canChangePassword() &&
           <EditableInput
             elementType="input"
             type="text"
             disabled={this.props.disabled}
-            required={true}
-            readOnly={!!(this.props.item && this.props.item.email)}
-            name="email"
-            label="Email"
-            ref="email"
-            value={this.props.item && this.props.item.email}
+            name="password"
+            label="Password"
+            ref="password"
             error={this.props.error}
             />
-          { this.canChangePassword() &&
-            <EditableInput
-              elementType="input"
-              type="text"
-              disabled={this.props.disabled}
-              name="password"
-              label="Password"
-              ref="password"
-              error={this.props.error}
-              />
-          }
-        </fieldset>
-        { !this.context.settingUp &&
-          <fieldset>
-            <legend><h4>Roles</h4></legend>
-            <EditableInput
-              elementType="input"
-              type="checkbox"
-              disabled={this.isDisabled("system")}
-              name="system"
-              ref="system"
-              label="System Admin"
-              checked={this.isSelected("system")}
-              onChange={() => this.handleRoleChange("system")}
-              />
-            <table className="library-admin-roles">
-              <thead>
-                <tr>
-                  <th></th>
-                  <th>
-                    <EditableInput
-                       elementType="input"
-                       type="checkbox"
-                       disabled={this.isDisabled("manager-all")}
-                       name="manager-all"
-                       ref="manager-all"
-                       label="Library Manager"
-                       checked={this.isSelected("manager-all")}
-                       onChange={() => this.handleRoleChange("manager-all")}
-                    />
-                  </th>
-                  <th>
-                    <EditableInput
-                      elementType="input"
-                      type="checkbox"
-                      disabled={this.isDisabled("librarian-all")}
-                      name="librarian-all"
-                      ref="librarian-all"
-                      label="Librarian"
-                      checked={this.isSelected("librarian-all")}
-                      onChange={() => this.handleRoleChange("librarian-all")}
-                      />
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                { this.props.data && this.props.data.allLibraries && this.props.data.allLibraries.map(library =>
-                  <tr key={library.short_name}>
-                    <td>
-                      {library.name}
-                    </td>
-                    <td>
-                      <EditableInput
-                        elementType="input"
-                        type="checkbox"
-                        disabled={this.isDisabled("manager", library.short_name)}
-                        name={"manager-" + library.short_name}
-                        ref={"manager-" + library.short_name}
-                        label=""
-                        checked={this.isSelected("manager", library.short_name)}
-                        onChange={() => this.handleRoleChange("manager", library.short_name)}
-                        />
-                    </td>
-                    <td>
-                      <EditableInput
-                        elementType="input"
-                        type="checkbox"
-                        disabled={this.isDisabled("librarian", library.short_name)}
-                        name={"librarian-" + library.short_name}
-                        ref={"librarian-" + library.short_name}
-                        label=""
-                        checked={this.isSelected("librarian", library.short_name)}
-                        onChange={() => this.handleRoleChange("librarian", library.short_name)}
-                        />
-                    </td>
-                  </tr>
-                ) }
-              </tbody>
-            </table>
-          </fieldset>
         }
-      </span>
+      </fieldset>
     );
   }
+
+  renderRoleForm() {
+    return (
+      <fieldset>
+        <legend className="visuallyHidden">Roles</legend>
+        <EditableInput
+          elementType="input"
+          type="checkbox"
+          disabled={this.isDisabled("system")}
+          name="system"
+          ref="system"
+          label="System Admin"
+          checked={this.isSelected("system")}
+          onChange={() => this.handleRoleChange("system")}
+          />
+        <table className="library-admin-roles">
+          <thead>
+            <tr>
+              <th></th>
+              <th>
+                <EditableInput
+                   elementType="input"
+                   type="checkbox"
+                   disabled={this.isDisabled("manager-all")}
+                   name="manager-all"
+                   ref="manager-all"
+                   label="Library Manager"
+                   checked={this.isSelected("manager-all")}
+                   onChange={() => this.handleRoleChange("manager-all")}
+                />
+              </th>
+              <th>
+                <EditableInput
+                  elementType="input"
+                  type="checkbox"
+                  disabled={this.isDisabled("librarian-all")}
+                  name="librarian-all"
+                  ref="librarian-all"
+                  label="Librarian"
+                  checked={this.isSelected("librarian-all")}
+                  onChange={() => this.handleRoleChange("librarian-all")}
+                  />
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            { this.props.data && this.props.data.allLibraries && this.props.data.allLibraries.map(library =>
+              <tr key={library.short_name}>
+                <td>
+                  {library.name}
+                </td>
+                <td>
+                  <EditableInput
+                    elementType="input"
+                    type="checkbox"
+                    disabled={this.isDisabled("manager", library.short_name)}
+                    name={"manager-" + library.short_name}
+                    ref={"manager-" + library.short_name}
+                    label=""
+                    checked={this.isSelected("manager", library.short_name)}
+                    onChange={() => this.handleRoleChange("manager", library.short_name)}
+                    />
+                </td>
+                <td>
+                  <EditableInput
+                    elementType="input"
+                    type="checkbox"
+                    disabled={this.isDisabled("librarian", library.short_name)}
+                    name={"librarian-" + library.short_name}
+                    ref={"librarian-" + library.short_name}
+                    label=""
+                    checked={this.isSelected("librarian", library.short_name)}
+                    onChange={() => this.handleRoleChange("librarian", library.short_name)}
+                    />
+                </td>
+              </tr>
+            ) }
+          </tbody>
+        </table>
+      </fieldset>
+    );
+  };
 
   render(): JSX.Element {
     return (
@@ -168,6 +170,13 @@ export default class IndividualAdminEditForm extends React.Component<IndividualA
           openByDefault={true}
           body={this.renderForm()}
         />
+        { !this.context.settingUp &&
+          <Collapsible
+            title="Admin Roles"
+            openByDefault={true}
+            body={this.renderRoleForm()}
+          />
+        }
         <SaveButton
           disabled={this.props.disabled}
           submit={this.submit}

--- a/src/components/IndividualAdminEditForm.tsx
+++ b/src/components/IndividualAdminEditForm.tsx
@@ -50,7 +50,7 @@ export default class IndividualAdminEditForm extends React.Component<IndividualA
     return (
       <form ref="form" onSubmit={this.submit} className="edit-form">
         <fieldset>
-          <legend className="visuallyHidden">Admin information</legend>
+          <legend><h4>Required admin information</h4></legend>
           <EditableInput
             elementType="input"
             type="text"

--- a/src/components/IndividualAdminEditForm.tsx
+++ b/src/components/IndividualAdminEditForm.tsx
@@ -165,6 +165,7 @@ export default class IndividualAdminEditForm extends React.Component<IndividualA
       <form ref="form" onSubmit={this.submit} className="edit-form">
         <Collapsible
           title="Admin Information"
+          openByDefault={true}
           body={this.renderForm()}
         />
         <SaveButton

--- a/src/components/IndividualAdminEditForm.tsx
+++ b/src/components/IndividualAdminEditForm.tsx
@@ -165,7 +165,6 @@ export default class IndividualAdminEditForm extends React.Component<IndividualA
       <form ref="form" onSubmit={this.submit} className="edit-form">
         <Collapsible
           title="Admin Information"
-          collapsible={false}
           body={this.renderForm()}
         />
         <SaveButton

--- a/src/components/LibraryEditForm.tsx
+++ b/src/components/LibraryEditForm.tsx
@@ -40,61 +40,71 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
           name="uuid"
           value={this.props.item && this.props.item.uuid}
           />
-        <Collapsible title="Required Fields" collapsible={false} body={
-          <fieldset>
-            <legend className="visuallyHidden">Required Fields</legend>
-            <EditableInput
-              elementType="input"
-              type="text"
-              disabled={this.props.disabled}
-              required={true}
-              name="name"
-              ref="name"
-              label="Name"
-              value={this.props.item && this.props.item.name}
-              description="The human-readable name of this library."
-              error={this.props.error}
-              />
-            <EditableInput
-              elementType="input"
-              type="text"
-              disabled={this.props.disabled}
-              required={true}
-              name="short_name"
-              ref="short_name"
-              label="Short name"
-              value={this.props.item && this.props.item.short_name}
-              description="A short name of this library, to use when identifying it in scripts or URLs, e.g. 'NYPL'."
-              error={this.props.error}
-              />
-            { requiredFields.map(setting =>
-              <ProtocolFormField
-                ref={setting.key}
-                setting={setting}
+        <Collapsible
+          title="Required Fields"
+          collapsible={false}
+          body={
+            <fieldset>
+              <legend className="visuallyHidden">Required Fields</legend>
+              <EditableInput
+                elementType="input"
+                type="text"
                 disabled={this.props.disabled}
-                value={this.props.item && this.props.item.settings && this.props.item.settings[setting.key]}
-                default={findDefault(setting)}
+                required={true}
+                name="name"
+                ref="name"
+                label="Name"
+                value={this.props.item && this.props.item.name}
+                description="The human-readable name of this library."
                 error={this.props.error}
                 />
-              )
-            }
-          </fieldset>}
+              <EditableInput
+                elementType="input"
+                type="text"
+                disabled={this.props.disabled}
+                required={true}
+                name="short_name"
+                ref="short_name"
+                label="Short name"
+                value={this.props.item && this.props.item.short_name}
+                description="A short name of this library, to use when identifying it in scripts or URLs, e.g. 'NYPL'."
+                error={this.props.error}
+                />
+              { requiredFields.map(setting =>
+                <ProtocolFormField
+                  key={setting.key}
+                  ref={setting.key}
+                  setting={setting}
+                  disabled={this.props.disabled}
+                  value={this.props.item && this.props.item.settings && this.props.item.settings[setting.key]}
+                  default={findDefault(setting)}
+                  error={this.props.error}
+                  />
+                )
+              }
+            </fieldset>
+          }
         />
-        <Collapsible title="Optional Fields" collapsible={true} body={
-          <fieldset>
-            <legend className="visuallyHidden">Additional Fields</legend>
-            { nonRequiredFields.map(setting =>
-              <ProtocolFormField
-                ref={setting.key}
-                setting={setting}
-                disabled={this.props.disabled}
-                value={this.props.item && this.props.item.settings && this.props.item.settings[setting.key]}
-                default={findDefault(setting)}
-                error={this.props.error}
-                />
-              )
-            }
-          </fieldset>}
+        <Collapsible
+          title="Optional Fields"
+          collapsible={true}
+          body={
+            <fieldset>
+              <legend className="visuallyHidden">Additional Fields</legend>
+              { nonRequiredFields.map(setting =>
+                <ProtocolFormField
+                  key={setting.key}
+                  ref={setting.key}
+                  setting={setting}
+                  disabled={this.props.disabled}
+                  value={this.props.item && this.props.item.settings && this.props.item.settings[setting.key]}
+                  default={findDefault(setting)}
+                  error={this.props.error}
+                  />
+                )
+              }
+            </fieldset>
+          }
         />
 
         <SaveButton

--- a/src/components/LibraryEditForm.tsx
+++ b/src/components/LibraryEditForm.tsx
@@ -42,7 +42,6 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
           />
         <Collapsible
           title="Required Fields"
-          collapsible={false}
           body={
             <fieldset>
               <legend className="visuallyHidden">Required Fields</legend>
@@ -87,7 +86,6 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
         />
         <Collapsible
           title="Optional Fields"
-          collapsible={true}
           body={
             <fieldset>
               <legend className="visuallyHidden">Additional Fields</legend>

--- a/src/components/LibraryEditForm.tsx
+++ b/src/components/LibraryEditForm.tsx
@@ -4,6 +4,7 @@ import ProtocolFormField from "./ProtocolFormField";
 import SaveButton from "./SaveButton";
 import { handleSubmit, findDefault, clearForm } from "./sharedFunctions";
 import { LibrariesData, LibraryData } from "../interfaces";
+import Collapsible from "./Collapsible";
 import { FetchErrorData } from "opds-web-client/lib/interfaces";
 
 export interface LibraryEditFormProps {
@@ -39,58 +40,62 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
           name="uuid"
           value={this.props.item && this.props.item.uuid}
           />
-        <fieldset>
-          <legend><h4>Required Fields</h4></legend>
-          <EditableInput
-            elementType="input"
-            type="text"
-            disabled={this.props.disabled}
-            required={true}
-            name="name"
-            ref="name"
-            label="Name"
-            value={this.props.item && this.props.item.name}
-            description="The human-readable name of this library."
-            error={this.props.error}
-            />
-          <EditableInput
-            elementType="input"
-            type="text"
-            disabled={this.props.disabled}
-            required={true}
-            name="short_name"
-            ref="short_name"
-            label="Short name"
-            value={this.props.item && this.props.item.short_name}
-            description="A short name of this library, to use when identifying it in scripts or URLs, e.g. 'NYPL'."
-            error={this.props.error}
-            />
-          { requiredFields.map(setting =>
-            <ProtocolFormField
-              ref={setting.key}
-              setting={setting}
+        <Collapsible title="Required Fields" collapsible={false} body={
+          <fieldset>
+            <legend className="visuallyHidden">Required Fields</legend>
+            <EditableInput
+              elementType="input"
+              type="text"
               disabled={this.props.disabled}
-              value={this.props.item && this.props.item.settings && this.props.item.settings[setting.key]}
-              default={findDefault(setting)}
+              required={true}
+              name="name"
+              ref="name"
+              label="Name"
+              value={this.props.item && this.props.item.name}
+              description="The human-readable name of this library."
               error={this.props.error}
               />
-            )
-          }
-        </fieldset>
-        <fieldset>
-          <legend><h4>Additional Fields</h4></legend>
-          { nonRequiredFields.map(setting =>
-            <ProtocolFormField
-              ref={setting.key}
-              setting={setting}
+            <EditableInput
+              elementType="input"
+              type="text"
               disabled={this.props.disabled}
-              value={this.props.item && this.props.item.settings && this.props.item.settings[setting.key]}
-              default={findDefault(setting)}
+              required={true}
+              name="short_name"
+              ref="short_name"
+              label="Short name"
+              value={this.props.item && this.props.item.short_name}
+              description="A short name of this library, to use when identifying it in scripts or URLs, e.g. 'NYPL'."
               error={this.props.error}
               />
-            )
-          }
-        </fieldset>
+            { requiredFields.map(setting =>
+              <ProtocolFormField
+                ref={setting.key}
+                setting={setting}
+                disabled={this.props.disabled}
+                value={this.props.item && this.props.item.settings && this.props.item.settings[setting.key]}
+                default={findDefault(setting)}
+                error={this.props.error}
+                />
+              )
+            }
+          </fieldset>}
+        />
+        <Collapsible title="Optional Fields" collapsible={true} body={
+          <fieldset>
+            <legend className="visuallyHidden">Additional Fields</legend>
+            { nonRequiredFields.map(setting =>
+              <ProtocolFormField
+                ref={setting.key}
+                setting={setting}
+                disabled={this.props.disabled}
+                value={this.props.item && this.props.item.settings && this.props.item.settings[setting.key]}
+                default={findDefault(setting)}
+                error={this.props.error}
+                />
+              )
+            }
+          </fieldset>}
+        />
 
         <SaveButton
           disabled={this.props.disabled}

--- a/src/components/LibraryEditForm.tsx
+++ b/src/components/LibraryEditForm.tsx
@@ -26,11 +26,11 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
   }
 
   render(): JSX.Element {
-    let f = [];
+    let requiredFields = [];
+    let nonRequiredFields = [];
     if (this.props.data && this.props.data.settings) {
-      const notfiltered = this.props.data.settings.filter(setting => !setting.required);
-      const filtered = this.props.data.settings.filter(setting => setting.required);
-      f = filtered.concat(notfiltered);
+      nonRequiredFields = this.props.data.settings.filter(setting => !setting.required);
+      requiredFields = this.props.data.settings.filter(setting => setting.required);
     }
     return (
       <form ref="form" onSubmit={this.submit} className="edit-form">
@@ -39,41 +39,58 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
           name="uuid"
           value={this.props.item && this.props.item.uuid}
           />
-        <EditableInput
-          elementType="input"
-          type="text"
-          disabled={this.props.disabled}
-          required={true}
-          name="name"
-          ref="name"
-          label="Name"
-          value={this.props.item && this.props.item.name}
-          description="The human-readable name of this library."
-          error={this.props.error}
-          />
-        <EditableInput
-          elementType="input"
-          type="text"
-          disabled={this.props.disabled}
-          required={true}
-          name="short_name"
-          ref="short_name"
-          label="Short name"
-          value={this.props.item && this.props.item.short_name}
-          description="A short name of this library, to use when identifying it in scripts or URLs, e.g. 'NYPL'."
-          error={this.props.error}
-          />
-        { this.props.data && this.props.data.settings && f.map(setting =>
-          <ProtocolFormField
-            ref={setting.key}
-            setting={setting}
+        <fieldset>
+          <legend><h4>Required Fields</h4></legend>
+          <EditableInput
+            elementType="input"
+            type="text"
             disabled={this.props.disabled}
-            value={this.props.item && this.props.item.settings && this.props.item.settings[setting.key]}
-            default={findDefault(setting)}
+            required={true}
+            name="name"
+            ref="name"
+            label="Name"
+            value={this.props.item && this.props.item.name}
+            description="The human-readable name of this library."
             error={this.props.error}
             />
-          )
-        }
+          <EditableInput
+            elementType="input"
+            type="text"
+            disabled={this.props.disabled}
+            required={true}
+            name="short_name"
+            ref="short_name"
+            label="Short name"
+            value={this.props.item && this.props.item.short_name}
+            description="A short name of this library, to use when identifying it in scripts or URLs, e.g. 'NYPL'."
+            error={this.props.error}
+            />
+          { requiredFields.map(setting =>
+            <ProtocolFormField
+              ref={setting.key}
+              setting={setting}
+              disabled={this.props.disabled}
+              value={this.props.item && this.props.item.settings && this.props.item.settings[setting.key]}
+              default={findDefault(setting)}
+              error={this.props.error}
+              />
+            )
+          }
+        </fieldset>
+        <fieldset>
+          <legend><h4>Additional Fields</h4></legend>
+          { nonRequiredFields.map(setting =>
+            <ProtocolFormField
+              ref={setting.key}
+              setting={setting}
+              disabled={this.props.disabled}
+              value={this.props.item && this.props.item.settings && this.props.item.settings[setting.key]}
+              default={findDefault(setting)}
+              error={this.props.error}
+              />
+            )
+          }
+        </fieldset>
 
         <SaveButton
           disabled={this.props.disabled}

--- a/src/components/LibraryEditForm.tsx
+++ b/src/components/LibraryEditForm.tsx
@@ -42,6 +42,7 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
           />
         <Collapsible
           title="Required Fields"
+          openByDefault={true}
           body={
             <fieldset>
               <legend className="visuallyHidden">Required Fields</legend>

--- a/src/components/ServiceEditForm.tsx
+++ b/src/components/ServiceEditForm.tsx
@@ -313,8 +313,8 @@ export default class ServiceEditForm<T extends ServicesData> extends React.Compo
 
   protocolSettings() {
     if (this.state.protocol && this.props.data && this.props.data.protocols) {
-      console.log(this.props.data.protocols);
       for (const protocol of this.props.data.protocols) {
+        console.log(protocol);
         if (protocol.name === this.state.protocol) {
           let p = [];
           if (this.state.parentId) {

--- a/src/components/ServiceEditForm.tsx
+++ b/src/components/ServiceEditForm.tsx
@@ -67,7 +67,7 @@ export default class ServiceEditForm<T extends ServicesData> extends React.Compo
             value={String(this.props.item.id)}
             />
         }
-        <Collapsible title="Required Fields" elementType="a" collapsible={false} body={
+        <Collapsible title="Required Fields" collapsible={false} body={
           <fieldset>
             <legend className="visuallyHidden"><h4>Required Fields</h4></legend>
             <EditableInput
@@ -139,7 +139,7 @@ export default class ServiceEditForm<T extends ServicesData> extends React.Compo
           </fieldset>}
         />
         { (nonRequiredFields.length > 0) && (
-          <Collapsible title="Optional Fields" elementType="a" collapsible={true} body={
+          <Collapsible title="Optional Fields" collapsible={true} body={
             <fieldset>
               <legend className="visuallyHidden">Additional Fields</legend>
               { nonRequiredFields.map(setting =>
@@ -157,91 +157,93 @@ export default class ServiceEditForm<T extends ServicesData> extends React.Compo
           />)
         }
         { (!this.sitewide() || this.protocolLibrarySettings().length > 0) &&
-          <fieldset>
-            <legend>Libraries</legend>
-            <div className="form-group">
-              { this.state.libraries.map(library =>
-                  <div key={library.short_name}>
-                    <WithRemoveButton
-                      disabled={this.props.disabled}
-                      onRemove={() => this.removeLibrary(library)}
-                      ref={library.short_name}
-                      >
-                      { this.props.data && this.props.data.protocols && this.protocolLibrarySettings() && this.protocolLibrarySettings().length > 0 &&
-                        <WithEditButton
-                          disabled={this.props.disabled}
-                          onEdit={() => this.expandLibrary(library)}
-                          >
-                          {this.getLibrary(library.short_name) && this.getLibrary(library.short_name).name}
-                        </WithEditButton>
-                      }
-                      { !(this.props.data && this.props.data.protocols && this.protocolLibrarySettings() && this.protocolLibrarySettings().length > 0) &&
-                        this.getLibrary(library.short_name) && this.getLibrary(library.short_name).name
-                      }
-                    </WithRemoveButton>
-                    { this.isExpanded(library) &&
-                      <div className="edit-library-settings">
-                        { this.props.data && this.props.data.protocols && this.protocolLibrarySettings() && this.protocolLibrarySettings().map(setting =>
-                          <ProtocolFormField
-                            key={setting.key}
-                            setting={setting}
+          <Collapsible title="Libraries" collapsible={true} body={
+            <fieldset>
+              <legend className="visuallyHidden">Libraries</legend>
+              <div className="form-group">
+                { this.state.libraries.map(library =>
+                    <div key={library.short_name}>
+                      <WithRemoveButton
+                        disabled={this.props.disabled}
+                        onRemove={() => this.removeLibrary(library)}
+                        ref={library.short_name}
+                        >
+                        { this.props.data && this.props.data.protocols && this.protocolLibrarySettings() && this.protocolLibrarySettings().length > 0 &&
+                          <WithEditButton
                             disabled={this.props.disabled}
-                            value={library[setting.key]}
-                            ref={library.short_name + "_" + setting.key}
-                            />
+                            onEdit={() => this.expandLibrary(library)}
+                            >
+                            {this.getLibrary(library.short_name) && this.getLibrary(library.short_name).name}
+                          </WithEditButton>
+                        }
+                        { !(this.props.data && this.props.data.protocols && this.protocolLibrarySettings() && this.protocolLibrarySettings().length > 0) &&
+                          this.getLibrary(library.short_name) && this.getLibrary(library.short_name).name
+                        }
+                      </WithRemoveButton>
+                      { this.isExpanded(library) &&
+                        <div className="edit-library-settings">
+                          { this.props.data && this.props.data.protocols && this.protocolLibrarySettings() && this.protocolLibrarySettings().map(setting =>
+                            <ProtocolFormField
+                              key={setting.key}
+                              setting={setting}
+                              disabled={this.props.disabled}
+                              value={library[setting.key]}
+                              ref={library.short_name + "_" + setting.key}
+                              />
+                            )
+                          }
+                          <button
+                            type="button"
+                            className="btn btn-default edit-library"
+                            disabled={this.props.disabled}
+                            onClick={() => this.editLibrary(library)}
+                            >Save</button>
+                        </div>
+                      }
+                    </div>
+                  )
+                }
+              </div>
+              { (this.availableLibraries().length > 0) &&
+                  <div className="form-group">
+                    <EditableInput
+                      elementType="select"
+                      disabled={this.props.disabled}
+                      name="add-library"
+                      label="Add Library"
+                      ref="addLibrary"
+                      value={this.state.selectedLibrary}
+                      onChange={this.selectLibrary}
+                      >
+                      <option value="none">Select a library</option>
+                      { this.availableLibraries().map(library =>
+                          <option key={library.short_name} value={library.short_name}>{library.name}</option>
+                        )
+                      }
+                    </EditableInput>
+                    { this.state.selectedLibrary &&
+                      <div>
+                        { this.props.data && this.props.data.protocols && this.protocolLibrarySettings() && this.protocolLibrarySettings().map(setting =>
+                            <ProtocolFormField
+                              key={setting.key}
+                              setting={setting}
+                              disabled={this.props.disabled}
+                              ref={setting.key}
+                              />
                           )
                         }
                         <button
                           type="button"
-                          className="btn btn-default edit-library"
+                          className="btn btn-default add-library"
                           disabled={this.props.disabled}
-                          onClick={() => this.editLibrary(library)}
-                          >Save</button>
+                          onClick={this.addLibrary}
+                          >Add Library</button>
                       </div>
                     }
                   </div>
-                )
               }
-            </div>
-            { (this.availableLibraries().length > 0) &&
-                <div className="form-group">
-                  <EditableInput
-                    elementType="select"
-                    disabled={this.props.disabled}
-                    name="add-library"
-                    label="Add Library"
-                    ref="addLibrary"
-                    value={this.state.selectedLibrary}
-                    onChange={this.selectLibrary}
-                    >
-                    <option value="none">Select a library</option>
-                    { this.availableLibraries().map(library =>
-                        <option key={library.short_name} value={library.short_name}>{library.name}</option>
-                      )
-                    }
-                  </EditableInput>
-                  { this.state.selectedLibrary &&
-                    <div>
-                      { this.props.data && this.props.data.protocols && this.protocolLibrarySettings() && this.protocolLibrarySettings().map(setting =>
-                          <ProtocolFormField
-                            key={setting.key}
-                            setting={setting}
-                            disabled={this.props.disabled}
-                            ref={setting.key}
-                            />
-                        )
-                      }
-                      <button
-                        type="button"
-                        className="btn btn-default add-library"
-                        disabled={this.props.disabled}
-                        onClick={this.addLibrary}
-                        >Add Library</button>
-                    </div>
-                  }
-                </div>
-            }
-          </fieldset>
+            </fieldset>}
+          />
         }
         <SaveButton
           disabled={this.props.disabled}

--- a/src/components/ServiceEditForm.tsx
+++ b/src/components/ServiceEditForm.tsx
@@ -112,7 +112,6 @@ export default class ServiceEditForm<T extends ServicesData> extends React.Compo
               <label class="control-label">Instructions</label>
               <Collapsible
                 title={this.protocolDescription()}
-                collapsible={true}
                 type="instruction"
                 text={this.protocolInstructions()}
               />
@@ -255,20 +254,18 @@ export default class ServiceEditForm<T extends ServicesData> extends React.Compo
         }
         <Collapsible
           title="Required Fields"
-          collapsible={false}
+          openByDefault={true}
           body={this.renderRequiredFields(requiredFields)}
         />
         { (nonRequiredFields.length > 0) && (
           <Collapsible
             title="Optional Fields"
-            collapsible={true}
             body={this.renderOptionalFields(nonRequiredFields)}
           />)
         }
         { (!this.sitewide() || this.protocolLibrarySettings().length > 0) &&
           <Collapsible
             title="Libraries"
-            collapsible={true}
             body={this.renderLibrariesForm()}
           />
         }

--- a/src/components/ServiceEditForm.tsx
+++ b/src/components/ServiceEditForm.tsx
@@ -107,16 +107,6 @@ export default class ServiceEditForm<T extends ServicesData> extends React.Compo
             }
           </EditableInput>
         }
-        { this.props.data && this.protocolInstructions() &&
-            <div class="form-group">
-              <label class="control-label">Instructions</label>
-              <Collapsible
-                title={this.protocolDescription()}
-                type="instruction"
-                text={this.protocolInstructions()}
-              />
-            </div>
-        }
         { requiredFields.map(setting =>
             <ProtocolFormField
               key={setting.key}
@@ -243,6 +233,8 @@ export default class ServiceEditForm<T extends ServicesData> extends React.Compo
 
   render(): JSX.Element {
     const { requiredFields, nonRequiredFields } = this.protocolSettings();
+    const showLibrariesForm = (!this.sitewide() || this.protocolLibrarySettings().length > 0);
+    const hasNonRequiredFields = nonRequiredFields.length > 0;
     return (
       <form ref="form" onSubmit={this.submit} className="edit-form">
         { this.props.item && this.props.item.id &&
@@ -252,18 +244,29 @@ export default class ServiceEditForm<T extends ServicesData> extends React.Compo
             value={String(this.props.item.id)}
             />
         }
+        { this.props.data && this.protocolInstructions() &&
+            <div class="form-group">
+              <label class="control-label">Instructions</label>
+              <Collapsible
+                title={this.protocolDescription()}
+                type="instruction"
+                text={this.protocolInstructions()}
+              />
+            </div>
+        }
         <Collapsible
           title="Required Fields"
           openByDefault={true}
+          collapsible={hasNonRequiredFields || showLibrariesForm}
           body={this.renderRequiredFields(requiredFields)}
         />
-        { (nonRequiredFields.length > 0) && (
+        { hasNonRequiredFields && (
           <Collapsible
             title="Optional Fields"
             body={this.renderOptionalFields(nonRequiredFields)}
           />)
         }
-        { (!this.sitewide() || this.protocolLibrarySettings().length > 0) &&
+        { (showLibrariesForm) &&
           <Collapsible
             title="Libraries"
             body={this.renderLibrariesForm()}

--- a/src/components/__tests__/BookCoverEditor-test.tsx
+++ b/src/components/__tests__/BookCoverEditor-test.tsx
@@ -164,12 +164,14 @@ describe("BookCoverEditor", () => {
     });
 
     it("shows save button", () => {
-      let save = wrapper.find("button");
-      expect(save.length).to.equal(1);
+      let buttons = wrapper.find("button");
+      // Counting the two buttons that are coming from the Collapsible component:
+      expect(buttons.length).to.equal(3);
+      let save = buttons.at(2);
       expect(save.props().disabled).to.be.ok;
 
       wrapper.setProps({ preview: "image data" });
-      save = wrapper.find("button");
+      save = wrapper.find("button").at(2);
       expect(save.props().disabled).not.to.be.ok;
     });
   });
@@ -273,7 +275,7 @@ describe("BookCoverEditor", () => {
       let rightsExplanation = editableInputByName("rights_explanation");
       rightsExplanation.get(0).setState({ value: "explanation" });
 
-      let saveButton = wrapper.find("button");
+      let saveButton = wrapper.find("button").at(2);
       saveButton.simulate("click");
 
       expect(editCover.callCount).to.equal(1);

--- a/src/components/__tests__/BookCoverEditor-test.tsx
+++ b/src/components/__tests__/BookCoverEditor-test.tsx
@@ -46,7 +46,7 @@ describe("BookCoverEditor", () => {
 
   describe("rendering", () => {
     beforeEach(() => {
-      wrapper = shallow(
+      wrapper = mount(
         <BookCoverEditor
           bookAdminUrl="/admin/book"
           rightsStatuses={rightsStatuses}
@@ -94,7 +94,7 @@ describe("BookCoverEditor", () => {
       let input = editableInputByName("title_position");
       expect(input.props().elementType).to.equal("select");
       expect(input.props().label).to.equal("Title and Author Position");
-      let options = input.children();
+      let options = input.find("option");
       expect(options.length).to.equal(4);
       expect(options.at(0).props().value).to.equal("none");
       expect(options.at(1).props().value).to.equal("top");
@@ -129,7 +129,7 @@ describe("BookCoverEditor", () => {
       expect(rightsStatusInput.props().elementType).to.equal("select");
       expect(rightsStatusInput.props().label).to.equal("License");
 
-      let children = rightsStatusInput.children();
+      let children = rightsStatusInput.find("option");
       expect(children.length).to.equal(3);
       expect(children.at(0).props().value).to.equal("http://creativecommons.org/licenses/by/4.0/");
       expect(children.at(0).text()).to.equal("Creative Commons Attribution (CC BY)");

--- a/src/components/__tests__/BookEditForm-test.tsx
+++ b/src/components/__tests__/BookEditForm-test.tsx
@@ -62,7 +62,7 @@ describe("BookEditForm", () => {
 
   describe("rendering", () => {
     beforeEach(() => {
-      wrapper = shallow(
+      wrapper = mount(
         <BookEditForm
           {...bookData}
           roles={roles}
@@ -342,7 +342,7 @@ describe("BookEditForm", () => {
   });
 
   it("disables all inputs", () => {
-    wrapper = shallow(
+    wrapper = mount(
       <BookEditForm
         {...bookData}
         roles={roles}

--- a/src/components/__tests__/Collapsible-test.tsx
+++ b/src/components/__tests__/Collapsible-test.tsx
@@ -8,87 +8,154 @@ import Collapsible from "../Collapsible";
 
 describe("Collapsible", () => {
 
-  let wrapper;
-  beforeEach(() => {
-    wrapper = mount(
-      <Collapsible title="TITLE!" text="INSTRUCTIONS!">
-      </Collapsible>
-    );
+  describe("Static panel", () => {
+    let wrapper;
+
+    beforeEach(() => {
+      wrapper = mount(
+        <Collapsible
+          title="TITLE!"
+          body={<div>Form here <label>Test label</label><input type="text" /></div>}
+          collapsible={false}
+        />
+      );
+    });
+
+    describe("rendering", () => {
+      it("renders a panel component", () => {
+        let panel = wrapper.find("Panel");
+        expect(panel.length).to.equal(1);
+        expect(panel.hasClass("collapsible")).to.be.true;
+      });
+
+      it("is opened by default", () => {
+        expect(wrapper.state().open).to.be.false;
+        expect(wrapper.props().collapsible).to.be.false;
+
+        let panel = wrapper.find("Panel");
+        expect(panel.props().expanded).to.be.false;
+        expect(panel.props().collapsible).to.be.false;
+      });
+
+      it("should render an HTML node", () => {
+        let section = wrapper.find("section");
+
+        expect(section.props().dangerouslySetInnerHTML).to.equal(undefined);
+        expect(section.html()).to.equal(
+          "<section><div><!-- react-text: 9 -->Form here <!-- /react-text --><label>" +
+          "Test label</label><input type=\"text\"></div></section>"
+        );
+      });
+    });
+
+    describe("behavior", () => {
+      it("should not expand or collapse when clicked", () => {
+        let panel = wrapper.find("Panel");
+        expect(wrapper.state().open).to.be.false;
+        expect(panel.props().expanded).to.be.false;
+
+        let title = wrapper.find(".panel-title");
+        title.simulate("click");
+
+        expect(wrapper.state().open).to.be.false;
+        expect(panel.props().expanded).to.be.false;
+      });
+
+      it("should not render an icon", () => {
+        let icon = wrapper.find(".glyphicon");
+        expect(icon.length).to.equal(0);
+      });
+    });
   });
 
-  describe("rendering", () => {
-
-    it("renders a panel component", () => {
-      let panel = wrapper.find("Panel");
-      expect(panel.length).to.equal(1);
-      expect(panel.hasClass("collapsible")).to.be.true;
+  describe("Collapsible panel", () => {
+    let wrapper;
+    beforeEach(() => {
+      wrapper = mount(
+        <Collapsible
+          title="TITLE!"
+          text="INSTRUCTIONS!"
+          type="instruction"
+          collapsible={true}
+        />
+      );
     });
 
-    it("is collapsed by default", () => {
-      expect(wrapper.state().open).to.be.false;
+    describe("rendering", () => {
+      it("renders a panel component", () => {
+        let panel = wrapper.find("Panel");
+        expect(panel.length).to.equal(1);
+        expect(panel.hasClass("collapsible")).to.be.true;
+      });
 
-      let panel = wrapper.find("Panel");
-      expect(panel.props().expanded).to.be.false;
-      expect(panel.props().defaultExpanded).to.be.false;
+      it("is collapsed by default", () => {
+        expect(wrapper.state().open).to.be.false;
+
+        let panel = wrapper.find("Panel");
+        expect(panel.props().expanded).to.be.false;
+        expect(panel.props().defaultExpanded).to.be.false;
+      });
+
+      it("receives the correct title and body props", () => {
+        let section = wrapper.find("section");
+
+        expect(wrapper.props().title).to.equal("TITLE!");
+        expect(wrapper.props().text).to.equal("INSTRUCTIONS!");
+        expect(section.props().dangerouslySetInnerHTML["__html"]).to.equal("INSTRUCTIONS!");
+      });
+
+      it("renders a heading with a title and a toggle button", () => {
+        let heading = wrapper.find(".panel-heading");
+        expect(heading.length).to.equal(1);
+        expect(heading.text()).to.equal("TITLE!");
+
+        let button = heading.find("button");
+        expect(button.length).to.equal(1);
+        let icon = button.find(".glyphicon");
+        expect(icon.length).to.equal(1);
+      });
+
+      it("renders a collapsible body section with the correct content", () => {
+        let body = wrapper.find(".panel-body");
+        expect(body.length).to.equal(1);
+        expect(body.text()).to.equal("INSTRUCTIONS!");
+      });
+
     });
 
-    it("receives the correct title and body props", () => {
-      expect(wrapper.props().title).to.equal("TITLE!");
-      expect(wrapper.props().body).to.equal("INSTRUCTIONS!");
+    describe("behavior", () => {
+
+      it("expands and collapses when clicked", () => {
+        let panel = wrapper.find("Panel");
+        expect(wrapper.state().open).to.be.false;
+        expect(panel.props().expanded).to.be.false;
+
+        let title = wrapper.find(".panel-title");
+        title.simulate("click");
+
+        expect(wrapper.state().open).to.be.true;
+        expect(panel.props().expanded).to.be.true;
+
+        title.simulate("click");
+
+        expect(wrapper.state().open).to.be.false;
+        expect(panel.props().expanded).to.be.false;
+      });
+
+      it("flips the toggle icon when clicked", () => {
+        let icon = wrapper.find(".glyphicon");
+        expect(icon.props().glyph).to.equal("plus");
+
+        let title = wrapper.find(".panel-title");
+        title.simulate("click");
+
+        expect(icon.props().glyph).to.equal("minus");
+
+        title.simulate("click");
+
+        expect(icon.props().glyph).to.equal("plus");
+      });
     });
-
-    it("renders a heading with a title and a toggle button", () => {
-      let heading = wrapper.find(".panel-heading");
-      expect(heading.length).to.equal(1);
-      expect(heading.text()).to.equal("TITLE!");
-
-      let button = heading.find("button");
-      expect(button.length).to.equal(1);
-      let icon = button.find(".glyphicon");
-      expect(icon.length).to.equal(1);
-    });
-
-    it("renders a collapsible body section with the correct content", () => {
-      let body = wrapper.find(".panel-body");
-      expect(body.length).to.equal(1);
-      expect(body.text()).to.equal("INSTRUCTIONS!");
-    });
-
-  });
-
-  describe("behavior", () => {
-
-    it("expands and collapses when clicked", () => {
-      let panel = wrapper.find("Panel");
-      expect(wrapper.state().open).to.be.false;
-      expect(panel.props().expanded).to.be.false;
-
-      let title = wrapper.find(".panel-title");
-      title.simulate("click");
-
-      expect(wrapper.state().open).to.be.true;
-      expect(panel.props().expanded).to.be.true;
-
-      title.simulate("click");
-
-      expect(wrapper.state().open).to.be.false;
-      expect(panel.props().expanded).to.be.false;
-    });
-
-    it("flips the toggle icon when clicked", () => {
-      let icon = wrapper.find(".glyphicon");
-      expect(icon.props().glyph).to.equal("plus");
-
-      let title = wrapper.find(".panel-title");
-      title.simulate("click");
-
-      expect(icon.props().glyph).to.equal("minus");
-
-      title.simulate("click");
-
-      expect(icon.props().glyph).to.equal("plus");
-    });
-
   });
 
 });

--- a/src/components/__tests__/Collapsible-test.tsx
+++ b/src/components/__tests__/Collapsible-test.tsx
@@ -11,7 +11,7 @@ describe("Collapsible", () => {
   let wrapper;
   beforeEach(() => {
     wrapper = mount(
-      <Collapsible title="TITLE!" body="INSTRUCTIONS!">
+      <Collapsible title="TITLE!" text="INSTRUCTIONS!">
       </Collapsible>
     );
   });

--- a/src/components/__tests__/Collapsible-test.tsx
+++ b/src/components/__tests__/Collapsible-test.tsx
@@ -7,68 +7,7 @@ import { shallow, mount } from "enzyme";
 import Collapsible from "../Collapsible";
 
 describe("Collapsible", () => {
-
-  describe("Static panel", () => {
-    let wrapper;
-
-    beforeEach(() => {
-      wrapper = mount(
-        <Collapsible
-          title="TITLE!"
-          body={<div>Form here <label>Test label</label><input type="text" /></div>}
-          collapsible={false}
-        />
-      );
-    });
-
-    describe("rendering", () => {
-      it("renders a panel component", () => {
-        let panel = wrapper.find("Panel");
-        expect(panel.length).to.equal(1);
-        expect(panel.hasClass("collapsible")).to.be.true;
-      });
-
-      it("is opened by default", () => {
-        expect(wrapper.state().open).to.be.false;
-        expect(wrapper.props().collapsible).to.be.false;
-
-        let panel = wrapper.find("Panel");
-        expect(panel.props().expanded).to.be.false;
-        expect(panel.props().collapsible).to.be.false;
-      });
-
-      it("should render an HTML node", () => {
-        let section = wrapper.find("section");
-
-        expect(section.props().dangerouslySetInnerHTML).to.equal(undefined);
-        expect(section.html()).to.equal(
-          "<section><div><!-- react-text: 9 -->Form here <!-- /react-text --><label>" +
-          "Test label</label><input type=\"text\"></div></section>"
-        );
-      });
-    });
-
-    describe("behavior", () => {
-      it("should not expand or collapse when clicked", () => {
-        let panel = wrapper.find("Panel");
-        expect(wrapper.state().open).to.be.false;
-        expect(panel.props().expanded).to.be.false;
-
-        let title = wrapper.find(".panel-title");
-        title.simulate("click");
-
-        expect(wrapper.state().open).to.be.false;
-        expect(panel.props().expanded).to.be.false;
-      });
-
-      it("should not render an icon", () => {
-        let icon = wrapper.find(".glyphicon");
-        expect(icon.length).to.equal(0);
-      });
-    });
-  });
-
-  describe("Collapsible panel", () => {
+  describe("Collapsible text", () => {
     let wrapper;
     beforeEach(() => {
       wrapper = mount(
@@ -76,7 +15,6 @@ describe("Collapsible", () => {
           title="TITLE!"
           text="INSTRUCTIONS!"
           type="instruction"
-          collapsible={true}
         />
       );
     });
@@ -94,6 +32,21 @@ describe("Collapsible", () => {
         let panel = wrapper.find("Panel");
         expect(panel.props().expanded).to.be.false;
         expect(panel.props().defaultExpanded).to.be.false;
+      });
+
+      it("should be opened by default with openByDefault prop passed", () => {
+        wrapper = mount(
+          <Collapsible
+            title="TITLE!"
+            text="INSTRUCTIONS!"
+            type="instruction"
+            openByDefault={true}
+          />
+        );
+        expect(wrapper.state().open).to.be.true;
+
+        let panel = wrapper.find("Panel");
+        expect(panel.props().expanded).to.be.true;
       });
 
       it("receives the correct title and body props", () => {
@@ -120,11 +73,9 @@ describe("Collapsible", () => {
         expect(body.length).to.equal(1);
         expect(body.text()).to.equal("INSTRUCTIONS!");
       });
-
     });
 
     describe("behavior", () => {
-
       it("expands and collapses when clicked", () => {
         let panel = wrapper.find("Panel");
         expect(wrapper.state().open).to.be.false;
@@ -158,4 +109,26 @@ describe("Collapsible", () => {
     });
   });
 
+  describe("Collapsible HTML body", () => {
+    let wrapper;
+    beforeEach(() => {
+      wrapper = mount(
+        <Collapsible
+          title="TITLE!"
+          body={<div>Form here <label>Test label</label><input type="text" /></div>}
+        />
+      );
+    });
+
+    it("should render the HTML body", () => {
+      let section = wrapper.find("section");
+
+      expect(wrapper.props().title).to.equal("TITLE!");
+      expect(wrapper.props().text).to.equal(undefined);
+      expect(section.props().dangerouslySetInnerHTML).to.equal(undefined);
+      expect(section.html()).to.equal(
+        "<section><div><!-- react-text: 12 -->Form here <!-- /react-text --><label>Test label</label><input type=\"text\"></div></section>"
+      );
+    });
+  });
 });

--- a/src/components/__tests__/CustomListEditor-test.tsx
+++ b/src/components/__tests__/CustomListEditor-test.tsx
@@ -77,7 +77,7 @@ describe("CustomListEditor", () => {
       }
     });
 
-    wrapper = shallow(
+    wrapper = mount(
       <CustomListEditor
         library="library"
         list={listData}

--- a/src/components/__tests__/IndividualAdminEditForm-test.tsx
+++ b/src/components/__tests__/IndividualAdminEditForm-test.tsx
@@ -43,7 +43,7 @@ describe("IndividualAdminEditForm", () => {
   describe("rendering", () => {
     beforeEach(() => {
       save = stub();
-      wrapper = shallow(
+      wrapper = mount(
         <IndividualAdminEditForm
           data={{ individualAdmins: [adminData], allLibraries }}
           disabled={false}

--- a/src/components/__tests__/LibraryEditForm-test.tsx
+++ b/src/components/__tests__/LibraryEditForm-test.tsx
@@ -45,7 +45,7 @@ describe("LibraryEditForm", () => {
   describe("rendering", () => {
     beforeEach(() => {
       save = stub();
-      wrapper = shallow(
+      wrapper = mount(
         <LibraryEditForm
           data={{ libraries: [libraryData], settings: settingFields }}
           disabled={false}

--- a/src/components/__tests__/ServiceEditForm-test.tsx
+++ b/src/components/__tests__/ServiceEditForm-test.tsx
@@ -218,9 +218,9 @@ describe("ServiceEditForm", () => {
 
       let collapsible = wrapper.find(".collapsible");
       expect(collapsible.length).to.equal(3);
-      let title = collapsible.at(1).find(".panel-title");
+      let title = collapsible.at(0).find(".panel-title");
       expect(title.text()).to.equal("click for instructions");
-      let body = collapsible.at(1).find(".panel-body");
+      let body = collapsible.at(0).find(".panel-body");
       expect(body.text()).to.equal("Instructions!");
     });
 

--- a/src/components/__tests__/ServiceEditForm-test.tsx
+++ b/src/components/__tests__/ServiceEditForm-test.tsx
@@ -118,7 +118,7 @@ describe("ServiceEditForm", () => {
   describe("rendering", () => {
     beforeEach(() => {
       save = stub();
-      wrapper = shallow(
+      wrapper = mount(
         <TestServiceEditForm
           disabled={false}
           data={servicesData}
@@ -151,7 +151,7 @@ describe("ServiceEditForm", () => {
       expect(children.at(1).text()).to.contain("protocol 2 label");
       expect(children.at(2).text()).to.contain("instructions label");
 
-      wrapper = shallow(
+      wrapper = mount(
         <TestServiceEditForm
           disabled={false}
           data={servicesData}
@@ -182,7 +182,7 @@ describe("ServiceEditForm", () => {
       input = protocolFormFieldByKey("protocol2_setting");
       expect(input.length).to.equal(0);
 
-      wrapper = shallow(
+      wrapper = mount(
         <TestServiceEditForm
           disabled={false}
           data={servicesData}
@@ -217,10 +217,10 @@ describe("ServiceEditForm", () => {
       wrapper.setState({ protocol: "protocol with instructions" });
 
       let collapsible = wrapper.find(".collapsible");
-      expect(collapsible.length).to.equal(1);
-      let title = collapsible.find(".panel-title");
+      expect(collapsible.length).to.equal(3);
+      let title = collapsible.at(1).find(".panel-title");
       expect(title.text()).to.equal("click for instructions");
-      let body = collapsible.find(".panel-body");
+      let body = collapsible.at(1).find(".panel-body");
       expect(body.text()).to.equal("Instructions!");
     });
 
@@ -231,7 +231,7 @@ describe("ServiceEditForm", () => {
 
     it("doesn't render parent dropdown when there are no available parents", () => {
       const newService = Object.assign({}, serviceData, { protocol: "protocol 3" });
-      wrapper = shallow(
+      wrapper = mount(
         <TestServiceEditForm
           disabled={false}
           data={servicesData}
@@ -250,7 +250,7 @@ describe("ServiceEditForm", () => {
       const parentService = Object.assign({}, serviceData, { protocol: "protocol 3", name: "Parent" });
       const childService = Object.assign({}, serviceData, { protocol: "protocol 3", id: 3, name: "Child" });
       let servicesDataWithParent = Object.assign({}, servicesData, { services: [parentService, childService] });
-      wrapper = shallow(
+      wrapper = mount(
         <TestServiceEditForm
           disabled={false}
           data={servicesDataWithParent}
@@ -270,7 +270,7 @@ describe("ServiceEditForm", () => {
       expect(children.at(1).text()).to.contain("Parent");
 
       childService.parent_id = parentService.id;
-      wrapper = shallow(
+      wrapper = mount(
         <TestServiceEditForm
           disabled={false}
           data={servicesDataWithParent}
@@ -293,7 +293,7 @@ describe("ServiceEditForm", () => {
       const parentService = Object.assign({}, serviceData, { protocol: "protocol 3", name: "Parent" });
       const childService = Object.assign({}, serviceData, { protocol: "protocol 3", id: 3, name: "Child" });
       let servicesDataWithParent = Object.assign({}, servicesData, { services: [parentService, childService] });
-      wrapper = shallow(
+      wrapper = mount(
         <TestServiceEditForm
           disabled={false}
           data={servicesDataWithParent}
@@ -318,7 +318,7 @@ describe("ServiceEditForm", () => {
       expect(input.props().value).to.equal("parent setting");
 
       childService.parent_id = parentService.id;
-      wrapper = shallow(
+      wrapper = mount(
         <TestServiceEditForm
           disabled={false}
           data={servicesDataWithParent}
@@ -348,7 +348,7 @@ describe("ServiceEditForm", () => {
         protocols: [servicesData.protocols[1]]
       });
 
-      wrapper = shallow(
+      wrapper = mount(
         <TestServiceEditForm
           disabled={false}
           data={servicesDataSitewide}
@@ -363,7 +363,7 @@ describe("ServiceEditForm", () => {
       let serviceDataSitewide = Object.assign({}, servicesData, {
         libraries: []
       });
-      wrapper = shallow(
+      wrapper = mount(
         <TestServiceEditForm
           disabled={false}
           data={servicesDataSitewide}
@@ -423,7 +423,7 @@ describe("ServiceEditForm", () => {
 
       let newServiceData = Object.assign({}, serviceData, { protocol: "protocol 3" });
 
-      wrapper = shallow(
+      wrapper = mount(
         <TestServiceEditForm
           disabled={false}
           data={servicesData}
@@ -506,7 +506,7 @@ describe("ServiceEditForm", () => {
       input = protocolFormFieldByKey("library_select_setting");
       expect(input.length).to.equal(0);
 
-      wrapper = shallow(
+      wrapper = mount(
         <TestServiceEditForm
           disabled={false}
           data={servicesData}

--- a/src/stylesheets/app.scss
+++ b/src/stylesheets/app.scss
@@ -15,6 +15,7 @@
 @import "classifications";
 @import "classifications_form";
 @import "classifications_table";
+@import "collapsible";
 @import "collection_edit_form";
 @import "color_picker";
 @import "complaint_form";

--- a/src/stylesheets/collapsible.scss
+++ b/src/stylesheets/collapsible.scss
@@ -1,0 +1,38 @@
+.instruction {
+  box-shadow: none;
+  border: 1px solid $linkcolor;
+  border-radius: 0;
+  .panel-heading {
+    border: none;
+    font-weight: bold;
+    padding: 0;
+    .panel-title {
+      width: 100%;
+      text-align: left;
+      background: $linkcolor;
+      padding: 5px 7px;
+      border: none;
+    }
+    .collapsed, .panel-title a {
+      color: white;
+      &:focus {
+        outline: none;
+        text-decoration: none;
+      }
+      .glyphicon {
+        float: right;
+        line-height: inherit;
+      }
+    }
+  }
+}
+
+.panel-title {
+  a {
+    display: block;
+  }
+  .glyphicon {
+    float: right;
+    line-height: inherit;
+  }
+}

--- a/src/stylesheets/collapsible.scss
+++ b/src/stylesheets/collapsible.scss
@@ -48,7 +48,7 @@
       .glyphicon {
         float: right;
         line-height: inherit;
-        color: #fff;
+        color: $WHITE;
       }
     }
   }

--- a/src/stylesheets/collapsible.scss
+++ b/src/stylesheets/collapsible.scss
@@ -1,3 +1,29 @@
+.collapsible {
+  a {
+    color: #000;
+
+    &:hover {
+      color: #000;
+    }
+  }
+
+  .panel-heading {
+    &:hover {
+      background-color: $medium-gray;
+    }
+  }
+  .panel-title {
+    a {
+      display: block;
+    }
+    .glyphicon {
+      float: right;
+      line-height: inherit;
+      color: $linkcolor;
+    }
+  }
+}
+
 .instruction {
   box-shadow: none;
   border: 1px solid $linkcolor;
@@ -22,17 +48,8 @@
       .glyphicon {
         float: right;
         line-height: inherit;
+        color: #fff;
       }
     }
-  }
-}
-
-.panel-title {
-  a {
-    display: block;
-  }
-  .glyphicon {
-    float: right;
-    line-height: inherit;
   }
 }

--- a/src/stylesheets/collapsible.scss
+++ b/src/stylesheets/collapsible.scss
@@ -1,5 +1,3 @@
-$panel-heading-color: #F5F5F5;
-
 .collapsible {
   a {
     color: #000;
@@ -11,12 +9,12 @@ $panel-heading-color: #F5F5F5;
   .panel-heading {
     border: none;
     padding: 0;
-    background-color: $panel-heading-color;
+    background-color: $gray;
 
     .panel-title {
       width: 100%;
       text-align: left;
-      background: $panel-heading-color;
+      background: $gray;
       padding: 7px 9px;
       border: none;
       &:hover {
@@ -29,6 +27,13 @@ $panel-heading-color: #F5F5F5;
         float: right;
         line-height: inherit;
         color: $linkcolor;
+      }
+    }
+  }
+  &.staticPanel {
+    .panel-title {
+      &:hover {
+        background-color: transparent;
       }
     }
   }

--- a/src/stylesheets/collapsible.scss
+++ b/src/stylesheets/collapsible.scss
@@ -1,3 +1,5 @@
+$panel-heading-color: #F5F5F5;
+
 .collapsible {
   a {
     color: #000;
@@ -9,12 +11,12 @@
   .panel-heading {
     border: none;
     padding: 0;
-    background-color: #f5f5f5;
+    background-color: $panel-heading-color;
 
     .panel-title {
       width: 100%;
       text-align: left;
-      background: #f5f5f5;
+      background: $panel-heading-color;
       padding: 7px 9px;
       border: none;
       &:hover {

--- a/src/stylesheets/collapsible.scss
+++ b/src/stylesheets/collapsible.scss
@@ -6,20 +6,28 @@
       color: #000;
     }
   }
-
   .panel-heading {
-    &:hover {
-      background-color: $medium-gray;
-    }
-  }
-  .panel-title {
-    a {
-      display: block;
-    }
-    .glyphicon {
-      float: right;
-      line-height: inherit;
-      color: $linkcolor;
+    border: none;
+    padding: 0;
+    background-color: #f5f5f5;
+
+    .panel-title {
+      width: 100%;
+      text-align: left;
+      background: #f5f5f5;
+      padding: 7px 9px;
+      border: none;
+      &:hover {
+        background-color: $medium-gray;
+      }
+      a {
+        display: block;
+      }
+      .glyphicon {
+        float: right;
+        line-height: inherit;
+        color: $linkcolor;
+      }
     }
   }
 }
@@ -29,17 +37,14 @@
   border: 1px solid $linkcolor;
   border-radius: 0;
   .panel-heading {
-    border: none;
     font-weight: bold;
-    padding: 0;
     .panel-title {
-      width: 100%;
-      text-align: left;
       background: $linkcolor;
-      padding: 5px 7px;
-      border: none;
+      &:hover {
+        background: $linkcolor;
+      }
     }
-    .collapsed, .panel-title a {
+    .panel-title a {
       color: white;
       &:focus {
         outline: none;
@@ -48,7 +53,7 @@
       .glyphicon {
         float: right;
         line-height: inherit;
-        color: $WHITE;
+        color: $white;
       }
     }
   }

--- a/src/stylesheets/colors.scss
+++ b/src/stylesheets/colors.scss
@@ -7,4 +7,5 @@ $red-dark: #97272C;
 $red-error: tint($red, 80%);
 $red-tint: tint($red, 30%);
 $light-gray: #D7D4D0;
+$medium-gray: #DDD;
 $dark-gray: #080807;

--- a/src/stylesheets/colors.scss
+++ b/src/stylesheets/colors.scss
@@ -9,4 +9,4 @@ $red-tint: tint($red, 30%);
 $light-gray: #D7D4D0;
 $medium-gray: #DDD;
 $dark-gray: #080807;
-$white: #fff;
+$white: #FFF;

--- a/src/stylesheets/colors.scss
+++ b/src/stylesheets/colors.scss
@@ -9,3 +9,4 @@ $red-tint: tint($red, 30%);
 $light-gray: #D7D4D0;
 $medium-gray: #DDD;
 $dark-gray: #080807;
+$white: #fff;

--- a/src/stylesheets/custom_list_editor.scss
+++ b/src/stylesheets/custom_list_editor.scss
@@ -35,16 +35,6 @@
       color: lighten($pagetextcolor, 40%);
     }
 
-    .collections {
-      width: 100%;
-
-      .form-group {
-        float: left;
-        margin-right: 15px;
-        margin-bottom: 2px;
-      }
-    }
-
     a {
       margin-left: 5px;
       font-size: 0.7em;
@@ -92,6 +82,16 @@
     flex-direction: column;
     flex-grow: 1;
     margin-top: 10px;
+
+    .collections {
+      width: 100%;
+
+      .form-group {
+        float: left;
+        margin-right: 15px;
+        margin-bottom: 2px;
+      }
+    }
 
     .entry-points {
       display: block;

--- a/src/stylesheets/custom_list_editor.scss
+++ b/src/stylesheets/custom_list_editor.scss
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   margin-left: 20px;
-  flex-grow: 1;
+  flex-grow: 0.9;
 
   .custom-list-editor-header {
     display: flex;
@@ -118,7 +118,7 @@
   .custom-list-search-results, .custom-list-entries {
     display: flex;
     flex-direction: column;
-    flex-basis: 44%;
+    flex-basis: 47%;
     margin-top: 15px;
     margin-right: 20px;
 

--- a/src/stylesheets/editable_input.scss
+++ b/src/stylesheets/editable_input.scss
@@ -6,44 +6,6 @@
   font-size: 0.8rem;
 }
 
-.collapsible {
-  box-shadow: none;
-  border: 1px solid $linkcolor;
-  border-radius: 0;
-  .panel-heading {
-    border: none;
-    font-weight: bold;
-    padding: 0;
-    .panel-title {
-      width: 100%;
-      text-align: left;
-      background: $linkcolor;
-      padding: 4px 7px;
-      border: none;
-    }
-    .collapsed, .panel-title a {
-      color: white;
-      &:focus {
-        outline: none;
-        text-decoration: none;
-      }
-      .glyphicon {
-        float: right;
-        line-height: inherit;
-      }
-    }
-  }
-}
-
-.panel-title {
-  a {
-    display: block;
-  }
-  .glyphicon {
-    float: right;
-    line-height: inherit;
-  }
-}
 .field-error {
   background: $white;
 

--- a/src/stylesheets/editable_input.scss
+++ b/src/stylesheets/editable_input.scss
@@ -34,6 +34,16 @@
     }
   }
 }
+
+.panel-title {
+  a {
+    display: block;
+  }
+  .glyphicon {
+    float: right;
+    line-height: inherit;
+  }
+}
 .field-error {
   background: $white;
 


### PR DESCRIPTION
This is based off and pointing to the current open PR #181 .
The second pass to fix [SIMPLY-1317](https://jira.nypl.org/browse/SIMPLY-1317).

Updated the collapsible component so that it would render a static panel component for required fields and collapsible for optional fields. Also keeping the instruction styling scss rules.

Updated some tests from `shallow` to `mount` because there is now an intermediary component that needs to be rendered before some `EditableInput` components are rendered. I did not update every single form because some, like the change password form, only have two inputs and it didn't seem necessary.

Preview:
![screen shot 2018-11-06 at 5 05 55 pm](https://user-images.githubusercontent.com/1280564/48096850-57689700-e1e6-11e8-9edc-994c96fa9a58.png)
