### PR TITLE
Lane empty list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### v0.0.90
 #### Fixed
 - Only showing the "Inherit restrictions from parent lane" setting on the Lane config page when creating child lanes and not a new parent lane.
+- Fixing the redirect to the edit Lane form when successfully creating a new Lane.
+- Fixing the display message for errors when unsuccessfully creating a new Lane.
 
 ### v0.0.89
 #### Updated

--- a/src/components/Lanes.tsx
+++ b/src/components/Lanes.tsx
@@ -22,7 +22,7 @@ export interface LanesStateProps {
   lanes: LaneData[];
   customLists: CustomListData[];
   responseBody?: string;
-  fetchError?: FetchErrorData;
+  formError?: FetchErrorData;
   isFetching: boolean;
 }
 
@@ -62,6 +62,7 @@ export class Lanes extends React.Component<LanesProps, LanesState> {
     this.hideLane = this.hideLane.bind(this);
     this.showLane = this.showLane.bind(this);
     this.resetLanes = this.resetLanes.bind(this);
+    this.toggle = this.toggle.bind(this);
 
     const expanded: { [key: string]: boolean } = {};
     for (const topLevelLane of this.props.lanes || []) {
@@ -76,8 +77,8 @@ export class Lanes extends React.Component<LanesProps, LanesState> {
   render(): JSX.Element {
     return (
       <div className="lanes-container">
-        { this.props.fetchError &&
-          <ErrorMessage error={this.props.fetchError} />
+        { this.props.formError &&
+          <ErrorMessage error={this.props.formError} />
         }
         { this.props.isFetching &&
           <LoadingIndicator />
@@ -150,16 +151,19 @@ export class Lanes extends React.Component<LanesProps, LanesState> {
     return (
       <ul>
         { lanes.map(lane =>
-            <li className={(String(lane.id) === this.props.identifier) ? "active" : ""}>
+            <li
+              key={lane.display_name.replace(" ", "").trim()}
+              className={(String(lane.id) === this.props.identifier) ? "active" : ""}
+            >
               <div>
                 <span>
                   { this.isExpanded(lane) &&
-                    <div className="collapse-button" onClick={() => { this.collapse(lane); }}>
+                    <div className="collapse-button" onClick={() => { this.toggle(lane); }}>
                       <PyramidIcon />
                     </div>
                   }
                   { !this.isExpanded(lane) &&
-                    <div className="expand-button" onClick={() => { this.expand(lane); }}>
+                    <div className="expand-button" onClick={() => { this.toggle(lane); }}>
                       <PyramidIcon />
                     </div>
                   }
@@ -217,15 +221,9 @@ export class Lanes extends React.Component<LanesProps, LanesState> {
     return !!this.state.expanded[lane.id];
   }
 
-  collapse(lane) {
+  toggle(lane) {
     const expanded = Object.assign({}, this.state.expanded);
-    expanded[lane.id] = false;
-    this.setState({ expanded });
-  }
-
-  expand(lane) {
-    const expanded = Object.assign({}, this.state.expanded);
-    expanded[lane.id] = true;
+    expanded[lane.id] = !expanded[lane.id];
     this.setState({ expanded });
   }
 
@@ -329,9 +327,9 @@ export class Lanes extends React.Component<LanesProps, LanesState> {
 function mapStateToProps(state, ownProps) {
   return {
     lanes: state.editor.lanes && state.editor.lanes.data && state.editor.lanes.data.lanes,
-    responseBody: state.editor.lanes && state.editor.lanes.responseBody,
+    responseBody: state.editor.lanes && state.editor.lanes.successMessage,
     customLists: state.editor.customLists && state.editor.customLists.data && state.editor.customLists.data.custom_lists,
-    fetchError: state.editor.lanes.fetchError || state.editor.laneVisibility.fetchError,
+    formError: state.editor.lanes.formError || state.editor.laneVisibility.formError,
     isFetching: state.editor.lanes.isFetching || state.editor.lanes.isEditing || state.editor.laneVisibility.isFetching || state.editor.customLists.isFetching || state.editor.resetLanes.isFetching
   };
 }

--- a/src/components/Lanes.tsx
+++ b/src/components/Lanes.tsx
@@ -23,6 +23,7 @@ export interface LanesStateProps {
   customLists: CustomListData[];
   responseBody?: string;
   formError?: FetchErrorData;
+  fetchError?: FetchErrorData;
   isFetching: boolean;
 }
 
@@ -75,10 +76,11 @@ export class Lanes extends React.Component<LanesProps, LanesState> {
   }
 
   render(): JSX.Element {
+    const errorMessage = this.props.formError || this.props.fetchError;
     return (
       <div className="lanes-container">
-        { this.props.formError &&
-          <ErrorMessage error={this.props.formError} />
+        { errorMessage &&
+          <ErrorMessage error={errorMessage} />
         }
         { this.props.isFetching &&
           <LoadingIndicator />
@@ -329,6 +331,7 @@ function mapStateToProps(state, ownProps) {
     lanes: state.editor.lanes && state.editor.lanes.data && state.editor.lanes.data.lanes,
     responseBody: state.editor.lanes && state.editor.lanes.successMessage,
     customLists: state.editor.customLists && state.editor.customLists.data && state.editor.customLists.data.custom_lists,
+    fetchError: state.editor.lanes.fetchError || state.editor.laneVisibility.fetchError,
     formError: state.editor.lanes.formError || state.editor.laneVisibility.formError,
     isFetching: state.editor.lanes.isFetching || state.editor.lanes.isEditing || state.editor.laneVisibility.isFetching || state.editor.customLists.isFetching || state.editor.resetLanes.isFetching
   };

--- a/src/components/__tests__/Lanes-test.tsx
+++ b/src/components/__tests__/Lanes-test.tsx
@@ -73,7 +73,7 @@ describe("Lanes", () => {
     let error = wrapper.find(ErrorMessage);
     expect(error.length).to.equal(0);
 
-    wrapper.setProps({ fetchError: { status: 500, response: "Error", url: "url" } });
+    wrapper.setProps({ formError: { status: 500, response: "Error", url: "url" } });
     error = wrapper.find(ErrorMessage);
     expect(error.length).to.equal(1);
   });

--- a/src/components/__tests__/Lanes-test.tsx
+++ b/src/components/__tests__/Lanes-test.tsx
@@ -69,11 +69,20 @@ describe("Lanes", () => {
     );
   });
 
-  it("renders error message", () => {
+  it("renders error message from a bad form submission", () => {
     let error = wrapper.find(ErrorMessage);
     expect(error.length).to.equal(0);
 
     wrapper.setProps({ formError: { status: 500, response: "Error", url: "url" } });
+    error = wrapper.find(ErrorMessage);
+    expect(error.length).to.equal(1);
+  });
+
+  it("renders error message from loading error", () => {
+    let error = wrapper.find(ErrorMessage);
+    expect(error.length).to.equal(0);
+
+    wrapper.setProps({ fetchError: { status: 500, response: "Error", url: "url" } });
     error = wrapper.find(ErrorMessage);
     expect(error.length).to.equal(1);
   });


### PR DESCRIPTION
Adding this PR as part of v0.0.90.
Resolves [SIMPLY-1481](https://jira.nypl.org/browse/SIMPLY-1481).

Just needed to update the mapping of the props and Redux store values in the Lane component to 1) correctly show form error messages and 2) correctly redirect after successfully creating a new Lane. Also did some minor code refactoring to Lanes.tsx.