### PR TITLE
Made it possible to change the order of lanes with the same parent lane.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - "7"
+  - "8"
 
 before_script:
 - export TZ=America/New_York

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v0.0.98
+#### Added
+- Made it possible to change the order of lanes (within the same parent lane) by dragging and dropping on the lanes page.
+
 ### v0.0.97
 #### Added
 - Made it possible for server-side configurations to specify that certain fields should be rendered as textarea elements.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.0.97",
+  "version": "0.0.98",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -7,7 +7,7 @@ import {
   MetadataServicesData, AnalyticsServicesData,
   CDNServicesData, SearchServicesData,
   DiscoveryServicesData, LibraryRegistrationsData,
-  CustomListsData, LanesData,
+  CustomListsData, LanesData, LaneData,
   RolesData, MediaData, LanguagesData, RightsStatusData,
   StorageServicesData, LoggingServicesData, CatalogServicesData,
   SelfTestsData, PatronData
@@ -95,6 +95,7 @@ export default class ActionCreator extends BaseActionCreator {
   static readonly DELETE_LANE = "DELETE_LANE";
   static readonly CHANGE_LANE_VISIBILITY = "CHANGE_LANE_VISIBILITY";
   static readonly RESET_LANES = "RESET_LANES";
+  static readonly CHANGE_LANE_ORDER = "CHANGE_LANE_ORDER";
 
   static readonly EDIT_BOOK_REQUEST = "EDIT_BOOK_REQUEST";
   static readonly EDIT_BOOK_SUCCESS = "EDIT_BOOK_SUCCESS";
@@ -649,6 +650,11 @@ export default class ActionCreator extends BaseActionCreator {
   resetLanes(library: string) {
     const url = "/" + library + "/admin/lanes/reset";
     return this.postForm(ActionCreator.RESET_LANES, url, null).bind(this);
+  }
+
+  changeLaneOrder(library: string, lanes: LaneData[]) {
+    const url = "/" + library + "/admin/lanes/change_order";
+    return this.postJSON<LaneData[]>(ActionCreator.CHANGE_LANE_ORDER, url, lanes).bind(this);
   }
 
   changePassword(data: FormData) {

--- a/src/components/CustomListEntriesEditor.tsx
+++ b/src/components/CustomListEntriesEditor.tsx
@@ -1,8 +1,5 @@
 import * as React from "react";
-const dnd = require("react-beautiful-dnd");
-const DragDropContext = dnd.DragDropContext;
-const Droppable = dnd.Droppable;
-const Draggable = dnd.Draggable;
+import { DragDropContext, Droppable, Draggable } from "react-beautiful-dnd";
 import { CollectionData, BookData } from "opds-web-client/lib/interfaces";
 import LoadButton from "./LoadButton";
 import ApplyIcon from "./icons/ApplyIcon";

--- a/src/components/IndividualAdminEditForm.tsx
+++ b/src/components/IndividualAdminEditForm.tsx
@@ -183,7 +183,6 @@ export default class IndividualAdminEditForm extends React.Component<IndividualA
           disabled={this.props.disabled}
           submit={this.submit}
           text="Submit"
-          form={this.refs}
         />
       </form>
     );

--- a/src/components/LaneCustomListsEditor.tsx
+++ b/src/components/LaneCustomListsEditor.tsx
@@ -1,8 +1,5 @@
 import * as React from "react";
-const dnd = require("react-beautiful-dnd");
-const DragDropContext = dnd.DragDropContext;
-const Droppable = dnd.Droppable;
-const Draggable = dnd.Draggable;
+import { DragDropContext, Droppable, Draggable } from "react-beautiful-dnd";
 import { CustomListData } from "../interfaces";
 import AddIcon from "./icons/AddIcon";
 import TrashIcon from "./icons/TrashIcon";

--- a/src/components/Lanes.tsx
+++ b/src/components/Lanes.tsx
@@ -12,6 +12,7 @@ import LaneEditor from "./LaneEditor";
 import LoadingIndicator from "opds-web-client/lib/components/LoadingIndicator";
 import ErrorMessage from "./ErrorMessage";
 import EditableInput from "./EditableInput";
+import SaveButton from "./SaveButton";
 import AddIcon from "./icons/AddIcon";
 import GrabIcon from "./icons/GrabIcon";
 import PencilIcon from "./icons/PencilIcon";
@@ -138,12 +139,12 @@ export class Lanes extends React.Component<LanesProps, LanesState> {
           { this.state.orderChanged &&
             <div className="order-change-info">
               <h2>Change Lane Order</h2>
-              <button
-                className="save-order btn btn-default"
-                onClick={this.saveOrder}
+              <SaveButton
+                submit={this.saveOrder}
+                disabled={this.props.isFetching}
+                text="Save Order Changes"
                 >
-                Save Order Changes
-              </button>
+              </SaveButton>
               <a
                 href="#"
                 className="cancel-order-changes"

--- a/src/components/Lanes.tsx
+++ b/src/components/Lanes.tsx
@@ -248,16 +248,9 @@ export class Lanes extends React.Component<LanesProps, LanesState> {
           <div className={"lane-info" + (provided ? " draggable" : "")}>
             <span>
               { snapshot && <GrabIcon /> }
-              { this.isExpanded(lane) &&
-                <div className="collapse-button" onClick={() => { this.toggle(lane); }}>
-                  <PyramidIcon />
-                </div>
-              }
-              { !this.isExpanded(lane) &&
-                <div className="expand-button" onClick={() => { this.toggle(lane); }}>
-                  <PyramidIcon />
-                </div>
-              }
+              <div className={this.isExpanded(lane) ? "collapse-button" :  "expand-button"} onClick={() => { this.toggle(lane); }}>
+                <PyramidIcon />
+              </div>
               { lane.display_name + " (" + lane.count + ")" }
             </span>
             { lane.visible && !this.state.orderChanged &&

--- a/src/components/Lanes.tsx
+++ b/src/components/Lanes.tsx
@@ -477,7 +477,7 @@ export class Lanes extends React.Component<LanesProps, LanesState> {
       lanesToUpdate = lanes;
     }
 
-    lanesToUpdate = lanesToUpdate.slice(0, oldIndex).concat(lanesToUpdate.slice(oldIndex + 1, lanes.length));
+    lanesToUpdate = lanesToUpdate.slice(0, oldIndex).concat(lanesToUpdate.slice(oldIndex + 1, lanesToUpdate.length));
     lanesToUpdate.splice(newIndex, 0, draggedLane);
 
     if (parent) {

--- a/src/components/Lanes.tsx
+++ b/src/components/Lanes.tsx
@@ -202,92 +202,106 @@ export class Lanes extends React.Component<LanesProps, LanesState> {
     const draggingLane = this.findLaneForIdentifier(this.state.lanes, this.state.draggableId);
     const disabled = this.isDropDisabled(draggingLane, parent);
 
-    return (
-      <Droppable
-        droppableId={parent ? String(parent.id) : "top"}
-        isDropDisabled={disabled}
-        >
-        {(provided, snapshot) => (
-          <ul
-            ref={provided.innerRef}
-            className={(snapshot.isDraggingOver && !disabled) ? "droppable dragging-over" : "droppable"}
-            >
-            { lanes.map(lane =>
-                <Draggable draggableId={String(lane.id)} key={lane.id}>
-                {(provided, snapshot) => (
-                    <li>
-                      <div
-                        className={(snapshot.isDragging ? "dragging " : " ") + ((String(lane.id) === this.props.identifier) ? "active" : "")}
-                        ref={provided.innerRef}
-                        style={provided.draggableStyle}
-                        {...provided.dragHandleProps}
-                        >
-                        <div className="lane-info">
-                          <span>
-                            <GrabIcon />
-                            { this.isExpanded(lane) &&
-                              <div className="collapse-button" onClick={() => { this.toggle(lane); }}>
-                                <PyramidIcon />
-                              </div>
-                            }
-                            { !this.isExpanded(lane) &&
-                              <div className="expand-button" onClick={() => { this.toggle(lane); }}>
-                                <PyramidIcon />
-                              </div>
-                            }
-                            { lane.display_name + " (" + lane.count + ")" }
-                          </span>
-                          { lane.visible &&
-                            <a
-                              className="hide-lane"
-                              href="#"
-                              onClick={() => { this.hideLane(lane); }}
-                              >Visible <VisibleIcon /></a>
-                          }
-                          { !lane.visible &&
-                            (!parent || (parent && parent.visible)) &&
-                            <a
-                              className="show-lane"
-                              href="#"
-                              onClick={() => { this.showLane(lane); }}
-                              >Hidden <HiddenIcon /></a>
-                          }
-                          { !lane.visible &&
-                            (parent && !parent.visible) &&
-                            <span>Hidden <HiddenIcon /></span>
-                          }
-                        </div>
-                        { this.isExpanded(lane) &&
-                          <div className="lane-buttons">
-                            { lane.custom_list_ids && lane.custom_list_ids.length > 0 &&
-                              <Link
-                                className="edit-lane btn btn-default"
-                                to={"/admin/web/lanes/" + this.props.library + "/edit/" + lane.id }
-                                >
-                                Edit Lane
-                                <PencilIcon />
-                              </Link>
-                            }
-                            <Link
-                              className="create-lane btn btn-default"
-                              to={"/admin/web/lanes/" + this.props.library + "/create/" + lane.id }
-                              >
-                                Create Sublane
-                                <AddIcon />
-                            </Link>
-                          </div>
-                        }
-                        { this.isExpanded(lane) && lane.sublanes && lane.sublanes.length > 0 && this.renderLanes(lane.sublanes, lane) }
-                      </div>
-                      { provided.placeholder }
-                    </li>
-                  )}
-                </Draggable>
+    if (lanes.length > 1) {
+      return (
+        <Droppable
+          droppableId={parent ? String(parent.id) : "top"}
+          isDropDisabled={disabled}
+          >
+          {(provided, snapshot) => (
+            <ul
+              ref={provided.innerRef}
+              className={(snapshot.isDraggingOver && !disabled) ? "droppable dragging-over" : "droppable"}
+              >
+              { lanes.map(lane =>
+                  <Draggable draggableId={String(lane.id)} key={lane.id}>
+                    {(provided, snapshot) => this.renderLane(lane, parent, provided, snapshot) }
+                  </Draggable>
               )}
               { provided.placeholder }
-          </ul>
-        )}
-      </Droppable>
+            </ul>
+          )}
+        </Droppable>
+      );
+    }
+    if (lanes.length === 1) {
+      return (
+        <ul>
+          { this.renderLane(lanes[0], parent) }
+        </ul>
+      );
+    }
+    return null;
+  }
+
+  renderLane(lane: LaneData, parent: LaneData | null, provided?, snapshot?) {
+    return (
+      <li>
+        <div
+          className={(snapshot && snapshot.isDragging ? "dragging " : " ") + ((String(lane.id) === this.props.identifier) ? "active" : "")}
+          ref={provided && provided.innerRef}
+          style={provided && provided.draggableStyle}
+          {...(provided ? provided.dragHandleProps : {})}
+          >
+          <div className={"lane-info" + (provided ? " draggable" : "")}>
+            <span>
+              { snapshot && <GrabIcon /> }
+              { this.isExpanded(lane) &&
+                <div className="collapse-button" onClick={() => { this.toggle(lane); }}>
+                  <PyramidIcon />
+                </div>
+              }
+              { !this.isExpanded(lane) &&
+                <div className="expand-button" onClick={() => { this.toggle(lane); }}>
+                  <PyramidIcon />
+                </div>
+              }
+              { lane.display_name + " (" + lane.count + ")" }
+            </span>
+            { lane.visible &&
+              <a
+                className="hide-lane"
+                href="#"
+                onClick={() => { this.hideLane(lane); }}
+                >Visible <VisibleIcon /></a>
+            }
+            { !lane.visible &&
+              (!parent || (parent && parent.visible)) &&
+              <a
+                className="show-lane"
+                href="#"
+                onClick={() => { this.showLane(lane); }}
+                >Hidden <HiddenIcon /></a>
+            }
+            { !lane.visible &&
+              (parent && !parent.visible) &&
+              <span>Hidden <HiddenIcon /></span>
+            }
+          </div>
+          { this.isExpanded(lane) &&
+            <div className="lane-buttons">
+              { lane.custom_list_ids && lane.custom_list_ids.length > 0 &&
+                <Link
+                  className="edit-lane btn btn-default"
+                  to={"/admin/web/lanes/" + this.props.library + "/edit/" + lane.id }
+                  >
+                  Edit Lane
+                  <PencilIcon />
+                </Link>
+              }
+              <Link
+                className="create-lane btn btn-default"
+                to={"/admin/web/lanes/" + this.props.library + "/create/" + lane.id }
+                >
+                  Create Sublane
+                  <AddIcon />
+              </Link>
+            </div>
+          }
+          { this.isExpanded(lane) && lane.sublanes && lane.sublanes.length > 0 && this.renderLanes(lane.sublanes, lane) }
+        </div>
+        { provided && provided.placeholder }
+      </li>
     );
   }
 

--- a/src/components/Lanes.tsx
+++ b/src/components/Lanes.tsx
@@ -1,8 +1,5 @@
 import * as React from "react";
-const dnd = require("react-beautiful-dnd");
-const DragDropContext = dnd.DragDropContext;
-const Droppable = dnd.Droppable;
-const Draggable = dnd.Draggable;
+import { DragDropContext, Droppable, Draggable } from "react-beautiful-dnd";
 import { Store } from "redux";
 import { connect } from "react-redux";
 import { Link } from "react-router";

--- a/src/components/Lanes.tsx
+++ b/src/components/Lanes.tsx
@@ -1,4 +1,8 @@
 import * as React from "react";
+const dnd = require("react-beautiful-dnd");
+const DragDropContext = dnd.DragDropContext;
+const Droppable = dnd.Droppable;
+const Draggable = dnd.Draggable;
 import { Store } from "redux";
 import { connect } from "react-redux";
 import { Link } from "react-router";
@@ -12,11 +16,13 @@ import LoadingIndicator from "opds-web-client/lib/components/LoadingIndicator";
 import ErrorMessage from "./ErrorMessage";
 import EditableInput from "./EditableInput";
 import AddIcon from "./icons/AddIcon";
+import GrabIcon from "./icons/GrabIcon";
 import PencilIcon from "./icons/PencilIcon";
 import PyramidIcon from "./icons/PyramidIcon";
 import ResetIcon from "./icons/ResetIcon";
 import VisibleIcon from "./icons/VisibleIcon";
 import HiddenIcon from "./icons/HiddenIcon";
+import XCloseIcon from "./icons/XCloseIcon";
 
 export interface LanesStateProps {
   lanes: LaneData[];
@@ -35,6 +41,7 @@ export interface LanesDispatchProps {
   showLane: (laneIdentifier: string) => Promise<void>;
   hideLane: (laneIdentifier: string) => Promise<void>;
   resetLanes: () => Promise<void>;
+  changeLaneOrder: (lanes: LaneData[]) => Promise<void>;
 }
 
 export interface LanesOwnProps {
@@ -51,6 +58,10 @@ export interface LanesState {
   expanded: {
     [key: string]: boolean;
   };
+  draggableId: string | null;
+  draggingFrom: string | null;
+  lanes: LaneData[];
+  orderChanged: boolean;
 }
 
 /** Body of the lanes page, with all a library's lanes shown in a left sidebar and
@@ -64,6 +75,10 @@ export class Lanes extends React.Component<LanesProps, LanesState> {
     this.showLane = this.showLane.bind(this);
     this.resetLanes = this.resetLanes.bind(this);
     this.toggle = this.toggle.bind(this);
+    this.resetOrder = this.resetOrder.bind(this);
+    this.onDragStart = this.onDragStart.bind(this);
+    this.onDragEnd = this.onDragEnd.bind(this);
+    this.saveOrder = this.saveOrder.bind(this);
 
     const expanded: { [key: string]: boolean } = {};
     for (const topLevelLane of this.props.lanes || []) {
@@ -71,8 +86,21 @@ export class Lanes extends React.Component<LanesProps, LanesState> {
     }
 
     this.state = {
-      expanded: expanded
+      expanded: expanded,
+      draggableId: null,
+      draggingFrom: null,
+      lanes: this.copyLanes(this.props.lanes || []),
+      orderChanged: false
     };
+  }
+
+  private copyLanes(lanes: LaneData[]): LaneData[] {
+    const copy = (lane) => {
+      return Object.assign({}, lane, {
+        sublanes: lane.sublanes.map(copy)
+      });
+    };
+    return lanes.map(copy);
   }
 
   render(): JSX.Element {
@@ -89,21 +117,42 @@ export class Lanes extends React.Component<LanesProps, LanesState> {
         <div className="lanes">
           <div className="lanes-sidebar">
             <h2>Lane Manager</h2>
-            <Link
-              className="create-lane btn btn-default"
-              to={"/admin/web/lanes/" + this.props.library + "/create"}
-              >
-                Create Top-Level Lane
-                <AddIcon />
-            </Link>
-            <Link
-              className="reset-lanes btn"
-              to={"/admin/web/lanes/" + this.props.library + "/reset"}
-              >
-                Reset all lanes
-                <ResetIcon />
-            </Link>
-            { this.props.lanes && this.props.lanes.length > 0 && this.renderLanes(this.props.lanes, null) }
+            <div>
+              <Link
+                className="create-lane btn btn-default"
+                to={"/admin/web/lanes/" + this.props.library + "/create"}
+                >
+                  Create Top-Level Lane
+                  <AddIcon />
+              </Link>
+              <Link
+                className="reset-lanes btn"
+                to={"/admin/web/lanes/" + this.props.library + "/reset"}
+                >
+                  Reset all lanes
+                  <ResetIcon />
+              </Link>
+            </div>
+            { this.state.orderChanged &&
+              <div>
+                <button
+                  className="save-order btn btn-default"
+                  onClick={this.saveOrder}
+                  >
+                  Save Order Changes
+                </button>
+                <a
+                  href="#"
+                  className="cancel-order-changes"
+                  onClick={this.resetOrder}
+                  >Cancel
+                    <XCloseIcon />
+                </a>
+              </div>
+            }
+            <DragDropContext onDragStart={this.onDragStart} onDragEnd={this.onDragEnd}>
+              { this.state.lanes && this.state.lanes.length > 0 && this.renderLanes(this.state.lanes, null) }
+            </DragDropContext>
           </div>
 
           { this.props.editOrCreate === "create" &&
@@ -150,72 +199,95 @@ export class Lanes extends React.Component<LanesProps, LanesState> {
   }
 
   renderLanes(lanes: LaneData[], parent: LaneData | null): JSX.Element {
+    const draggingLane = this.findLaneForIdentifier(this.state.lanes, this.state.draggableId);
+    const disabled = this.isDropDisabled(draggingLane, parent);
+
     return (
-      <ul>
-        { lanes.map(lane =>
-            <li
-              key={lane.display_name.replace(" ", "").trim()}
-              className={(String(lane.id) === this.props.identifier) ? "active" : ""}
+      <Droppable
+        droppableId={parent ? String(parent.id) : "top"}
+        isDropDisabled={disabled}
+        >
+        {(provided, snapshot) => (
+          <ul
+            ref={provided.innerRef}
+            className={(snapshot.isDraggingOver && !disabled) ? "droppable dragging-over" : "droppable"}
             >
-              <div>
-                <span>
-                  { this.isExpanded(lane) &&
-                    <div className="collapse-button" onClick={() => { this.toggle(lane); }}>
-                      <PyramidIcon />
-                    </div>
-                  }
-                  { !this.isExpanded(lane) &&
-                    <div className="expand-button" onClick={() => { this.toggle(lane); }}>
-                      <PyramidIcon />
-                    </div>
-                  }
-                  { lane.display_name + " (" + lane.count + ")" }
-                </span>
-                { lane.visible &&
-                  <a
-                    className="hide-lane"
-                    href="#"
-                    onClick={() => { this.hideLane(lane); }}
-                    >Visible <VisibleIcon /></a>
-                }
-                { !lane.visible &&
-                  (!parent || (parent && parent.visible)) &&
-                  <a
-                    className="show-lane"
-                    href="#"
-                    onClick={() => { this.showLane(lane); }}
-                    >Hidden <HiddenIcon /></a>
-                }
-                { !lane.visible &&
-                  (parent && !parent.visible) &&
-                  <span>Hidden <HiddenIcon /></span>
-                }
-              </div>
-              { this.isExpanded(lane) &&
-                <div className="lane-buttons">
-                  { lane.custom_list_ids && lane.custom_list_ids.length > 0 &&
-                    <Link
-                      className="edit-lane btn btn-default"
-                      to={"/admin/web/lanes/" + this.props.library + "/edit/" + lane.id }
-                      >
-                      Edit Lane
-                      <PencilIcon />
-                    </Link>
-                  }
-                  <Link
-                    className="create-lane btn btn-default"
-                    to={"/admin/web/lanes/" + this.props.library + "/create/" + lane.id }
-                    >
-                      Create Sublane
-                      <AddIcon />
-                  </Link>
-                </div>
-              }
-              { this.isExpanded(lane) && lane.sublanes && lane.sublanes.length > 0 && this.renderLanes(lane.sublanes, lane) }
-            </li>
-          )
-        }
-      </ul>
+            { lanes.map(lane =>
+                <Draggable draggableId={String(lane.id)} key={lane.id}>
+                {(provided, snapshot) => (
+                    <li>
+                      <div
+                        className={(snapshot.isDragging ? "dragging " : " ") + ((String(lane.id) === this.props.identifier) ? "active" : "")}
+                        ref={provided.innerRef}
+                        style={provided.draggableStyle}
+                        {...provided.dragHandleProps}
+                        >
+                        <div className="lane-info">
+                          <span>
+                            <GrabIcon />
+                            { this.isExpanded(lane) &&
+                              <div className="collapse-button" onClick={() => { this.toggle(lane); }}>
+                                <PyramidIcon />
+                              </div>
+                            }
+                            { !this.isExpanded(lane) &&
+                              <div className="expand-button" onClick={() => { this.toggle(lane); }}>
+                                <PyramidIcon />
+                              </div>
+                            }
+                            { lane.display_name + " (" + lane.count + ")" }
+                          </span>
+                          { lane.visible &&
+                            <a
+                              className="hide-lane"
+                              href="#"
+                              onClick={() => { this.hideLane(lane); }}
+                              >Visible <VisibleIcon /></a>
+                          }
+                          { !lane.visible &&
+                            (!parent || (parent && parent.visible)) &&
+                            <a
+                              className="show-lane"
+                              href="#"
+                              onClick={() => { this.showLane(lane); }}
+                              >Hidden <HiddenIcon /></a>
+                          }
+                          { !lane.visible &&
+                            (parent && !parent.visible) &&
+                            <span>Hidden <HiddenIcon /></span>
+                          }
+                        </div>
+                        { this.isExpanded(lane) &&
+                          <div className="lane-buttons">
+                            { lane.custom_list_ids && lane.custom_list_ids.length > 0 &&
+                              <Link
+                                className="edit-lane btn btn-default"
+                                to={"/admin/web/lanes/" + this.props.library + "/edit/" + lane.id }
+                                >
+                                Edit Lane
+                                <PencilIcon />
+                              </Link>
+                            }
+                            <Link
+                              className="create-lane btn btn-default"
+                              to={"/admin/web/lanes/" + this.props.library + "/create/" + lane.id }
+                              >
+                                Create Sublane
+                                <AddIcon />
+                            </Link>
+                          </div>
+                        }
+                        { this.isExpanded(lane) && lane.sublanes && lane.sublanes.length > 0 && this.renderLanes(lane.sublanes, lane) }
+                      </div>
+                      { provided.placeholder }
+                    </li>
+                  )}
+                </Draggable>
+              )}
+              { provided.placeholder }
+          </ul>
+        )}
+      </Droppable>
     );
   }
 
@@ -226,7 +298,7 @@ export class Lanes extends React.Component<LanesProps, LanesState> {
   toggle(lane) {
     const expanded = Object.assign({}, this.state.expanded);
     expanded[lane.id] = !expanded[lane.id];
-    this.setState({ expanded });
+    this.setState({ ...this.state, expanded });
   }
 
   componentWillReceiveProps(nextProps) {
@@ -235,7 +307,14 @@ export class Lanes extends React.Component<LanesProps, LanesState> {
       for (const topLevelLane of nextProps.lanes || []) {
         expanded[topLevelLane.id] = true;
       }
-      this.setState({ expanded });
+      const lanes = this.copyLanes(nextProps.lanes);
+      this.setState({
+        expanded,
+        lanes,
+        draggingFrom: null,
+        draggableId: null,
+        orderChanged: false
+      });
     }
   }
 
@@ -246,6 +325,15 @@ export class Lanes extends React.Component<LanesProps, LanesState> {
     if (this.props.fetchCustomLists) {
       this.props.fetchCustomLists();
     }
+  }
+
+  resetOrder() {
+    this.setState({ ...this.state, lanes: this.props.lanes, orderChanged: false });
+  }
+
+  async saveOrder() {
+    await this.props.changeLaneOrder(this.state.lanes);
+    this.props.fetchLanes();
   }
 
   async editLane(data: FormData): Promise<void> {
@@ -280,7 +368,7 @@ export class Lanes extends React.Component<LanesProps, LanesState> {
 
   private findLaneForIdentifier(lanes, identifier): LaneData | null {
     for (const lane of lanes) {
-      if (String(lane.id) === identifier) {
+      if (String(lane.id) === String(identifier)) {
         return lane;
       }
       const sublaneMatch = this.findLaneForIdentifier(lane.sublanes, identifier);
@@ -307,7 +395,7 @@ export class Lanes extends React.Component<LanesProps, LanesState> {
 
   findParentOfLane(lane: LaneData, lanes?: LaneData[]): LaneData {
     if (!lanes) {
-      lanes = this.props.lanes || [];
+      lanes = this.state.lanes || [];
     }
 
     for (const possibleParent of lanes) {
@@ -324,6 +412,88 @@ export class Lanes extends React.Component<LanesProps, LanesState> {
     }
     return null;
   }
+
+  isDropDisabled(draggingLane: LaneData | null, toLane: LaneData | null) {
+    if (!draggingLane) {
+      return false;
+    }
+
+    // You can only drag a lane within its parent. It would be nice
+    // to change the parent by dragging, but it's difficult because
+    // dragging a child can cause the parent to move and mess up
+    // the positioning of the dragging child.
+
+    const draggingParent = this.findParentOfLane(draggingLane);
+    if (draggingParent && toLane === null) {
+      return true;
+    }
+    if (!draggingParent && toLane !== null) {
+      return true;
+    }
+    if (draggingParent && toLane && (draggingParent.id !== toLane.id)) {
+      return true;
+    }
+    return false;
+  }
+
+  onDragStart(initial) {
+    document.body.classList.add("dragging");
+    const draggableId = initial.draggableId;
+    const source = initial.source;
+    this.setState({
+      ...this.state,
+      draggableId,
+      draggingFrom: source.droppableId
+    });
+  }
+
+  onDragEnd(result) {
+    document.body.classList.remove("dragging");
+    const {
+      draggableId,
+      destination,
+      source
+    } = result;
+
+    if (destination.droppableId !== source.droppableId) {
+      return;
+    }
+
+    const oldIndex = source.index;
+    const newIndex = destination.index;
+
+    if (oldIndex === newIndex) {
+      return;
+    }
+
+    let lanes = this.state.lanes;
+    const draggedLane = this.findLaneForIdentifier(lanes, draggableId);
+    const parent = this.findParentOfLane(draggedLane, lanes);
+
+    let lanesToUpdate;
+    if (parent) {
+      lanesToUpdate = parent.sublanes;
+    } else {
+      lanesToUpdate = lanes;
+    }
+
+    lanesToUpdate = lanesToUpdate.slice(0, oldIndex).concat(lanesToUpdate.slice(oldIndex + 1, lanes.length));
+    lanesToUpdate.splice(newIndex, 0, draggedLane);
+
+    if (parent) {
+      parent.sublanes = lanesToUpdate;
+    } else {
+      lanes = lanesToUpdate;
+    }
+
+    this.setState({
+      ...this.state,
+      draggableId: null,
+      draggingFrom: null,
+      lanes,
+      orderChanged: true
+    });
+  }
 }
 
 function mapStateToProps(state, ownProps) {
@@ -331,9 +501,9 @@ function mapStateToProps(state, ownProps) {
     lanes: state.editor.lanes && state.editor.lanes.data && state.editor.lanes.data.lanes,
     responseBody: state.editor.lanes && state.editor.lanes.successMessage,
     customLists: state.editor.customLists && state.editor.customLists.data && state.editor.customLists.data.custom_lists,
-    fetchError: state.editor.lanes.fetchError || state.editor.laneVisibility.fetchError,
+    fetchError: state.editor.lanes.fetchError || state.editor.laneVisibility.fetchError || state.editor.laneOrder.fetchError,
     formError: state.editor.lanes.formError || state.editor.laneVisibility.formError,
-    isFetching: state.editor.lanes.isFetching || state.editor.lanes.isEditing || state.editor.laneVisibility.isFetching || state.editor.customLists.isFetching || state.editor.resetLanes.isFetching
+    isFetching: state.editor.lanes.isFetching || state.editor.lanes.isEditing || state.editor.laneVisibility.isFetching || state.editor.customLists.isFetching || state.editor.resetLanes.isFetching || state.editor.laneOrder.isFetching
   };
 }
 
@@ -347,7 +517,8 @@ function mapDispatchToProps(dispatch, ownProps) {
     deleteLane: (identifier: string) => dispatch(actions.deleteLane(ownProps.library, identifier)),
     showLane: (identifier: string) => dispatch(actions.showLane(ownProps.library, identifier)),
     hideLane: (identifier: string) => dispatch(actions.hideLane(ownProps.library, identifier)),
-    resetLanes: () => dispatch(actions.resetLanes(ownProps.library))
+    resetLanes: () => dispatch(actions.resetLanes(ownProps.library)),
+    changeLaneOrder: (lanes: LaneData[]) => dispatch(actions.changeLaneOrder(ownProps.library, lanes))
   };
 }
 

--- a/src/components/Lanes.tsx
+++ b/src/components/Lanes.tsx
@@ -116,15 +116,15 @@ export class Lanes extends React.Component<LanesProps, LanesState> {
             <h2>Lane Manager</h2>
             <div>
               <Link
-                className="create-lane btn btn-default"
-                to={"/admin/web/lanes/" + this.props.library + "/create"}
+                className={"create-lane btn btn-default" + (this.state.orderChanged ? " disabled" : "")}
+                to={this.state.orderChanged ? null : ("/admin/web/lanes/" + this.props.library + "/create")}
                 >
                   Create Top-Level Lane
                   <AddIcon />
               </Link>
               <Link
-                className="reset-lanes btn"
-                to={"/admin/web/lanes/" + this.props.library + "/reset"}
+                className={"reset-lanes btn" + (this.state.orderChanged ? " disabled" : "")}
+                to={this.state.orderChanged ? null : ("/admin/web/lanes/" + this.props.library + "/reset")}
                 >
                   Reset all lanes
                   <ResetIcon />
@@ -255,14 +255,17 @@ export class Lanes extends React.Component<LanesProps, LanesState> {
               }
               { lane.display_name + " (" + lane.count + ")" }
             </span>
-            { lane.visible &&
+            { lane.visible && !this.state.orderChanged &&
               <a
                 className="hide-lane"
                 href="#"
                 onClick={() => { this.hideLane(lane); }}
                 >Visible <VisibleIcon /></a>
             }
-            { !lane.visible &&
+            { lane.visible && this.state.orderChanged &&
+              <span>Visible <VisibleIcon /></span>
+            }
+            { !lane.visible && !this.state.orderChanged &&
               (!parent || (parent && parent.visible)) &&
               <a
                 className="show-lane"
@@ -271,7 +274,7 @@ export class Lanes extends React.Component<LanesProps, LanesState> {
                 >Hidden <HiddenIcon /></a>
             }
             { !lane.visible &&
-              (parent && !parent.visible) &&
+              (this.state.orderChanged || (parent && !parent.visible)) &&
               <span>Hidden <HiddenIcon /></span>
             }
           </div>
@@ -279,16 +282,16 @@ export class Lanes extends React.Component<LanesProps, LanesState> {
             <div className="lane-buttons">
               { lane.custom_list_ids && lane.custom_list_ids.length > 0 &&
                 <Link
-                  className="edit-lane btn btn-default"
-                  to={"/admin/web/lanes/" + this.props.library + "/edit/" + lane.id }
+                  className={"edit-lane btn btn-default" + (this.state.orderChanged ? " disabled" : "")}
+                  to={this.state.orderChanged ? null : "/admin/web/lanes/" + this.props.library + "/edit/" + lane.id }
                   >
                   Edit Lane
                   <PencilIcon />
                 </Link>
               }
               <Link
-                className="create-lane btn btn-default"
-                to={"/admin/web/lanes/" + this.props.library + "/create/" + lane.id }
+                className={"create-lane btn btn-default" + (this.state.orderChanged ? " disabled" : "")}
+                to={this.state.orderChanged ? null : "/admin/web/lanes/" + this.props.library + "/create/" + lane.id }
                 >
                   Create Sublane
                   <AddIcon />

--- a/src/components/Lanes.tsx
+++ b/src/components/Lanes.tsx
@@ -130,29 +130,33 @@ export class Lanes extends React.Component<LanesProps, LanesState> {
                   <ResetIcon />
               </Link>
             </div>
-            { this.state.orderChanged &&
-              <div>
-                <button
-                  className="save-order btn btn-default"
-                  onClick={this.saveOrder}
-                  >
-                  Save Order Changes
-                </button>
-                <a
-                  href="#"
-                  className="cancel-order-changes"
-                  onClick={this.resetOrder}
-                  >Cancel
-                    <XCloseIcon />
-                </a>
-              </div>
-            }
             <DragDropContext onDragStart={this.onDragStart} onDragEnd={this.onDragEnd}>
               { this.state.lanes && this.state.lanes.length > 0 && this.renderLanes(this.state.lanes, null) }
             </DragDropContext>
           </div>
 
-          { this.props.editOrCreate === "create" &&
+          { this.state.orderChanged &&
+            <div className="order-change-info">
+              <h2>Change Lane Order</h2>
+              <button
+                className="save-order btn btn-default"
+                onClick={this.saveOrder}
+                >
+                Save Order Changes
+              </button>
+              <a
+                href="#"
+                className="cancel-order-changes"
+                onClick={this.resetOrder}
+                >Cancel
+                  <XCloseIcon />
+              </a>
+              <hr />
+              <p>Save or cancel your changes to the lane order before making additional changes.</p>
+            </div>
+          }
+
+          { !this.state.orderChanged && this.props.editOrCreate === "create" &&
             <LaneEditor
               library={this.props.library}
               parent={this.parentOfNewLane()}
@@ -162,7 +166,7 @@ export class Lanes extends React.Component<LanesProps, LanesState> {
               />
           }
 
-          { this.laneToEdit() &&
+          { !this.state.orderChanged && this.laneToEdit() &&
             <LaneEditor
               library={this.props.library}
               lane={this.laneToEdit()}
@@ -175,7 +179,7 @@ export class Lanes extends React.Component<LanesProps, LanesState> {
               />
           }
 
-          { this.props.editOrCreate === "reset" &&
+          { !this.state.orderChanged && this.props.editOrCreate === "reset" &&
             <div className="reset">
               <h2>Reset all lanes</h2>
               <p>This will delete all lanes for the library and automatically generate new lanes based on the library's language configuration or the languages in the library's collection.</p>

--- a/src/components/Lanes.tsx
+++ b/src/components/Lanes.tsx
@@ -475,6 +475,7 @@ export class Lanes extends React.Component<LanesProps, LanesState> {
     const newIndex = destination.index;
 
     if (oldIndex === newIndex) {
+      // The lane was dropped back to its original position.
       return;
     }
 
@@ -482,6 +483,8 @@ export class Lanes extends React.Component<LanesProps, LanesState> {
     const draggedLane = this.findLaneForIdentifier(lanes, draggableId);
     const parent = this.findParentOfLane(draggedLane, lanes);
 
+    // If the lane has a parent, we'll update its position within its parents'
+    // sublanes. Otherwise, we'll update its position at the top-level.
     let lanesToUpdate;
     if (parent) {
       lanesToUpdate = parent.sublanes;
@@ -489,9 +492,12 @@ export class Lanes extends React.Component<LanesProps, LanesState> {
       lanesToUpdate = lanes;
     }
 
+    // Remove the lane from its old position.
     lanesToUpdate = lanesToUpdate.slice(0, oldIndex).concat(lanesToUpdate.slice(oldIndex + 1, lanesToUpdate.length));
+    // Put it back in its new position.
     lanesToUpdate.splice(newIndex, 0, draggedLane);
 
+    // Actually update the lanes.
     if (parent) {
       parent.sublanes = lanesToUpdate;
     } else {

--- a/src/components/Lanes.tsx
+++ b/src/components/Lanes.tsx
@@ -455,7 +455,7 @@ export class Lanes extends React.Component<LanesProps, LanesState> {
       source
     } = result;
 
-    if (destination.droppableId !== source.droppableId) {
+    if (!destination || !source || (destination.droppableId !== source.droppableId)) {
       return;
     }
 

--- a/src/components/LibraryEditForm.tsx
+++ b/src/components/LibraryEditForm.tsx
@@ -139,7 +139,6 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
           disabled={this.props.disabled}
           submit={this.submit}
           text="Submit"
-          form={this.refs}
         />
       </form>
     );

--- a/src/components/SaveButton.tsx
+++ b/src/components/SaveButton.tsx
@@ -3,7 +3,6 @@ import * as React from "react";
 export interface SaveButtonProps {
   disabled: boolean;
   submit?: any;
-  form: any;
   text?: string;
 }
 

--- a/src/components/ServiceEditForm.tsx
+++ b/src/components/ServiceEditForm.tsx
@@ -276,7 +276,6 @@ export default class ServiceEditForm<T extends ServicesData> extends React.Compo
           disabled={this.props.disabled}
           submit={this.submit}
           text="Submit"
-          form={this.refs}
         />
       </form>
     );

--- a/src/components/SitewideSettingEditForm.tsx
+++ b/src/components/SitewideSettingEditForm.tsx
@@ -104,7 +104,6 @@ export default class SitewideSettingEditForm extends React.Component<SitewideSet
               disabled={this.props.disabled}
               submit={this.submit}
               text="Submit"
-              form={this.refs}
             />
           </form>
         }

--- a/src/components/__tests__/CustomListEntriesEditor-test.tsx
+++ b/src/components/__tests__/CustomListEntriesEditor-test.tsx
@@ -4,9 +4,7 @@ import { stub } from "sinon";
 import * as React from "react";
 import { shallow, mount } from "enzyme";
 
-const dnd = require("react-beautiful-dnd");
-const Droppable = dnd.Droppable;
-const Draggable = dnd.Draggable;
+import { Droppable, Draggable } from "react-beautiful-dnd";
 
 import CustomListEntriesEditor from "../CustomListEntriesEditor";
 

--- a/src/components/__tests__/LaneCustomListsEditor-test.tsx
+++ b/src/components/__tests__/LaneCustomListsEditor-test.tsx
@@ -4,9 +4,7 @@ import { stub } from "sinon";
 import * as React from "react";
 import { shallow, mount } from "enzyme";
 
-const dnd = require("react-beautiful-dnd");
-const Droppable = dnd.Droppable;
-const Draggable = dnd.Draggable;
+import { Droppable, Draggable } from "react-beautiful-dnd";
 
 import LaneCustomListsEditor from "../LaneCustomListsEditor";
 

--- a/src/components/__tests__/Lanes-test.tsx
+++ b/src/components/__tests__/Lanes-test.tsx
@@ -3,10 +3,7 @@ import { stub } from "sinon";
 
 import * as React from "react";
 import { shallow, mount } from "enzyme";
-const dnd = require("react-beautiful-dnd");
-const DragDropContext = dnd.DragDropContext;
-const Droppable = dnd.Droppable;
-const Draggable = dnd.Draggable;
+import { DragDropContext, Droppable, Draggable } from "react-beautiful-dnd";
 
 import { Lanes } from "../Lanes";
 import ErrorMessage from "../ErrorMessage";

--- a/src/components/__tests__/Lanes-test.tsx
+++ b/src/components/__tests__/Lanes-test.tsx
@@ -11,6 +11,7 @@ import LoadingIndicator from "opds-web-client/lib/components/LoadingIndicator";
 import LaneEditor from "../LaneEditor";
 import { Link } from "react-router";
 import EditableInput from "../EditableInput";
+import SaveButton from "../SaveButton";
 import { LaneData } from "../../interfaces";
 
 describe("Lanes", () => {
@@ -466,7 +467,7 @@ describe("Lanes", () => {
     orderInfo = wrapper.find(".order-change-info");
     expect(orderInfo.length).to.equal(1);
 
-    let save = orderInfo.find(".save-order");
+    let save = orderInfo.find(SaveButton);
     expect(save.length).to.equal(1);
     let reset = orderInfo.find(".cancel-order-changes");
     expect(reset.length).to.equal(1);
@@ -673,7 +674,7 @@ describe("Lanes", () => {
     mountWrapper();
     wrapper.setState({ orderChanged: true, lanes: [lanesData[1], lanesData[0]] });
 
-    let saveOrderButton = wrapper.find(".save-order");
+    let saveOrderButton = wrapper.find(SaveButton);
     saveOrderButton.simulate("click");
     expect(changeLaneOrder.callCount).to.equal(1);
     expect(changeLaneOrder.args[0][0]).to.deep.equal([lanesData[1], lanesData[0]]);

--- a/src/components/__tests__/Lanes-test.tsx
+++ b/src/components/__tests__/Lanes-test.tsx
@@ -3,6 +3,10 @@ import { stub } from "sinon";
 
 import * as React from "react";
 import { shallow, mount } from "enzyme";
+const dnd = require("react-beautiful-dnd");
+const DragDropContext = dnd.DragDropContext;
+const Droppable = dnd.Droppable;
+const Draggable = dnd.Draggable;
 
 import { Lanes } from "../Lanes";
 import ErrorMessage from "../ErrorMessage";
@@ -21,6 +25,7 @@ describe("Lanes", () => {
   let showLane;
   let hideLane;
   let resetLanes;
+  let changeLaneOrder;
 
   let customListsData = [
     { id: 1, name: "list 1", entries: [] },
@@ -42,6 +47,36 @@ describe("Lanes", () => {
       custom_list_ids: [], inherit_parent_restrictions: false }
   ];
 
+  const mountWrapper = () => {
+    wrapper = mount(
+      <Lanes
+        csrfToken="token"
+        library="library"
+        lanes={lanesData}
+        customLists={customListsData}
+        isFetching={false}
+        fetchLanes={fetchLanes}
+        fetchCustomLists={fetchCustomLists}
+        editLane={editLane}
+        deleteLane={deleteLane}
+        showLane={showLane}
+        hideLane={hideLane}
+        resetLanes={resetLanes}
+        changeLaneOrder={changeLaneOrder}
+        />
+    );
+  };
+
+  const getTopLevelLanes = () => {
+    let sidebar = wrapper.find(".lanes-sidebar");
+    let topLevelLanes = sidebar.children(DragDropContext).children(Draggable).children("div");
+    return topLevelLanes;
+  };
+
+  const getDroppableById = (id) => {
+    return wrapper.find(Droppable).filterWhere(node => node.props().droppableId === id);
+  };
+
   beforeEach(() => {
     fetchLanes = stub();
     fetchCustomLists = stub();
@@ -50,6 +85,7 @@ describe("Lanes", () => {
     showLane = stub().returns(new Promise<void>(resolve => resolve()));
     hideLane = stub().returns(new Promise<void>(resolve => resolve()));
     resetLanes = stub().returns(new Promise<void>(resolve => resolve()));
+    changeLaneOrder = stub().returns(new Promise<void>(resolve => resolve()));
 
     wrapper = shallow(
       <Lanes
@@ -65,6 +101,7 @@ describe("Lanes", () => {
         showLane={showLane}
         hideLane={hideLane}
         resetLanes={resetLanes}
+        changeLaneOrder={changeLaneOrder}
         />
     );
   });
@@ -97,18 +134,33 @@ describe("Lanes", () => {
   });
 
   it("renders create top-level lane link", () => {
-    let create = wrapper.find(".lanes-sidebar > .create-lane");
+    let create = wrapper.find(".lanes-sidebar > div > .create-lane");
     expect(create.length).to.equal(1);
     expect(create.props().to).to.equal("/admin/web/lanes/library/create");
   });
 
   it("renders reset link", () => {
-    let reset = wrapper.find(".lanes-sidebar > .reset-lanes");
+    let reset = wrapper.find(".lanes-sidebar .reset-lanes");
     expect(reset.length).to.equal(1);
     expect(reset.props().to).to.equal("/admin/web/lanes/library/reset");
   });
 
+  it("renders save and reset order if order has changed", () => {
+    let save = wrapper.find(".lanes-sidebar .save-order");
+    expect(save.length).to.equal(0);
+    let reset = wrapper.find(".lanes-sidebar .cancel-order-changes");
+    expect(reset.length).to.equal(0);
+
+    wrapper.setState({ orderChanged: true });
+    save = wrapper.find(".lanes-sidebar .save-order");
+    expect(save.length).to.equal(1);
+    reset = wrapper.find(".lanes-sidebar .cancel-order-changes");
+    expect(reset.length).to.equal(1);
+  });
+
   it("renders and expands and collapses lanes and sublanes", () => {
+    mountWrapper();
+
     const expectExpanded = (lane) => {
       let collapse = lane.find("> div > span > .collapse-button");
       expect(collapse.length).to.equal(1);
@@ -125,7 +177,7 @@ describe("Lanes", () => {
       return expand;
     };
 
-    let topLevelLanes = wrapper.find(".lanes-sidebar > ul > li");
+    let topLevelLanes = getTopLevelLanes();
     expect(topLevelLanes.length).to.equal(2);
     let lane1 = topLevelLanes.at(0);
     let lane4 = topLevelLanes.at(1);
@@ -139,27 +191,27 @@ describe("Lanes", () => {
     expectExpanded(lane4);
 
     // lane 1 has one sublane which is collapsed
-    let sublane2 = lane1.find("> ul > li");
+    let sublane2 = lane1.children(Droppable).children(Draggable).children("div");
     expect(sublane2.text()).to.contain("sublane 2");
     expect(sublane2.text()).to.contain("(3)");
     expect(sublane2.length).to.equal(1);
     let sublane2Expand = expectCollapsed(sublane2);
 
     // lane 4 has no sublanes
-    let lane4Sublanes = lane4.find("> ul > li");
+    let lane4Sublanes = lane4.children(Droppable).children(Draggable).children("div");
     expect(lane4Sublanes.length).to.equal(0);
 
     // sublane 2 has a sublane, but it's not shown since sublane 2 is collapsed.
-    let sublane3 = sublane2.find("> ul > li");
+    let sublane3 = sublane2.children(Droppable).children(Draggable).children("div");
     expect(sublane3.length).to.equal(0);
 
     // if we expand sublane 2, we can see sublane 3 below it.
     sublane2Expand.simulate("click");
-    topLevelLanes = wrapper.find(".lanes-sidebar > ul > li");
+    topLevelLanes = getTopLevelLanes();
     lane1 = topLevelLanes.at(0);
-    sublane2 = lane1.find("> ul > li");
+    sublane2 = lane1.children(Droppable).children(Draggable).children("div");
     let sublane2Collapse = expectExpanded(sublane2);
-    sublane3 = sublane2.find("> ul > li");
+    sublane3 = sublane2.children(Droppable).children(Draggable).children("div");
     expect(sublane3.length).to.equal(1);
     expect(sublane3.text()).to.contain("sublane 3");
     expect(sublane3.text()).to.contain("(2)");
@@ -167,121 +219,125 @@ describe("Lanes", () => {
 
     // if we collapse sublane 2, sublane 3 is hidden again.
     sublane2Collapse.simulate("click");
-    topLevelLanes = wrapper.find(".lanes-sidebar > ul > li");
+    topLevelLanes = getTopLevelLanes();
     lane1 = topLevelLanes.at(0);
-    sublane2 = lane1.find("> ul > li");
+    sublane2 = lane1.children(Droppable).children(Draggable).children("div");
     expectCollapsed(sublane2);
-    sublane3 = sublane2.find("> ul > li");
+    sublane3 = sublane2.children(Droppable).children(Draggable).children("div");
     expect(sublane3.length).to.equal(0);
 
     // if we collapse lane 1, sublane 2 is hidden.
     let lane1Collapse = expectExpanded(lane1);
     lane1Collapse.simulate("click");
-    topLevelLanes = wrapper.find(".lanes-sidebar > ul > li");
+    topLevelLanes = getTopLevelLanes();
     lane1 = topLevelLanes.at(0);
     let lane1Expand = expectCollapsed(lane1);
-    sublane2 = lane1.find("> ul > li");
+    sublane2 = lane1.children(Droppable).children(Draggable).children("div");
     expect(sublane2.length).to.equal(0);
 
     // if we expand lane 1, sublane 2 is shown again.
     lane1Expand.simulate("click");
-    topLevelLanes = wrapper.find(".lanes-sidebar > ul > li");
+    topLevelLanes = getTopLevelLanes();
     lane1 = topLevelLanes.at(0);
     expectExpanded(lane1);
-    sublane2 = lane1.find("> ul > li");
+    sublane2 = lane1.children(Droppable).children(Draggable).children("div");
     expect(sublane2.length).to.equal(1);
   });
 
   it("renders active lane", () => {
-    let topLevelLanes = wrapper.find(".lanes-sidebar > ul > li");
+    mountWrapper();
+    let topLevelLanes = getTopLevelLanes();
     let lane1 = topLevelLanes.at(0);
     let lane4 = topLevelLanes.at(1);
-    let sublane2 = lane1.find("> ul > li");
+    let sublane2 = lane1.children(Droppable).children(Draggable).children("div");
     expect(lane1.props().className).not.to.contain("active");
     expect(lane4.props().className).not.to.contain("active");
     expect(sublane2.props().className).not.to.contain("active");
 
     wrapper.setProps({ identifier: "1" });
-    topLevelLanes = wrapper.find(".lanes-sidebar > ul > li");
+    topLevelLanes = getTopLevelLanes();
     lane1 = topLevelLanes.at(0);
     lane4 = topLevelLanes.at(1);
-    sublane2 = lane1.find("> ul > li");
+    sublane2 = lane1.children(Droppable).children(Draggable).children("div");
     expect(lane1.props().className).to.contain("active");
     expect(lane4.props().className).not.to.contain("active");
     expect(sublane2.props().className).not.to.contain("active");
 
     wrapper.setProps({ identifier: "2" });
-    topLevelLanes = wrapper.find(".lanes-sidebar > ul > li");
+    topLevelLanes = getTopLevelLanes();
     lane1 = topLevelLanes.at(0);
     lane4 = topLevelLanes.at(1);
-    sublane2 = lane1.find("> ul > li");
+    sublane2 = lane1.children(Droppable).children(Draggable).children("div");
     expect(lane1.props().className).not.to.contain("active");
     expect(lane4.props().className).not.to.contain("active");
     expect(sublane2.props().className).to.contain("active");
   });
 
   it("renders create sublane link", () => {
-    let topLevelLanes = wrapper.find(".lanes-sidebar > ul > li");
+    mountWrapper();
+    let topLevelLanes = getTopLevelLanes();
     let lane1 = topLevelLanes.at(0);
-    let lane1CreateSublane = lane1.find("> .lane-buttons .create-lane");
+    let lane1CreateSublane = lane1.children(".lane-buttons").children(Link).filterWhere(node => node.props().className.includes("create-lane"));
     expect(lane1CreateSublane.length).to.equal(1);
     expect(lane1CreateSublane.props().to).to.equal("/admin/web/lanes/library/create/1");
     let lane4 = topLevelLanes.at(1);
-    let lane4CreateSublane = lane4.find("> .lane-buttons .create-lane");
+    let lane4CreateSublane = lane4.children(".lane-buttons").children(Link).filterWhere(node => node.props().className.includes("create-lane"));
     expect(lane4CreateSublane.length).to.equal(1);
     expect(lane4CreateSublane.props().to).to.equal("/admin/web/lanes/library/create/4");
 
     // sublane 2 is collapsed so its create sublane button isn't shown
-    let sublane2 = lane1.find("> ul > li");
-    let sublane2CreateSublane = sublane2.find("> .lane-buttons .create-lane");
+    let sublane2 = lane1.children(Droppable).children(Draggable).children("div");
+    let sublane2CreateSublane = sublane2.children(".lane-buttons").children(Link).filterWhere(node => node.props().className.includes("create-lane"));
     expect(sublane2CreateSublane.length).to.equal(0);
     let sublane2Expand = sublane2.find("> div > span > .expand-button");
     sublane2Expand.simulate("click");
 
-    topLevelLanes = wrapper.find(".lanes-sidebar > ul > li");
+    topLevelLanes = getTopLevelLanes();
     lane1 = topLevelLanes.at(0);
-    sublane2 = lane1.find("> ul > li");
-    sublane2CreateSublane = sublane2.find("> .lane-buttons .create-lane");
+    sublane2 = lane1.children(Droppable).children(Draggable).children("div");
+    sublane2CreateSublane = sublane2.children(".lane-buttons").children(Link).filterWhere(node => node.props().className.includes("create-lane"));
     expect(sublane2CreateSublane.length).to.equal(1);
     expect(sublane2CreateSublane.props().to).to.equal("/admin/web/lanes/library/create/2");
   });
 
   it("renders edit link", () => {
-    let topLevelLanes = wrapper.find(".lanes-sidebar > ul > li");
+    mountWrapper();
+    let topLevelLanes = getTopLevelLanes();
     let lane1 = topLevelLanes.at(0);
-    let lane1Edit = lane1.find("> .lane-buttons .edit-lane");
+    let lane1Edit = lane1.children(".lane-buttons").children(Link).filterWhere(node => node.props().className.includes("edit-lane"));
     expect(lane1Edit.length).to.equal(1);
     expect(lane1Edit.props().to).to.equal("/admin/web/lanes/library/edit/1");
 
     // lane 4 wasn't created from lists, so it's not editable
     let lane4 = topLevelLanes.at(1);
-    let lane4Edit = lane4.find("> .lane-buttons .edit-lane");
+    let lane4Edit = lane4.children(".lane-buttons").children(Link).filterWhere(node => node.props().className.includes("edit-lane"));
     expect(lane4Edit.length).to.equal(0);
 
     // sublane 2 is collapsed so its edit button isn't shown
-    let sublane2 = lane1.find("> ul > li");
-    let sublane2Edit = sublane2.find("> .lane-buttons .edit-lane");
+    let sublane2 = lane1.children(Droppable).children(Draggable).children("div");
+    let sublane2Edit = sublane2.children(".lane-buttons").children(Link).filterWhere(node => node.props().className.includes("edit-lane"));
     expect(sublane2Edit.length).to.equal(0);
     let sublane2Expand = sublane2.find("> div > span > .expand-button");
     sublane2Expand.simulate("click");
 
-    topLevelLanes = wrapper.find(".lanes-sidebar > ul > li");
+    topLevelLanes = getTopLevelLanes();
     lane1 = topLevelLanes.at(0);
-    sublane2 = lane1.find("> ul > li");
-    sublane2Edit = sublane2.find("> .lane-buttons .edit-lane");
+    sublane2 = lane1.children(Droppable).children(Draggable).children("div");
+    sublane2Edit = sublane2.children(".lane-buttons").children(Link).filterWhere(node => node.props().className.includes("edit-lane"));
     expect(sublane2Edit.length).to.equal(1);
     expect(sublane2Edit.props().to).to.equal("/admin/web/lanes/library/edit/2");
   });
 
   it("shows a lane", () => {
-    let topLevelLanes = wrapper.find(".lanes-sidebar > ul > li");
+    mountWrapper();
+    let topLevelLanes = getTopLevelLanes();
     let lane1 = topLevelLanes.at(0);
 
     // lane 1 is already visible, so it has no show link
     let lane1Show = lane1.find("> div > .show-lane");
     expect(lane1Show.length).to.equal(0);
 
-    let sublane2 = lane1.find("> ul > li");
+    let sublane2 = lane1.children(Droppable).children(Draggable).children("div");
     expect(sublane2.text()).to.contain("Hidden");
     let sublane2Show = sublane2.find("> div > .show-lane");
     expect(sublane2Show.length).to.equal(1);
@@ -293,10 +349,10 @@ describe("Lanes", () => {
     let sublane2Expand = sublane2.find("> div > span > .expand-button");
     sublane2Expand.simulate("click");
 
-    topLevelLanes = wrapper.find(".lanes-sidebar > ul > li");
+    topLevelLanes = getTopLevelLanes();
     lane1 = topLevelLanes.at(0);
-    sublane2 = lane1.find("> ul > li");
-    let sublane3 = sublane2.find("> ul > li");
+    sublane2 = lane1.children(Droppable).children(Draggable).children("div");
+    let sublane3 = sublane2.children(Droppable).children(Draggable).children("div");
 
     // sublane 3 has a hidden parent, so it can't be shown.
     expect(sublane3.text()).to.contain("Hidden");
@@ -305,13 +361,14 @@ describe("Lanes", () => {
   });
 
   it("hides a lane", () => {
-    let topLevelLanes = wrapper.find(".lanes-sidebar > ul > li");
+    mountWrapper();
+    let topLevelLanes = getTopLevelLanes();
     let lane1 = topLevelLanes.at(0);
     expect(lane1.text()).to.contain("Visible");
     let lane1Hide = lane1.find("> div > .hide-lane");
     expect(lane1Hide.length).to.equal(1);
 
-    let sublane2 = lane1.find("> ul > li");
+    let sublane2 = lane1.children(Droppable).children(Draggable).children("div");
     expect(sublane2.text()).to.contain("Hidden");
     let sublane2Hide = sublane2.find("> div > .hide-lane");
     expect(sublane2Hide.length).to.equal(0);
@@ -373,9 +430,9 @@ describe("Lanes", () => {
     editor = wrapper.find(LaneEditor);
     expect(editor.length).to.equal(1);
     expect(editor.props().library).to.equal("library");
-    expect(editor.props().lane).to.equal(sublaneData);
-    expect(editor.props().parent).to.equal(lanesData[0]);
-    expect(editor.props().customLists).to.equal(customListsData);
+    expect(editor.props().lane).to.deep.equal(sublaneData);
+    expect(editor.props().parent).to.deep.equal(lanesData[0]);
+    expect(editor.props().customLists).to.deep.equal(customListsData);
     expect(editor.props().editLane).to.be.ok;
     expect(editor.props().deleteLane).to.be.ok;
     expect(editor.props().hideLane).to.be.ok;
@@ -393,23 +450,8 @@ describe("Lanes", () => {
   });
 
   it("resets lanes", () => {
-    wrapper = mount(
-      <Lanes
-        csrfToken="token"
-        library="library"
-        editOrCreate="reset"
-        lanes={lanesData}
-        customLists={customListsData}
-        isFetching={false}
-        fetchLanes={fetchLanes}
-        fetchCustomLists={fetchCustomLists}
-        editLane={editLane}
-        deleteLane={deleteLane}
-        showLane={showLane}
-        hideLane={hideLane}
-        resetLanes={resetLanes}
-        />
-    );
+    mountWrapper();
+    wrapper.setProps({ editOrCreate: "reset" });
 
     // mock typing in the 'RESET' confirmation input box
     let editableInputStub = stub(EditableInput.prototype, "getValue").returns("DO NOT RESET");
@@ -424,5 +466,141 @@ describe("Lanes", () => {
     expect(fetchLanes.callCount).to.equal(2);
 
     editableInputStub.restore();
+  });
+
+  it("prevents dragging a lane out of its parent", () => {
+    mountWrapper();
+
+    // simulate starting a drag of lane1
+    (wrapper.instance() as Lanes).onDragStart({
+      draggableId: "1",
+      source: {
+        droppableId: "top"
+      }
+    });
+
+    // dropping should be disabled everywhere except the top-level lane
+    let topDroppable = getDroppableById("top");
+    expect(topDroppable.props().isDropDisabled).to.be.false;
+    let lane1Droppable = getDroppableById("1");
+    expect(lane1Droppable.props().isDropDisabled).to.be.true;
+
+    // sublane 2 is collapsed so it isn't droppable
+    let topLevelLanes = getTopLevelLanes();
+    let lane1 = topLevelLanes.at(0);
+    let sublane2 = lane1.children(Droppable).children(Draggable).children("div");
+    let sublane2Expand = sublane2.find("> div > span > .expand-button");
+    sublane2Expand.simulate("click");
+    let sublane2Droppable = getDroppableById("2");
+    expect(sublane2Droppable.props().isDropDisabled).to.be.true;
+
+    // now simulate dragging sublane 2
+    (wrapper.instance() as Lanes).onDragStart({
+      draggableId: "2",
+      source: {
+        droppableId: "1"
+      }
+    });
+
+    expect(topDroppable.props().isDropDisabled).to.be.true;
+    expect(lane1Droppable.props().isDropDisabled).to.be.false;
+    expect(sublane2Droppable.props().isDropDisabled).to.be.true;
+  });
+
+  it("drags a top-level lane", () => {
+    mountWrapper();
+
+    // simulate starting a drag of lane1
+    (wrapper.instance() as Lanes).onDragStart({
+      draggableId: "1",
+      source: {
+        droppableId: "top"
+      }
+    });
+
+    // simulate dropping below lane 4
+    (wrapper.instance() as Lanes).onDragEnd({
+      draggableId: "1",
+      source: {
+        droppableId: "top",
+        index: 0
+      },
+      destination: {
+        droppableId: "top",
+        index: 1
+      }
+    });
+
+    let topLevelLanes = getTopLevelLanes();
+    let lane4 = topLevelLanes.at(0);
+    let lane1 = topLevelLanes.at(1);
+    expect(lane1.text()).to.contain("lane 1");
+    expect(lane1.text()).to.contain("(5)");
+    expect(lane4.text()).to.contain("lane 4");
+    expect(lane4.text()).to.contain("(1)");
+  });
+
+  it("drags a sublane", () => {
+    let newSublaneData: LaneData = {
+      id: 5, display_name: "sublane 5", visible: true, count: 6, sublanes: [],
+      custom_list_ids: [2], inherit_parent_restrictions: false
+    };
+    lanesData = [
+      { id: 1, display_name: "lane 1", visible: true, count: 5,
+        sublanes: [sublaneData, newSublaneData], custom_list_ids: [1], inherit_parent_restrictions: true },
+      { id: 4, display_name: "lane 4", visible: true, count: 1, sublanes: [],
+        custom_list_ids: [], inherit_parent_restrictions: false }
+    ];
+    mountWrapper();
+
+    // simulate starting a drag of sublane 5
+    (wrapper.instance() as Lanes).onDragStart({
+      draggableId: "5",
+      source: {
+        droppableId: "1"
+      }
+    });
+
+    // simulate dropping above sublane 2
+    (wrapper.instance() as Lanes).onDragEnd({
+      draggableId: "5",
+      source: {
+        droppableId: "1",
+        index: 1
+      },
+      destination: {
+        droppableId: "1",
+        index: 0
+      }
+    });
+
+    let topLevelLanes = getTopLevelLanes();
+    let lane1 = topLevelLanes.at(0);
+    let sublanes = lane1.children(Droppable).children(Draggable).children("div");
+    let sublane5 = sublanes.at(0);
+    let sublane2 = sublanes.at(1);
+    expect(sublane2.text()).to.contain("sublane 2");
+    expect(sublane5.text()).to.contain("sublane 5");
+  });
+
+  it("saves lane order changes", () => {
+    mountWrapper();
+    wrapper.setState({ orderChanged: true, lanes: [lanesData[1], lanesData[0]] });
+
+    let saveOrderButton = wrapper.find(".save-order");
+    saveOrderButton.simulate("click");
+    expect(changeLaneOrder.callCount).to.equal(1);
+    expect(changeLaneOrder.args[0][0]).to.deep.equal([lanesData[1], lanesData[0]]);
+    expect(fetchLanes.callCount).to.equal(2);
+  });
+
+  it("resets lane order changes", () => {
+    mountWrapper();
+    wrapper.setState({ orderChanged: true, lanes: [lanesData[1], lanesData[0]] });
+
+    let cancelOrderChangesButton = wrapper.find(".cancel-order-changes");
+    cancelOrderChangesButton.simulate("click");
+    expect(wrapper.state().orderChanged).to.equal(false);
+    expect(wrapper.state().lanes).to.deep.equal(lanesData);
   });
 });

--- a/src/components/__tests__/Lanes-test.tsx
+++ b/src/components/__tests__/Lanes-test.tsx
@@ -156,19 +156,6 @@ describe("Lanes", () => {
     expect(reset.props().className).to.contain("disabled");
   });
 
-  it("renders save and reset order if order has changed", () => {
-    let save = wrapper.find(".lanes-sidebar .save-order");
-    expect(save.length).to.equal(0);
-    let reset = wrapper.find(".lanes-sidebar .cancel-order-changes");
-    expect(reset.length).to.equal(0);
-
-    wrapper.setState({ orderChanged: true });
-    save = wrapper.find(".lanes-sidebar .save-order");
-    expect(save.length).to.equal(1);
-    reset = wrapper.find(".lanes-sidebar .cancel-order-changes");
-    expect(reset.length).to.equal(1);
-  });
-
   it("renders and expands and collapses lanes and sublanes", () => {
     mountWrapper();
 
@@ -469,6 +456,20 @@ describe("Lanes", () => {
     expect(fetchLanes.callCount).to.equal(1);
 
     confirmStub.restore();
+  });
+
+  it("renders save and reset order if order has changed", () => {
+    let orderInfo = wrapper.find(".order-change-info");
+    expect(orderInfo.length).to.equal(0);
+
+    wrapper.setState({ orderChanged: true });
+    orderInfo = wrapper.find(".order-change-info");
+    expect(orderInfo.length).to.equal(1);
+
+    let save = orderInfo.find(".save-order");
+    expect(save.length).to.equal(1);
+    let reset = orderInfo.find(".cancel-order-changes");
+    expect(reset.length).to.equal(1);
   });
 
   it("renders create form", () => {

--- a/src/components/__tests__/Lanes-test.tsx
+++ b/src/components/__tests__/Lanes-test.tsx
@@ -134,12 +134,26 @@ describe("Lanes", () => {
     let create = wrapper.find(".lanes-sidebar > div > .create-lane");
     expect(create.length).to.equal(1);
     expect(create.props().to).to.equal("/admin/web/lanes/library/create");
+
+    // the link is disabled if there are lane order changes
+    wrapper.setState({ orderChanged: true });
+    create = wrapper.find(".lanes-sidebar > div > .create-lane");
+    expect(create.length).to.equal(1);
+    expect(create.props().to).to.be.null;
+    expect(create.props().className).to.contain("disabled");
   });
 
   it("renders reset link", () => {
     let reset = wrapper.find(".lanes-sidebar .reset-lanes");
     expect(reset.length).to.equal(1);
     expect(reset.props().to).to.equal("/admin/web/lanes/library/reset");
+
+    // the link is disabled if there are lane order changes
+    wrapper.setState({ orderChanged: true });
+    reset = wrapper.find(".lanes-sidebar > div > .reset-lanes");
+    expect(reset.length).to.equal(1);
+    expect(reset.props().to).to.be.null;
+    expect(reset.props().className).to.contain("disabled");
   });
 
   it("renders save and reset order if order has changed", () => {
@@ -297,6 +311,28 @@ describe("Lanes", () => {
     sublane2CreateSublane = sublane2.children(".lane-buttons").children(Link).filterWhere(node => node.props().className.includes("create-lane"));
     expect(sublane2CreateSublane.length).to.equal(1);
     expect(sublane2CreateSublane.props().to).to.equal("/admin/web/lanes/library/create/2");
+
+    // the links are disabled if there are lane order changes.
+    wrapper.setState({ orderChanged: true });
+
+    topLevelLanes = getTopLevelLanes();
+    lane1 = topLevelLanes.at(0);
+    lane1CreateSublane = lane1.children(".lane-buttons").children(Link).filterWhere(node => node.props().className.includes("create-lane"));
+    expect(lane1CreateSublane.length).to.equal(1);
+    expect(lane1CreateSublane.props().to).to.be.null;
+    expect(lane1CreateSublane.props().className).to.contain("disabled");
+
+    lane4 = topLevelLanes.at(1);
+    lane4CreateSublane = lane4.children(".lane-buttons").children(Link).filterWhere(node => node.props().className.includes("create-lane"));
+    expect(lane4CreateSublane.length).to.equal(1);
+    expect(lane4CreateSublane.props().to).to.be.null;
+    expect(lane4CreateSublane.props().className).to.contain("disabled");
+
+    sublane2 = lane1.find("> ul > li > div");
+    sublane2CreateSublane = sublane2.children(".lane-buttons").children(Link).filterWhere(node => node.props().className.includes("create-lane"));
+    expect(sublane2CreateSublane.length).to.equal(1);
+    expect(sublane2CreateSublane.props().to).to.be.null;
+    expect(sublane2CreateSublane.props().className).to.contain("disabled");
   });
 
   it("renders edit link", () => {
@@ -325,6 +361,22 @@ describe("Lanes", () => {
     sublane2Edit = sublane2.children(".lane-buttons").children(Link).filterWhere(node => node.props().className.includes("edit-lane"));
     expect(sublane2Edit.length).to.equal(1);
     expect(sublane2Edit.props().to).to.equal("/admin/web/lanes/library/edit/2");
+
+    // the links are disabled if there are lane order changes.
+    wrapper.setState({ orderChanged: true });
+
+    topLevelLanes = getTopLevelLanes();
+    lane1 = topLevelLanes.at(0);
+    lane1Edit = lane1.children(".lane-buttons").children(Link).filterWhere(node => node.props().className.includes("edit-lane"));
+    expect(lane1Edit.length).to.equal(1);
+    expect(lane1Edit.props().to).to.be.null;
+    expect(lane1Edit.props().className).to.contain("disabled");
+
+    sublane2 = lane1.find("> ul > li > div");
+    sublane2Edit = sublane2.children(".lane-buttons").children(Link).filterWhere(node => node.props().className.includes("edit-lane"));
+    expect(sublane2Edit.length).to.equal(1);
+    expect(sublane2Edit.props().to).to.be.null;
+    expect(sublane2Edit.props().className).to.contain("disabled");
   });
 
   it("shows a lane", () => {
@@ -357,6 +409,16 @@ describe("Lanes", () => {
     expect(sublane3.text()).to.contain("Hidden");
     let sublane3Show = sublane3.find("> div > .show-lane");
     expect(sublane3Show.length).to.equal(0);
+
+    // if lane order has changed, no lanes can be shown
+    wrapper.setState({ orderChanged: true });
+
+    topLevelLanes = getTopLevelLanes();
+    lane1 = topLevelLanes.at(0);
+    sublane2 = lane1.find("> ul > li > div");
+    expect(sublane2.text()).to.contain("Hidden");
+    sublane2Show = sublane2.find("> div > .show-lane");
+    expect(sublane2Show.length).to.equal(0);
   });
 
   it("hides a lane", () => {
@@ -375,6 +437,15 @@ describe("Lanes", () => {
     lane1Hide.simulate("click");
     expect(hideLane.callCount).to.equal(1);
     expect(hideLane.args[0][0]).to.equal("1");
+
+    // if lane order has changed, no lanes can be hidden
+    wrapper.setState({ orderChanged: true });
+
+    topLevelLanes = getTopLevelLanes();
+    lane1 = topLevelLanes.at(0);
+    expect(lane1.text()).to.contain("Visible");
+    lane1Hide = lane1.find("> div > .hide-lane");
+    expect(lane1Hide.length).to.equal(0);
   });
 
   it("edits a lane", () => {

--- a/src/components/__tests__/Lanes-test.tsx
+++ b/src/components/__tests__/Lanes-test.tsx
@@ -191,27 +191,29 @@ describe("Lanes", () => {
     expectExpanded(lane4);
 
     // lane 1 has one sublane which is collapsed
-    let sublane2 = lane1.children(Droppable).children(Draggable).children("div");
+    let sublane2 = lane1.find("> ul > li > div");
     expect(sublane2.text()).to.contain("sublane 2");
     expect(sublane2.text()).to.contain("(3)");
     expect(sublane2.length).to.equal(1);
     let sublane2Expand = expectCollapsed(sublane2);
 
     // lane 4 has no sublanes
-    let lane4Sublanes = lane4.children(Droppable).children(Draggable).children("div");
+    let lane4Sublanes = lane4.find("> ul > li > div");
+    let lane4Draggables = lane4.children(Droppable).children(Draggable).children("div");
     expect(lane4Sublanes.length).to.equal(0);
+    expect(lane4Draggables.length).to.equal(0);
 
     // sublane 2 has a sublane, but it's not shown since sublane 2 is collapsed.
-    let sublane3 = sublane2.children(Droppable).children(Draggable).children("div");
+    let sublane3 = sublane2.find("> ul > li > div");
     expect(sublane3.length).to.equal(0);
 
     // if we expand sublane 2, we can see sublane 3 below it.
     sublane2Expand.simulate("click");
     topLevelLanes = getTopLevelLanes();
     lane1 = topLevelLanes.at(0);
-    sublane2 = lane1.children(Droppable).children(Draggable).children("div");
+    sublane2 = lane1.find("> ul > li > div");
     let sublane2Collapse = expectExpanded(sublane2);
-    sublane3 = sublane2.children(Droppable).children(Draggable).children("div");
+    sublane3 = sublane2.find("> ul > li > div");
     expect(sublane3.length).to.equal(1);
     expect(sublane3.text()).to.contain("sublane 3");
     expect(sublane3.text()).to.contain("(2)");
@@ -221,9 +223,9 @@ describe("Lanes", () => {
     sublane2Collapse.simulate("click");
     topLevelLanes = getTopLevelLanes();
     lane1 = topLevelLanes.at(0);
-    sublane2 = lane1.children(Droppable).children(Draggable).children("div");
+    sublane2 = lane1.find("> ul > li > div");
     expectCollapsed(sublane2);
-    sublane3 = sublane2.children(Droppable).children(Draggable).children("div");
+    sublane3 = sublane2.find("> ul > li > div");
     expect(sublane3.length).to.equal(0);
 
     // if we collapse lane 1, sublane 2 is hidden.
@@ -232,7 +234,7 @@ describe("Lanes", () => {
     topLevelLanes = getTopLevelLanes();
     lane1 = topLevelLanes.at(0);
     let lane1Expand = expectCollapsed(lane1);
-    sublane2 = lane1.children(Droppable).children(Draggable).children("div");
+    sublane2 = lane1.find("> ul > li > div");
     expect(sublane2.length).to.equal(0);
 
     // if we expand lane 1, sublane 2 is shown again.
@@ -240,7 +242,7 @@ describe("Lanes", () => {
     topLevelLanes = getTopLevelLanes();
     lane1 = topLevelLanes.at(0);
     expectExpanded(lane1);
-    sublane2 = lane1.children(Droppable).children(Draggable).children("div");
+    sublane2 = lane1.find("> ul > li > div");
     expect(sublane2.length).to.equal(1);
   });
 
@@ -249,7 +251,7 @@ describe("Lanes", () => {
     let topLevelLanes = getTopLevelLanes();
     let lane1 = topLevelLanes.at(0);
     let lane4 = topLevelLanes.at(1);
-    let sublane2 = lane1.children(Droppable).children(Draggable).children("div");
+    let sublane2 = lane1.find("> ul > li > div");
     expect(lane1.props().className).not.to.contain("active");
     expect(lane4.props().className).not.to.contain("active");
     expect(sublane2.props().className).not.to.contain("active");
@@ -258,7 +260,7 @@ describe("Lanes", () => {
     topLevelLanes = getTopLevelLanes();
     lane1 = topLevelLanes.at(0);
     lane4 = topLevelLanes.at(1);
-    sublane2 = lane1.children(Droppable).children(Draggable).children("div");
+    sublane2 = lane1.find("> ul > li > div");
     expect(lane1.props().className).to.contain("active");
     expect(lane4.props().className).not.to.contain("active");
     expect(sublane2.props().className).not.to.contain("active");
@@ -267,7 +269,7 @@ describe("Lanes", () => {
     topLevelLanes = getTopLevelLanes();
     lane1 = topLevelLanes.at(0);
     lane4 = topLevelLanes.at(1);
-    sublane2 = lane1.children(Droppable).children(Draggable).children("div");
+    sublane2 = lane1.find("> ul > li > div");
     expect(lane1.props().className).not.to.contain("active");
     expect(lane4.props().className).not.to.contain("active");
     expect(sublane2.props().className).to.contain("active");
@@ -286,7 +288,7 @@ describe("Lanes", () => {
     expect(lane4CreateSublane.props().to).to.equal("/admin/web/lanes/library/create/4");
 
     // sublane 2 is collapsed so its create sublane button isn't shown
-    let sublane2 = lane1.children(Droppable).children(Draggable).children("div");
+    let sublane2 = lane1.find("> ul > li > div");
     let sublane2CreateSublane = sublane2.children(".lane-buttons").children(Link).filterWhere(node => node.props().className.includes("create-lane"));
     expect(sublane2CreateSublane.length).to.equal(0);
     let sublane2Expand = sublane2.find("> div > span > .expand-button");
@@ -294,7 +296,7 @@ describe("Lanes", () => {
 
     topLevelLanes = getTopLevelLanes();
     lane1 = topLevelLanes.at(0);
-    sublane2 = lane1.children(Droppable).children(Draggable).children("div");
+    sublane2 = lane1.find("> ul > li > div");
     sublane2CreateSublane = sublane2.children(".lane-buttons").children(Link).filterWhere(node => node.props().className.includes("create-lane"));
     expect(sublane2CreateSublane.length).to.equal(1);
     expect(sublane2CreateSublane.props().to).to.equal("/admin/web/lanes/library/create/2");
@@ -314,7 +316,7 @@ describe("Lanes", () => {
     expect(lane4Edit.length).to.equal(0);
 
     // sublane 2 is collapsed so its edit button isn't shown
-    let sublane2 = lane1.children(Droppable).children(Draggable).children("div");
+    let sublane2 = lane1.find("> ul > li > div");
     let sublane2Edit = sublane2.children(".lane-buttons").children(Link).filterWhere(node => node.props().className.includes("edit-lane"));
     expect(sublane2Edit.length).to.equal(0);
     let sublane2Expand = sublane2.find("> div > span > .expand-button");
@@ -322,7 +324,7 @@ describe("Lanes", () => {
 
     topLevelLanes = getTopLevelLanes();
     lane1 = topLevelLanes.at(0);
-    sublane2 = lane1.children(Droppable).children(Draggable).children("div");
+    sublane2 = lane1.find("> ul > li > div");
     sublane2Edit = sublane2.children(".lane-buttons").children(Link).filterWhere(node => node.props().className.includes("edit-lane"));
     expect(sublane2Edit.length).to.equal(1);
     expect(sublane2Edit.props().to).to.equal("/admin/web/lanes/library/edit/2");
@@ -337,7 +339,7 @@ describe("Lanes", () => {
     let lane1Show = lane1.find("> div > .show-lane");
     expect(lane1Show.length).to.equal(0);
 
-    let sublane2 = lane1.children(Droppable).children(Draggable).children("div");
+    let sublane2 = lane1.find("> ul > li > div");
     expect(sublane2.text()).to.contain("Hidden");
     let sublane2Show = sublane2.find("> div > .show-lane");
     expect(sublane2Show.length).to.equal(1);
@@ -351,8 +353,8 @@ describe("Lanes", () => {
 
     topLevelLanes = getTopLevelLanes();
     lane1 = topLevelLanes.at(0);
-    sublane2 = lane1.children(Droppable).children(Draggable).children("div");
-    let sublane3 = sublane2.children(Droppable).children(Draggable).children("div");
+    sublane2 = lane1.find("> ul > li > div");
+    let sublane3 = sublane2.find("> ul > li > div");
 
     // sublane 3 has a hidden parent, so it can't be shown.
     expect(sublane3.text()).to.contain("Hidden");
@@ -368,7 +370,7 @@ describe("Lanes", () => {
     let lane1Hide = lane1.find("> div > .hide-lane");
     expect(lane1Hide.length).to.equal(1);
 
-    let sublane2 = lane1.children(Droppable).children(Draggable).children("div");
+    let sublane2 = lane1.find("> ul > li > div");
     expect(sublane2.text()).to.contain("Hidden");
     let sublane2Hide = sublane2.find("> div > .hide-lane");
     expect(sublane2Hide.length).to.equal(0);
@@ -469,6 +471,21 @@ describe("Lanes", () => {
   });
 
   it("prevents dragging a lane out of its parent", () => {
+    let newSublaneData: LaneData = {
+      id: 5, display_name: "sublane 5", visible: true, count: 6, sublanes: [],
+      custom_list_ids: [2], inherit_parent_restrictions: false
+    };
+    let newSubsublaneData: LaneData = {
+      id: 6, display_name: "sublane 6", visible: true, count: 6, sublanes: [],
+      custom_list_ids: [2], inherit_parent_restrictions: false
+    };
+    lanesData = [
+      { id: 1, display_name: "lane 1", visible: true, count: 5,
+        sublanes: [{...sublaneData, sublanes: [subsublaneData, newSubsublaneData] }, newSublaneData],
+        custom_list_ids: [1], inherit_parent_restrictions: true },
+      { id: 4, display_name: "lane 4", visible: true, count: 1, sublanes: [],
+        custom_list_ids: [], inherit_parent_restrictions: false }
+    ];
     mountWrapper();
 
     // simulate starting a drag of lane1
@@ -488,7 +505,7 @@ describe("Lanes", () => {
     // sublane 2 is collapsed so it isn't droppable
     let topLevelLanes = getTopLevelLanes();
     let lane1 = topLevelLanes.at(0);
-    let sublane2 = lane1.children(Droppable).children(Draggable).children("div");
+    let sublane2 = lane1.children(Droppable).children(Draggable).children("div").at(0);
     let sublane2Expand = sublane2.find("> div > span > .expand-button");
     sublane2Expand.simulate("click");
     let sublane2Droppable = getDroppableById("2");
@@ -602,5 +619,104 @@ describe("Lanes", () => {
     cancelOrderChangesButton.simulate("click");
     expect(wrapper.state().orderChanged).to.equal(false);
     expect(wrapper.state().lanes).to.deep.equal(lanesData);
+  });
+
+  it("renders draggable sublanes only if there's more than one", () => {
+    // lane structure:
+    //        top
+    //       /   \
+    //      1     4
+    //     / \
+    //    2   5
+    //   /   / \
+    //  3   6   7
+    //      |
+    //      8
+    //
+    // top, 1, and 5 are the only lanes with draggable sublanes.
+    // 1, 2, 4, 5, 6, and 7 should be draggable.
+
+    let sublane8Data: LaneData = {
+      id: 8, display_name: "sublane 8", visible: true, count: 6, sublanes: [],
+      custom_list_ids: [2], inherit_parent_restrictions: false
+    };
+    let sublane6Data: LaneData = {
+      id: 6, display_name: "sublane 6", visible: true, count: 6, sublanes: [sublane8Data],
+      custom_list_ids: [2], inherit_parent_restrictions: false
+    };
+    let sublane7Data: LaneData = {
+      id: 7, display_name: "sublane 7", visible: true, count: 6, sublanes: [],
+      custom_list_ids: [2], inherit_parent_restrictions: false
+    };
+    let sublane5Data: LaneData = {
+      id: 5, display_name: "sublane 5", visible: true, count: 6, sublanes: [sublane6Data, sublane7Data],
+      custom_list_ids: [2], inherit_parent_restrictions: false
+    };
+    lanesData = [
+      { id: 1, display_name: "lane 1", visible: true, count: 5,
+        sublanes: [sublaneData, sublane5Data], custom_list_ids: [1], inherit_parent_restrictions: true },
+      { id: 4, display_name: "lane 4", visible: true, count: 1, sublanes: [],
+        custom_list_ids: [], inherit_parent_restrictions: false }
+    ];
+    mountWrapper();
+    let topLevelLanes = getTopLevelLanes();
+
+    let lane1 = topLevelLanes.at(0);
+    expect(lane1.children(Droppable).children(Draggable).children("div").length).to.equal(2);
+    expect(lane1.find("> ul > li > div").length).to.equal(0);
+
+    let lane1Children = lane1.children(Droppable).children(Draggable).children("div");
+    let sublane2 = lane1Children.at(0);
+    let sublane2Expand = sublane2.find("> div > span > .expand-button");
+    sublane2Expand.simulate("click");
+    topLevelLanes = getTopLevelLanes();
+    lane1 = topLevelLanes.at(0);
+    lane1Children = lane1.children(Droppable).children(Draggable).children("div");
+    sublane2 = lane1Children.at(0);
+    expect(sublane2.text()).to.contain("sublane 2");
+    expect(sublane2.children(Droppable).children(Draggable).children("div").length).to.equal(0);
+    expect(sublane2.find("> ul > li > div").length).to.equal(1);
+
+    let sublane5 = lane1Children.at(1);
+    let sublane5Expand = sublane5.find("> div > span > .expand-button");
+    sublane5Expand.simulate("click");
+    topLevelLanes = getTopLevelLanes();
+    lane1 = topLevelLanes.at(0);
+    lane1Children = lane1.children(Droppable).children(Draggable).children("div");
+    sublane5 = lane1Children.at(1);
+    expect(sublane5.text()).to.contain("sublane 5");
+    expect(sublane5.children(Droppable).children(Draggable).children("div").length).to.equal(2);
+    expect(sublane5.find("> ul > li > div").length).to.equal(0);
+
+    let sublane5Children = sublane5.children(Droppable).children(Draggable).children("div");
+    let sublane6 = sublane5Children.at(0);
+    let sublane6Expand = sublane6.find("> div > span > .expand-button");
+    sublane6Expand.simulate("click");
+    topLevelLanes = getTopLevelLanes();
+    lane1 = topLevelLanes.at(0);
+    lane1Children = lane1.children(Droppable).children(Draggable).children("div");
+    sublane5 = lane1Children.at(1);
+    sublane5Children = sublane5.children(Droppable).children(Draggable).children("div");
+    sublane6 = sublane5Children.at(0);
+    expect(sublane6.text()).to.contain("sublane 6");
+    expect(sublane6.children(Droppable).children(Draggable).children("div").length).to.equal(0);
+    expect(sublane6.find("> ul > li > div").length).to.equal(1);
+
+    let sublane7 = sublane5Children.at(1);
+    let sublane7Expand = sublane7.find("> div > span > .expand-button");
+    sublane7Expand.simulate("click");
+    topLevelLanes = getTopLevelLanes();
+    lane1 = topLevelLanes.at(0);
+    lane1Children = lane1.children(Droppable).children(Draggable).children("div");
+    sublane5 = lane1Children.at(1);
+    sublane5Children = sublane5.children(Droppable).children(Draggable).children("div");
+    sublane7 = sublane5Children.at(1);
+    expect(sublane7.text()).to.contain("sublane 7");
+    expect(sublane7.children(Droppable).children(Draggable).children("div").length).to.equal(0);
+    expect(sublane7.find("> ul > li > div").length).to.equal(0);
+
+    let lane4 = topLevelLanes.at(1);
+    expect(lane4.children(Droppable).children(Draggable).children("div").length).to.equal(0);
+    expect(lane4.find("> ul > li > div").length).to.equal(0);
   });
 });

--- a/src/components/__tests__/SaveButton-test.tsx
+++ b/src/components/__tests__/SaveButton-test.tsx
@@ -18,7 +18,6 @@ describe("SaveButton", () => {
       <SaveButton
         disabled={false}
         submit={submit}
-        form={undefined}
       />
     );
   });

--- a/src/reducers/__tests__/createFetchEditReducer-test.ts
+++ b/src/reducers/__tests__/createFetchEditReducer-test.ts
@@ -103,6 +103,18 @@ describe("fetch-edit reducer", () => {
     expect(fetchOnlyReducer(oldState, action)).to.deep.equal(newState);
   });
 
+  it("handles success", () => {
+    let action = { type: "TEST_FETCH_SUCCESS", data: testData };
+    let oldState = Object.assign({}, initState, {
+      isFetching: true
+    });
+    let newState = Object.assign({}, initState, {
+      isFetching: false
+    });
+    expect(reducer(oldState, action)).to.deep.equal(newState);
+    expect(fetchOnlyReducer(oldState, action)).to.deep.equal(newState);
+  });
+
   it("handles load", () => {
     let action = { type: "TEST_FETCH_LOAD", data: testData };
     let newState = Object.assign({}, initState, {

--- a/src/reducers/createFetchEditReducer.ts
+++ b/src/reducers/createFetchEditReducer.ts
@@ -52,6 +52,13 @@ export default<T> (fetchPrefix: string, editPrefix?: string, extraActions?: Extr
           isLoaded: true
         });
 
+      case `${fetchPrefix}_${ActionCreator.SUCCESS}`:
+        return Object.assign({}, state, {
+          fetchError: null,
+          formError: null,
+          isFetching: false
+        });
+
       case `${fetchPrefix}_${ActionCreator.LOAD}`:
         return Object.assign({}, state, {
           data: action.data,

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -30,6 +30,7 @@ import customListDetails, { FetchMoreCustomListDetails } from "./customListDetai
 import lanes from "./lanes";
 import laneVisibility from "./laneVisibility";
 import resetLanes from "./resetLanes";
+import laneOrder from "./laneOrder";
 import selfTests from "./selfTests";
 import roles from "./roles";
 import media from "./media";
@@ -84,6 +85,7 @@ export interface State {
   lanes: FetchEditState<LanesData>;
   laneVisibility: FetchEditState<void>;
   resetLanes: FetchEditState<void>;
+  laneOrder: FetchEditState<void>;
   selfTests: FetchEditState<void>;
   roles: FetchEditState<RolesData>;
   media: FetchEditState<MediaData>;
@@ -126,6 +128,7 @@ export default combineReducers<State>({
   lanes,
   laneVisibility,
   resetLanes,
+  laneOrder,
   selfTests,
   roles,
   media,

--- a/src/reducers/laneOrder.ts
+++ b/src/reducers/laneOrder.ts
@@ -1,0 +1,4 @@
+import ActionCreator from "../actions";
+import createFetchEditReducer from "./createFetchEditReducer";
+
+export default createFetchEditReducer<void>(ActionCreator.CHANGE_LANE_ORDER);

--- a/src/stylesheets/lanes.scss
+++ b/src/stylesheets/lanes.scss
@@ -118,15 +118,20 @@
     }
   }
 
-  .lanes-sidebar .save-order {
-    float: left;
-    margin-top: 5px;
-    margin-right: 5px;
-  }
+  .order-change-info {
+    .save-order {
+      margin-right: 5px;
+    }
 
-  .lanes-sidebar .cancel-order-changes {
-    display: inline-block;
-    font-size: 0.7em;
+    .cancel-order-changes {
+      display: inline-block;
+      font-size: 0.7em;
+    }
+
+    svg {
+      margin-left: 5px;
+      fill: $linkcolor;
+    }
   }
 
   .lanes-sidebar .btn {

--- a/src/stylesheets/lanes.scss
+++ b/src/stylesheets/lanes.scss
@@ -49,8 +49,11 @@
         flex-direction: row;
         justify-content: space-between;
         margin-bottom: 5px;
-        cursor: grab;
-        cursor: -webkit-grab;
+
+        &.draggable {
+          cursor: grab;
+          cursor: -webkit-grab;
+        }
       }
 
       .lane-buttons {

--- a/src/stylesheets/lanes.scss
+++ b/src/stylesheets/lanes.scss
@@ -40,24 +40,38 @@
         border-bottom: none;
       }
 
-      &.active {
+      .active {
         background-color: $pagecolorlight;
       }
 
-      > div {
+      .lane-info {
         display: flex;
         flex-direction: row;
         justify-content: space-between;
         margin-bottom: 5px;
+        cursor: grab;
+        cursor: -webkit-grab;
+      }
 
-        &.lane-buttons {
+      .lane-buttons {
+        display: flex;
+        flex-direction: row;
+        justify-content: flex-end;
+        align-self: flex-end;
+
+        > a {
           align-self: flex-end;
         }
       }
 
-      > a {
-        align-self: flex-end;
+      .dragging {
+        border: 1px solid $pagetextcolor;
+        background-color: $pagecolorlight;
       }
+    }
+
+    &.dragging-over {
+      border: 1px solid red;
     }
   }
 
@@ -100,7 +114,16 @@
     }
   }
 
-  .lanes-sidebar a.btn {
+  .lanes-sidebar .save-order {
+    margin-top: 5px;
+    margin-right: 5px;
+  }
+
+  .lanes-sidebar .cancel-order-changes {
+    font-size: 0.7em;
+  }
+
+  .lanes-sidebar .btn {
     display: inline-block;
     font-size: 0.9em;
     color: $invertedlinkcolor;

--- a/src/stylesheets/lanes.scss
+++ b/src/stylesheets/lanes.scss
@@ -122,7 +122,7 @@
     margin: 7px;
     padding-top: 14px;
 
-    .save-order {
+    .btn {
       margin-right: 5px;
     }
 

--- a/src/stylesheets/lanes.scss
+++ b/src/stylesheets/lanes.scss
@@ -119,6 +119,9 @@
   }
 
   .order-change-info {
+    margin: 7px;
+    padding-top: 14px;
+
     .save-order {
       margin-right: 5px;
     }

--- a/src/stylesheets/lanes.scss
+++ b/src/stylesheets/lanes.scss
@@ -79,6 +79,7 @@
   }
 
   .lanes-sidebar > ul {
+    clear: both;
     padding-left: 0px;
     margin-top: 10px;
     border-top: 4px solid $gray;
@@ -118,11 +119,13 @@
   }
 
   .lanes-sidebar .save-order {
+    float: left;
     margin-top: 5px;
     margin-right: 5px;
   }
 
   .lanes-sidebar .cancel-order-changes {
+    display: inline-block;
     font-size: 0.7em;
   }
 


### PR DESCRIPTION
This adds drag-and-drop functionality to the list of lanes, and buttons for saving or resetting the order changes. You can only change the order within the parent, you can't move a lane to a different parent.

Unfortunately the drag and drop library broke many of enzyme's selectors, so the way the tests have to look up elements is ugly. I'm also getting some typings errors in the travis build that I'm still looking into.