### PR TITLE
Only displaying inherit restriction config on Lane page for child lanes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v0.0.90
+#### Fixed
+- Only showing the "Inherit restrictions from parent lane" setting on the Lane config page when creating child lanes and not a new parent lane.
+
 ### v0.0.89
 #### Updated
 - Updated the opds-web-client package and passing down a prop to use all languages when doing submitting a search term.

--- a/src/components/LaneEditor.tsx
+++ b/src/components/LaneEditor.tsx
@@ -123,13 +123,15 @@ export default class LaneEditor extends React.Component<LaneEditorProps, LaneEdi
               <div>This lane's parent is currently hidden. <HiddenIcon /></div>
             }
             </h4>
-            <EditableInput
-              type="checkbox"
-              name="inherit_parent_restrictions"
-              checked={this.state.inheritParentRestrictions}
-              label="Inherit restrictions from parent lane"
-              onChange={this.changeInheritParentRestrictions}
-              />
+            { this.props.parent &&
+              <EditableInput
+                type="checkbox"
+                name="inherit_parent_restrictions"
+                checked={this.state.inheritParentRestrictions}
+                label="Inherit restrictions from parent lane"
+                onChange={this.changeInheritParentRestrictions}
+                />
+            }
           </div>
         </div>
         <div className="lane-editor-body">

--- a/src/components/__tests__/LaneEditor-test.tsx
+++ b/src/components/__tests__/LaneEditor-test.tsx
@@ -105,7 +105,22 @@ describe("LaneEditor", () => {
     expect(parentInfo.text()).to.contain("sublane of lane");
   });
 
-  it("shows and changes inherit parent restrictions setting", () => {
+  it("doesn't show the inherit parent restrictions setting on a new lane", () => {
+    let input = wrapper.find(EditableInput);
+    expect(input.length).to.equal(0);
+  });
+
+  it("shows and changes inherit parent restrictions setting on a child lane", () => {
+    wrapper = mount(
+      <LaneEditor
+        library="library"
+        lane={laneData}
+        parent={laneData}
+        customLists={customListsData}
+        editLane={editLane}
+        />
+    );
+
     let input = wrapper.find(EditableInput);
     expect(input.props().checked).to.be.true;
     expect(input.props().label).to.contain("restrictions");


### PR DESCRIPTION
Resolves [SIMPLY-598](https://jira.nypl.org/browse/SIMPLY-598);