### PR TITLE
Show metadata service name instead of protocol.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### v0.1.1
 ##### Updated
 - Improved appearance and readability of Diagnostics page.
+- Listed Metadata Services by individual name rather than by protocol.
 
 ### v0.1.0
 #### Added

--- a/src/components/MetadataServices.tsx
+++ b/src/components/MetadataServices.tsx
@@ -16,7 +16,7 @@ export class MetadataServices extends EditableConfigList<MetadataServicesData, M
   labelKey = "protocol";
 
   label(item): string {
-    let label = item.name ? item.name : item.protocol;
+    let label = item.name ? `${item.name}: ${item.protocol}` : item.protocol;
     return label;
   }
 }

--- a/src/components/MetadataServices.tsx
+++ b/src/components/MetadataServices.tsx
@@ -16,12 +16,8 @@ export class MetadataServices extends EditableConfigList<MetadataServicesData, M
   labelKey = "protocol";
 
   label(item): string {
-    for (const protocol of this.props.data.protocols) {
-      if (protocol.name === item.protocol) {
-        return protocol.label;
-      }
-    }
-    return item.protocol;
+    let label = item.name ? item.name : item.protocol;
+    return label;
   }
 }
 
@@ -30,7 +26,7 @@ function mapStateToProps(state, ownProps) {
   if (state.editor.libraries && state.editor.libraries.data) {
     data.allLibraries = state.editor.libraries.data.libraries;
   }
-  // fetchError = an error involving loading the list of metadata services; formError = an error upon submission of the 
+  // fetchError = an error involving loading the list of metadata services; formError = an error upon submission of the
   // create/edit form.
   return {
     data: data,

--- a/src/components/__tests__/MetadataServices-test.tsx
+++ b/src/components/__tests__/MetadataServices-test.tsx
@@ -52,7 +52,7 @@ describe("MetadataServices", () => {
   it("shows metadata service list", () => {
     let metadataService = wrapper.find("li");
     expect(metadataService.length).to.equal(1);
-    expect(metadataService.at(0).text()).to.contain("test protocol label");
+    expect(metadataService.at(0).text()).to.contain("test protocol");
     let editLink = metadataService.at(0).find("a");
     expect(editLink.props().href).to.equal("/admin/web/config/metadata/edit/2");
   });

--- a/src/components/__tests__/MetadataServices-test.tsx
+++ b/src/components/__tests__/MetadataServices-test.tsx
@@ -14,6 +14,7 @@ describe("MetadataServices", () => {
     metadata_services: [{
       id: 2,
       protocol: "test protocol",
+      name: "sample name",
       settings: {
         "test_setting": "test setting"
       },
@@ -52,7 +53,7 @@ describe("MetadataServices", () => {
   it("shows metadata service list", () => {
     let metadataService = wrapper.find("li");
     expect(metadataService.length).to.equal(1);
-    expect(metadataService.at(0).text()).to.contain("test protocol");
+    expect(metadataService.at(0).text()).to.contain("sample name: test protocol");
     let editLink = metadataService.at(0).find("a");
     expect(editLink.props().href).to.equal("/admin/web/config/metadata/edit/2");
   });


### PR DESCRIPTION
Resolves https://jira.nypl.org/browse/SIMPLY-1717