### PR TITLE
Update 86

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v0.0.86
+#### Fixed
+- Fixed a bug which prevented forms containing collapsible elements from being submitted on enter.
+
 ### v0.0.85
 #### Fixed
 - Fixed a bug involving registering libraries with a discovery service: once a

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.0.85",
+  "version": "0.0.86",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Apparently the fix for the collapsible element toggling rather than submitting (https://github.com/NYPL-Simplified/circulation-web/pull/186) didn't make it into the last version.