### PR TITLE
Change copy to be more accurate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### v0.0.93
 #### Updated
 - Further subdivided library form for increased readability.
+- Made copy about resetting Adobe IDs more accurate.
 
 ### v0.0.92
 #### Updated

--- a/src/components/ResetAdobeId.tsx
+++ b/src/components/ResetAdobeId.tsx
@@ -70,7 +70,7 @@ export class ResetAdobeId extends React.Component<ResetAdobeIdProps, ResetAdobeI
         }
         <p>This feature allows you to delete the existing Adobe ID for an individual patron; a new Adobe ID will be assigned
           automatically when the patron logs in again. This step is necessary when patrons reach their device installation limit.
-          Please be sure to inform patrons that resetting their Adobe ID will cause them to lose any existing loans.</p>
+          Please be sure to inform patrons that resetting their Adobe ID will automatically revoke their access to any existing loans.</p>
         <ManagePatronsForm
           store={this.props.store}
           csrfToken={this.props.csrfToken}
@@ -80,7 +80,7 @@ export class ResetAdobeId extends React.Component<ResetAdobeIdProps, ResetAdobeI
             <div className="reset-adobe-id">
               <p className="patron-warning">
                 <b>Patron {patron && (patron.username || patron.personal_name || patron.authorization_identifier)} will
-                   lose any existing loans when the Adobe ID is reset.</b>
+                   lose access to any existing loans when the Adobe ID is reset.</b>
               </p>
               { responseBody &&
                 <Alert bsStyle="success">

--- a/src/components/__tests__/ResetAdobeId-test.tsx
+++ b/src/components/__tests__/ResetAdobeId-test.tsx
@@ -88,7 +88,7 @@ describe("ResetAdobeId", () => {
 
     it("should display a warning message before the submission button", () => {
       const patronWarning = wrapper.find(".patron-warning");
-      expect(patronWarning.text()).to.equal("Patron User Name will lose any existing loans when the Adobe ID is reset.");
+      expect(patronWarning.text()).to.equal("Patron User Name will lose access to any existing loans when the Adobe ID is reset.");
     });
 
     it("should have a submission button with a .btn-danger class", () => {
@@ -223,7 +223,7 @@ describe("ResetAdobeId", () => {
     it("should update the warning message if a new patron was searched and found", () => {
       wrapper.setProps({ patron: patrons[1] });
       const patronWarning = wrapper.find(".patron-warning");
-      expect(patronWarning.text()).to.equal("Patron Personal Name2 will lose any existing loans when the Adobe ID is reset.");
+      expect(patronWarning.text()).to.equal("Patron Personal Name2 will lose access to any existing loans when the Adobe ID is reset.");
     });
 
     it("should restore the checkbox and the reset button if a new patron was searched and found", () => {


### PR DESCRIPTION
I updated the description on the Adobe reset page to say that the patron's access to loans will be revoked, rather than that the patron will lose loans.