### PR TITLE
Allow dollar sign in number field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.0.92",
+  "version": "0.0.94",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5239,12 +5239,12 @@
           "resolved": "http://registry.npmjs.org/react-redux/-/react-redux-4.4.9.tgz",
           "integrity": "sha512-3XS7mjTOcvaP2H5OE/LxEgDHRuEyTZxBRlwvXHzNqYkZdYd7Ra98AimWoDSHP9OcLoydjA1ocgiZxxcqeXj0Sw==",
           "requires": {
-            "create-react-class": "15.6.3",
-            "hoist-non-react-statics": "2.5.5",
-            "invariant": "2.2.2",
-            "lodash": "4.17.5",
-            "loose-envify": "1.3.1",
-            "prop-types": "15.6.0"
+            "create-react-class": "^15.5.1",
+            "hoist-non-react-statics": "^2.5.0",
+            "invariant": "^2.0.0",
+            "lodash": "^4.2.0",
+            "loose-envify": "^1.1.0",
+            "prop-types": "^15.5.4"
           }
         }
       }

--- a/src/components/EditableConfigList.tsx
+++ b/src/components/EditableConfigList.tsx
@@ -76,7 +76,6 @@ export abstract class GenericEditableConfigList<T, U, V extends EditableConfigLi
     let EditForm = this.EditForm;
     let AdditionalContent = this.AdditionalContent || null;
     let headers = this.getHeaders();
-
     return (
       <div className={this.getClassName()}>
         <h2>{headers["h2"]}</h2>

--- a/src/components/EditableInput.tsx
+++ b/src/components/EditableInput.tsx
@@ -121,7 +121,11 @@ export default class EditableInput extends React.Component<EditableInputProps, E
 
   validateNumber(e) {
     const validChars = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", ".", "Enter"];
-    if (validChars.indexOf(e.key) < 0) {
+
+    // An admin might want to type a dollar sign at the beginning of the "maximum amount in fines" field.
+    let allowDollar = ((e.currentTarget.name === "max_outstanding_fines") && (e.target.selectionStart === 0));
+
+    if ((validChars.indexOf(e.key) < 0) && !allowDollar) {
       e.preventDefault();
     }
   }


### PR DESCRIPTION
While QA-ing the number field validations, I discovered that--as evidenced by the libraries which already exist on QA--admins usually want to start the maximum fines field with a dollar sign.  I changed the client-side validation so that you can type in a dollar sign if it's the first character in that field.  I also changed the server-side validation so that you don't get an error message when you submit the resulting string.

In the event that we ever add another case in which people should be allowed to type a non-numeric character into a number field, I'll abstract this out and implement it more elegantly; for now, since it's the only one, hard-coding it seemed good enough.