### PR TITLE
Replicate type=number functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v0.0.94
+#### Updated
+- Implemented a custom number validator for better error handling.
+
 ### v0.0.93
 #### Updated
 - Further subdivided library form for increased readability.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.0.93",
+  "version": "0.0.94",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/components/EditableInput.tsx
+++ b/src/components/EditableInput.tsx
@@ -9,6 +9,7 @@ export interface EditableInputProps extends React.HTMLProps<EditableInput> {
   required?: boolean;
   error?: FetchErrorData;
   optionalText?: boolean;
+  validation?: string;
 }
 
 export interface EditableInputState {
@@ -73,6 +74,7 @@ export default class EditableInput extends React.Component<EditableInputProps, E
       ref: "element",
       value: this.state.value,
       checked: this.state.checked,
+      onKeyPress: this.props.validation && this.props.validation === "number" && this.validateNumber,
       onChange: this.handleChange,
       style: this.props.style,
       placeholder: this.props.placeholder,
@@ -114,6 +116,13 @@ export default class EditableInput extends React.Component<EditableInputProps, E
         value = this.getValue();
       }
       this.setState({ value, checked });
+    }
+  }
+
+  validateNumber(e) {
+    const validChars = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", ".", "Enter"];
+    if (validChars.indexOf(e.key) < 0) {
+      e.preventDefault();
     }
   }
 

--- a/src/components/ProtocolFormField.tsx
+++ b/src/components/ProtocolFormField.tsx
@@ -78,7 +78,7 @@ export default class ProtocolFormField extends React.Component<ProtocolFormField
       return (
         <EditableInput
           elementType="input"
-          type="number"
+          validation="number"
           required={setting.required}
           step={1}
           disabled={this.props.disabled}
@@ -247,5 +247,6 @@ export default class ProtocolFormField extends React.Component<ProtocolFormField
     }
     this.setState({ listItems: [] });
   }
+
 
 }

--- a/src/components/__tests__/ProtocolFormField-test.tsx
+++ b/src/components/__tests__/ProtocolFormField-test.tsx
@@ -175,7 +175,7 @@ describe("ProtocolFormField", () => {
 
     let input = wrapper.find(EditableInput);
     expect(input.length).to.equal(1);
-    expect(input.prop("type")).to.equal("number");
+    expect(input.prop("validation")).to.equal("number");
     expect(input.prop("disabled")).to.equal(true);
     expect(input.prop("name")).to.equal("setting");
     expect(input.prop("label")).to.equal("label");


### PR DESCRIPTION
A solution to the `type=number` issue: I wrote a method that prevents the user from entering invalid characters, but submits the input to the server for validation no matter what.