### PR TITLE
Added a system configuration tab for external catalogs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v0.0.91
+#### Added
+Added a system configuration tab for external catalogs.
+
 ### v0.0.90
 #### Fixed
 - Only showing the "Inherit restrictions from parent lane" setting on the Lane config page when creating child lanes and not a new parent lane.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.0.90",
+  "version": "0.0.91",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -9,8 +9,8 @@ import {
   DiscoveryServicesData, LibraryRegistrationsData,
   CustomListsData, LanesData,
   RolesData, MediaData, LanguagesData, RightsStatusData,
-  StorageServicesData, LoggingServicesData, SelfTestsData,
-  PatronData
+  StorageServicesData, LoggingServicesData, CatalogServicesData,
+  SelfTestsData, PatronData
 } from "./interfaces";
 import { CollectionData } from "opds-web-client/lib/interfaces";
 import DataFetcher from "opds-web-client/lib/DataFetcher";
@@ -75,6 +75,9 @@ export default class ActionCreator extends BaseActionCreator {
   static readonly STORAGE_SERVICES = "STORAGE_SERVICES";
   static readonly EDIT_STORAGE_SERVICE = "EDIT_STORAGE_SERVICE";
   static readonly DELETE_STORAGE_SERVICE = "DELETE_STORAGE_SERVICE";
+  static readonly CATALOG_SERVICES = "CATALOG_SERVICES";
+  static readonly EDIT_CATALOG_SERVICE = "EDIT_CATALOG_SERVICE";
+  static readonly DELETE_CATALOG_SERVICE = "DELETE_CATALOG_SERVICE";
   static readonly DISCOVERY_SERVICES = "DISCOVERY_SERVICES";
   static readonly EDIT_DISCOVERY_SERVICE = "EDIT_DISCOVERY_SERVICE";
   static readonly DELETE_DISCOVERY_SERVICE = "DELETE_DISCOVERY_SERVICE";
@@ -539,6 +542,21 @@ export default class ActionCreator extends BaseActionCreator {
   deleteStorageService(identifier: string | number) {
     const url = "/admin/storage_service/" + identifier;
     return this.postForm(ActionCreator.DELETE_STORAGE_SERVICE, url, null, "DELETE").bind(this);
+  }
+
+  fetchCatalogServices() {
+    const url = "/admin/catalog_services";
+    return this.fetchJSON<CatalogServicesData>(ActionCreator.CATALOG_SERVICES, url).bind(this);
+  }
+
+  editCatalogService(data: FormData) {
+    const url = "/admin/catalog_services";
+    return this.postForm(ActionCreator.EDIT_CATALOG_SERVICE, url, data).bind(this);
+  }
+
+  deleteCatalogService(identifier: string | number) {
+    const url = "/admin/catalog_service/" + identifier;
+    return this.postForm(ActionCreator.DELETE_CATALOG_SERVICE, url, null, "DELETE").bind(this);
   }
 
   fetchDiscoveryServices() {

--- a/src/components/CatalogServices.tsx
+++ b/src/components/CatalogServices.tsx
@@ -1,0 +1,58 @@
+import EditableConfigList, { EditableConfigListStateProps, EditableConfigListDispatchProps, EditableConfigListOwnProps } from "./EditableConfigList";
+import { connect } from "react-redux";
+import ActionCreator from "../actions";
+import { CatalogServicesData, CatalogServiceData } from "../interfaces";
+import ServiceEditForm from "./ServiceEditForm";
+
+/** Right panel for catalog services on the system configuration page.
+    Shows a list of current catalog services and allows creating a new
+    service or editing or deleting an existing service. */
+export class CatalogServices extends EditableConfigList<CatalogServicesData, CatalogServiceData> {
+  EditForm = ServiceEditForm;
+  listDataKey = "catalog_services";
+  itemTypeName = "catalog service";
+  urlBase = "/admin/web/config/catalogServices/";
+  identifierKey = "id";
+  labelKey = "protocol";
+
+  label(item): string {
+    for (const protocol of this.props.data.protocols) {
+      if (protocol.name === item.protocol) {
+        return `${item.name}: ${protocol.label}`;
+      }
+    }
+    return item.protocol;
+  }
+}
+
+function mapStateToProps(state, ownProps) {
+  const data = Object.assign({}, state.editor.catalogServices && state.editor.catalogServices.data || {});
+  if (state.editor.libraries && state.editor.libraries.data) {
+    data.allLibraries = state.editor.libraries.data.libraries;
+  }
+  // fetchError = an error involving loading the list of catalog services; formError = an error upon submission
+  // of the create/edit form.
+  return {
+    data: data,
+    responseBody: state.editor.catalogServices && state.editor.catalogServices.successMessage,
+    fetchError: state.editor.catalogServices.fetchError,
+    formError: state.editor.catalogServices.formError,
+    isFetching: state.editor.catalogServices.isFetching || state.editor.catalogServices.isEditing
+  };
+}
+
+function mapDispatchToProps(dispatch, ownProps) {
+  let actions = new ActionCreator(null, ownProps.csrfToken);
+  return {
+    fetchData: () => dispatch(actions.fetchCatalogServices()),
+    editItem: (data: FormData) => dispatch(actions.editCatalogService(data)),
+    deleteItem: (identifier: string | number) => dispatch(actions.deleteCatalogService(identifier))
+  };
+}
+
+const ConnectedCatalogServices = connect<EditableConfigListStateProps<CatalogServicesData>, EditableConfigListDispatchProps<CatalogServicesData>, EditableConfigListOwnProps>(
+  mapStateToProps,
+  mapDispatchToProps
+)(CatalogServices);
+
+export default ConnectedCatalogServices;

--- a/src/components/ConfigTabContainer.tsx
+++ b/src/components/ConfigTabContainer.tsx
@@ -10,6 +10,7 @@ import AnalyticsServices from "./AnalyticsServices";
 import CDNServices from "./CDNServices";
 import SearchServices from "./SearchServices";
 import StorageServices from "./StorageServices";
+import CatalogServices from "./CatalogServices";
 import DiscoveryServices from "./DiscoveryServices";
 import LoggingServices from "./LoggingServices";
 import { TabContainer, TabContainerProps, TabContainerContext } from "./TabContainer";
@@ -135,6 +136,14 @@ export default class ConfigTabContainer extends TabContainer<ConfigTabContainerP
           identifier={this.props.identifier}
           />
       );
+      tabs["catalogServices"] = (
+        <CatalogServices
+          store={this.props.store}
+          csrfToken={this.props.csrfToken}
+          editOrCreate={this.props.editOrCreate}
+          identifier={this.props.identifier}
+          />
+      );
       tabs["discovery"] = (
         <DiscoveryServices
           store={this.props.store}
@@ -165,6 +174,8 @@ export default class ConfigTabContainer extends TabContainer<ConfigTabContainerP
       return "Sitewide Settings";
     } else if (name === "cdn") {
       return "CDN";
+    } else if (name === "catalogServices") {
+      return "External Catalogs";
     } else {
       return super.tabDisplayName(name);
     }

--- a/src/components/ConfigTabContainer.tsx
+++ b/src/components/ConfigTabContainer.tsx
@@ -35,123 +35,64 @@ export default class ConfigTabContainer extends TabContainer<ConfigTabContainerP
     admin: React.PropTypes.object.isRequired
   };
 
+  LIBRARY_MANAGER_TABS = ["libraries", "individualAdmins"];
+  SYSTEM_ADMIN_TABS = ["collections", "adminAuth", "patronAuth", "sitewideSettings",
+                       "logging", "metadata", "analytics", "cdn", "search", "storage",
+                       "catalogServices", "discovery"];
+
+  COMPONENT_CLASSES = {
+    libraries: Libraries,
+    individualAdmins: IndividualAdmins,
+    collections: Collections,
+    adminAuth: AdminAuthServices,
+    patronAuth: PatronAuthServices,
+    sitewideSettings: SitewideSettings,
+    logging: LoggingServices,
+    metadata: MetadataServices,
+    analytics: AnalyticsServices,
+    cdn: CDNServices,
+    search: SearchServices,
+    storage: StorageServices,
+    catalogServices: CatalogServices,
+    discovery: DiscoveryServices
+  };
+
+  DISPLAY_NAMES = {
+    adminAuth: "Admin Authentication",
+    individualAdmins: "Admins",
+    patronAuth: "Patron Authentication",
+    sitewideSettings: "Sitewide Settings",
+    cdn: "CDN",
+    catalogServices: "External Catalogs"
+  };
+
   tabs() {
     const tabs = {};
     if (this.context.admin.isLibraryManagerOfSomeLibrary()) {
-      tabs["libraries"] = (
-        <Libraries
-          store={this.props.store}
-          csrfToken={this.props.csrfToken}
-          editOrCreate={this.props.editOrCreate}
-          identifier={this.props.identifier}
-          />
-      );
-      tabs["individualAdmins"] = (
-        <IndividualAdmins
-          store={this.props.store}
-          csrfToken={this.props.csrfToken}
-          editOrCreate={this.props.editOrCreate}
-          identifier={this.props.identifier}
-          />
-      );
+      for (let tab of this.LIBRARY_MANAGER_TABS) {
+        let ComponentClass = this.COMPONENT_CLASSES[tab];
+        tabs[tab] = (
+          <ComponentClass
+            store={this.props.store}
+            csrfToken={this.props.csrfToken}
+            editOrCreate={this.props.editOrCreate}
+            identifier={this.props.identifier}
+            />
+        );
+      }
     }
     if (this.context.admin.isSystemAdmin()) {
-      tabs["collections"] = (
-        <Collections
-          store={this.props.store}
-          csrfToken={this.props.csrfToken}
-          editOrCreate={this.props.editOrCreate}
-          identifier={this.props.identifier}
-          />
-      );
-      tabs["adminAuth"] = (
-        <AdminAuthServices
-          store={this.props.store}
-          csrfToken={this.props.csrfToken}
-          editOrCreate={this.props.editOrCreate}
-          identifier={this.props.identifier}
-          />
-      );
-      tabs["patronAuth"] = (
-        <PatronAuthServices
-          store={this.props.store}
-          csrfToken={this.props.csrfToken}
-          editOrCreate={this.props.editOrCreate}
-          identifier={this.props.identifier}
-          />
-      );
-      tabs["sitewideSettings"] = (
-        <SitewideSettings
-          store={this.props.store}
-          csrfToken={this.props.csrfToken}
-          editOrCreate={this.props.editOrCreate}
-          identifier={this.props.identifier}
-          />
-      );
-      tabs["logging"] = (
-        <LoggingServices
-          store={this.props.store}
-          csrfToken={this.props.csrfToken}
-          editOrCreate={this.props.editOrCreate}
-          identifier={this.props.identifier}
-          />
-      );
-      tabs["metadata"] = (
-        <MetadataServices
-          store={this.props.store}
-          csrfToken={this.props.csrfToken}
-          editOrCreate={this.props.editOrCreate}
-          identifier={this.props.identifier}
-          />
-      );
-      tabs["analytics"] = (
-        <AnalyticsServices
-          store={this.props.store}
-          csrfToken={this.props.csrfToken}
-          editOrCreate={this.props.editOrCreate}
-          identifier={this.props.identifier}
-          />
-      );
-      tabs["cdn"] = (
-        <CDNServices
-          store={this.props.store}
-          csrfToken={this.props.csrfToken}
-          editOrCreate={this.props.editOrCreate}
-          identifier={this.props.identifier}
-          />
-      );
-      tabs["search"] = (
-        <SearchServices
-          store={this.props.store}
-          csrfToken={this.props.csrfToken}
-          editOrCreate={this.props.editOrCreate}
-          identifier={this.props.identifier}
-          />
-      );
-      tabs["storage"] = (
-        <StorageServices
-          store={this.props.store}
-          csrfToken={this.props.csrfToken}
-          editOrCreate={this.props.editOrCreate}
-          identifier={this.props.identifier}
-          />
-      );
-      tabs["catalogServices"] = (
-        <CatalogServices
-          store={this.props.store}
-          csrfToken={this.props.csrfToken}
-          editOrCreate={this.props.editOrCreate}
-          identifier={this.props.identifier}
-          />
-      );
-      tabs["discovery"] = (
-        <DiscoveryServices
-          store={this.props.store}
-          csrfToken={this.props.csrfToken}
-          editOrCreate={this.props.editOrCreate}
-          identifier={this.props.identifier}
-          />
-      );
+      for (let tab of this.SYSTEM_ADMIN_TABS) {
+        let ComponentClass = this.COMPONENT_CLASSES[tab];
+        tabs[tab] = (
+          <ComponentClass
+            store={this.props.store}
+            csrfToken={this.props.csrfToken}
+            editOrCreate={this.props.editOrCreate}
+            identifier={this.props.identifier}
+            />
+        );
+      }
     }
     return tabs;
   }
@@ -164,18 +105,8 @@ export default class ConfigTabContainer extends TabContainer<ConfigTabContainerP
   }
 
   tabDisplayName(name) {
-    if (name === "adminAuth") {
-      return "Admin Authentication";
-    } else if (name === "individualAdmins") {
-      return "Admins";
-    } else if (name === "patronAuth") {
-      return "Patron Authentication";
-    } else if (name === "sitewideSettings") {
-      return "Sitewide Settings";
-    } else if (name === "cdn") {
-      return "CDN";
-    } else if (name === "catalogServices") {
-      return "External Catalogs";
+    if (this.DISPLAY_NAMES[name]) {
+      return this.DISPLAY_NAMES[name];
     } else {
       return super.tabDisplayName(name);
     }

--- a/src/components/ServiceEditForm.tsx
+++ b/src/components/ServiceEditForm.tsx
@@ -245,8 +245,8 @@ export default class ServiceEditForm<T extends ServicesData> extends React.Compo
             />
         }
         { this.props.data && this.protocolInstructions() &&
-            <div class="form-group">
-              <label class="control-label">Instructions</label>
+            <div className="form-group">
+              <label className="control-label">Instructions</label>
               <Collapsible
                 title={this.protocolDescription()}
                 type="instruction"

--- a/src/components/__tests__/CatalogServices-test.tsx
+++ b/src/components/__tests__/CatalogServices-test.tsx
@@ -1,0 +1,62 @@
+import { expect } from "chai";
+import { stub } from "sinon";
+
+import * as React from "react";
+import { shallow } from "enzyme";
+
+import { CatalogServices } from "../CatalogServices";
+
+describe("CatalogServices", () => {
+  let wrapper;
+  let fetchData;
+  let editItem;
+  let data = {
+    catalog_services: [{
+      id: 2,
+      protocol: "test protocol",
+      settings: {
+        "test_setting": "test setting"
+      },
+      libraries: [{
+        short_name: "nypl",
+        test_library_setting: "test library setting"
+      }],
+      name: "nypl catalog",
+    }],
+    protocols: [{
+      name: "test protocol",
+      label: "test protocol label",
+      settings: []
+    }],
+    allLibraries: [{
+      short_name: "nypl"
+    }]
+  };
+
+  const pause = () => {
+    return new Promise<void>(resolve => setTimeout(resolve, 0));
+  };
+
+  beforeEach(() => {
+    fetchData = stub();
+    editItem = stub().returns(new Promise<void>(resolve => resolve()));
+
+    wrapper = shallow(
+      <CatalogServices
+        data={data}
+        fetchData={fetchData}
+        editItem={editItem}
+        csrfToken="token"
+        isFetching={false}
+        />
+    );
+  });
+
+  it("shows catalog service list", () => {
+    let catalogService = wrapper.find("li");
+    expect(catalogService.length).to.equal(1);
+    expect(catalogService.at(0).text()).to.contain("nypl catalog: test protocol label");
+    let editLink = catalogService.at(0).find("a");
+    expect(editLink.props().href).to.equal("/admin/web/config/catalogServices/edit/2");
+  });
+});

--- a/src/components/__tests__/ConfigTabContainer-test.tsx
+++ b/src/components/__tests__/ConfigTabContainer-test.tsx
@@ -17,6 +17,7 @@ import AnalyticsServices from "../AnalyticsServices";
 import CDNServices from "../CDNServices";
 import SearchServices from "../SearchServices";
 import StorageServices from "../StorageServices";
+import CatalogServices from "../CatalogServices";
 import DiscoveryServices from "../DiscoveryServices";
 import { mockRouterContext } from "./routing";
 import Admin from "../../models/Admin";
@@ -60,6 +61,7 @@ describe("ConfigTabContainer", () => {
       expect(linkTexts).to.contain("Sitewide Settings");
       expect(linkTexts).to.contain("Metadata");
       expect(linkTexts).to.contain("CDN");
+      expect(linkTexts).to.contain("External Catalogs");
     });
 
     it("shows components", () => {
@@ -67,7 +69,8 @@ describe("ConfigTabContainer", () => {
         Libraries, IndividualAdmins, Collections,
         AdminAuthServices, PatronAuthServices, SitewideSettings,
         MetadataServices, AnalyticsServices, CDNServices,
-        SearchServices, StorageServices, DiscoveryServices
+        SearchServices, StorageServices, CatalogServices,
+        DiscoveryServices
       ];
       for (const componentClass of componentClasses) {
         const component = wrapper.find(componentClass);
@@ -114,6 +117,7 @@ describe("ConfigTabContainer", () => {
       expect(linkTexts).not.to.contain("Sitewide Settings");
       expect(linkTexts).not.to.contain("Metadata");
       expect(linkTexts).not.to.contain("CDN");
+      expect(linkTexts).not.to.contain("External Catalogs");
     });
 
     it("shows components", () => {
@@ -130,7 +134,8 @@ describe("ConfigTabContainer", () => {
       const hiddenComponentClasses = [
         Collections, AdminAuthServices, PatronAuthServices, SitewideSettings,
         MetadataServices, AnalyticsServices, CDNServices,
-        SearchServices, StorageServices, DiscoveryServices
+        SearchServices, StorageServices, CatalogServices,
+        DiscoveryServices
       ];
       for (const componentClass of hiddenComponentClasses) {
         const component = wrapper.find(componentClass);
@@ -167,7 +172,8 @@ describe("ConfigTabContainer", () => {
         Libraries, IndividualAdmins, Collections,
         AdminAuthServices, PatronAuthServices, SitewideSettings,
         MetadataServices, AnalyticsServices, CDNServices,
-        SearchServices, StorageServices, DiscoveryServices
+        SearchServices, StorageServices, CatalogServices,
+        DiscoveryServices
       ];
       for (const componentClass of componentClasses) {
         const component = wrapper.find(componentClass);

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -338,6 +338,12 @@ export interface StorageServicesData extends ServicesData {
   storage_services: StorageServiceData[];
 }
 
+export interface CatalogServiceData extends ServiceData {}
+
+export interface CatalogServicesData extends ServicesData {
+  catalog_services: CatalogServiceData[];
+}
+
 export interface DiscoveryServiceData extends ServiceData {}
 
 export interface DiscoveryServicesData extends ServicesWithRegistrationsData {

--- a/src/reducers/catalogServices.ts
+++ b/src/reducers/catalogServices.ts
@@ -1,0 +1,5 @@
+import { CatalogServicesData } from "../interfaces";
+import ActionCreator from "../actions";
+import createFetchEditReducer from "./createFetchEditReducer";
+
+export default createFetchEditReducer<CatalogServicesData>(ActionCreator.CATALOG_SERVICES, ActionCreator.EDIT_CATALOG_SERVICE);

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -19,6 +19,7 @@ import analyticsServices from "./analyticsServices";
 import cdnServices from "./cdnServices";
 import searchServices from "./searchServices";
 import storageServices from "./storageServices";
+import catalogServices from "./catalogServices";
 import discoveryServices from "./discoveryServices";
 import registerLibraryWithDiscoveryService from "./registerLibraryWithDiscoveryService";
 import discoveryServiceLibraryRegistrations from "./discoveryServiceLibraryRegistrations";
@@ -44,7 +45,7 @@ import {
   LibrariesData, CollectionsData, AdminAuthServicesData, IndividualAdminsData,
   PatronAuthServicesData, SitewideSettingsData, LoggingServicesData, MetadataServicesData,
   AnalyticsServicesData, CDNServicesData, SearchServicesData, StorageServicesData,
-  DiscoveryServicesData, LibraryRegistrationsData, CustomListsData,
+  CatalogServicesData, DiscoveryServicesData, LibraryRegistrationsData, CustomListsData,
   LanesData, RolesData, MediaData, LanguagesData,
   RightsStatusData, PatronData
 } from "../interfaces";
@@ -71,6 +72,7 @@ export interface State {
   cdnServices: FetchEditState<CDNServicesData>;
   searchServices: FetchEditState<SearchServicesData>;
   storageServices: FetchEditState<StorageServicesData>;
+  catalogServices: FetchEditState<CatalogServicesData>;
   discoveryServices: FetchEditState<DiscoveryServicesData>;
   registerLibraryWithDiscoveryService: RegisterLibraryState;
   discoveryServiceLibraryRegistrations: FetchEditState<LibraryRegistrationsData>;
@@ -112,6 +114,7 @@ export default combineReducers<State>({
   cdnServices,
   searchServices,
   storageServices,
+  catalogServices,
   discoveryServices,
   registerLibraryWithDiscoveryService,
   discoveryServiceLibraryRegistrations,


### PR DESCRIPTION
I'm still working on tests for the corresponding circulation branch, but this branch adds a new service type to system configuration. For now, the only protocol is "MARC Export", which will set up the circ manager to generate MARC files that can be imported into an external catalog.