### PR TITLE
Pass down formError, not fetchError.

### DIFF
--- a/src/components/EditableConfigList.tsx
+++ b/src/components/EditableConfigList.tsx
@@ -153,7 +153,7 @@ export abstract class GenericEditableConfigList<T, U, V extends EditableConfigLi
               urlBase={this.urlBase}
               listDataKey={this.listDataKey}
               responseBody={this.props.responseBody}
-              error={this.props.fetchError}
+              error={this.props.formError}
               />
           </div>
         }
@@ -169,7 +169,7 @@ export abstract class GenericEditableConfigList<T, U, V extends EditableConfigLi
               urlBase={this.urlBase}
               listDataKey={this.listDataKey}
               responseBody={this.props.responseBody}
-              error={this.props.fetchError}
+              error={this.props.formError}
               />
           </div>
         }


### PR DESCRIPTION
EditableConfigList was passing the wrong error as a prop to the edit forms, so the error fields weren't being highlighted.