### PR TITLE
Displaying the name of each Patron Authentication protocol configured.

### DIFF
--- a/src/components/PatronAuthServices.tsx
+++ b/src/components/PatronAuthServices.tsx
@@ -19,7 +19,7 @@ export class PatronAuthServices extends EditableConfigList<PatronAuthServicesDat
   label(item): string {
     for (const protocol of this.props.data.protocols) {
       if (protocol.name === item.protocol) {
-        return protocol.label;
+        return `${item.name} - ${protocol.label}`;
       }
     }
     return item.protocol;

--- a/src/components/PatronAuthServices.tsx
+++ b/src/components/PatronAuthServices.tsx
@@ -19,7 +19,7 @@ export class PatronAuthServices extends EditableConfigList<PatronAuthServicesDat
   label(item): string {
     for (const protocol of this.props.data.protocols) {
       if (protocol.name === item.protocol) {
-        return `${item.name} - ${protocol.label}`;
+        return `${item.name}: ${protocol.label}`;
       }
     }
     return item.protocol;

--- a/src/components/__tests__/PatronAuthServices-test.tsx
+++ b/src/components/__tests__/PatronAuthServices-test.tsx
@@ -20,7 +20,8 @@ describe("PatronAuthServices", () => {
       libraries: [{
         short_name: "nypl",
         test_library_setting: "test library setting"
-      }]
+      }],
+      name: "nypl protocol",
     }],
     protocols: [{
       name: "test protocol",
@@ -54,7 +55,7 @@ describe("PatronAuthServices", () => {
   it("shows patron auth service list", () => {
     let patronAuthService = wrapper.find("li");
     expect(patronAuthService.length).to.equal(1);
-    expect(patronAuthService.at(0).text()).to.contain("test protocol label");
+    expect(patronAuthService.at(0).text()).to.contain("nypl protocol - test protocol label");
     let editLink = patronAuthService.at(0).find("a");
     expect(editLink.props().href).to.equal("/admin/web/config/patronAuth/edit/2");
   });

--- a/src/components/__tests__/PatronAuthServices-test.tsx
+++ b/src/components/__tests__/PatronAuthServices-test.tsx
@@ -55,7 +55,7 @@ describe("PatronAuthServices", () => {
   it("shows patron auth service list", () => {
     let patronAuthService = wrapper.find("li");
     expect(patronAuthService.length).to.equal(1);
-    expect(patronAuthService.at(0).text()).to.contain("nypl protocol - test protocol label");
+    expect(patronAuthService.at(0).text()).to.contain("nypl protocol: test protocol label");
     let editLink = patronAuthService.at(0).find("a");
     expect(editLink.props().href).to.equal("/admin/web/config/patronAuth/edit/2");
   });


### PR DESCRIPTION
Resolves [SIMPLY-580](https://jira.nypl.org/browse/SIMPLY-580).
Simply displaying the name of each Patron Authentication protocol before what protocol it is.

<img width="756" alt="screen shot 2018-11-23 at 3 46 33 pm" src="https://user-images.githubusercontent.com/1280564/48959993-80539080-ef37-11e8-8ed7-8f7646f5618f.png">
