### PR TITLE
Minor bug fix - Library registration form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v0.1.5
+#### Fixed
+- Fixed minor bug affecting the display for libraries for which registration has failed.
+
 ### v0.1.4
 #### Added
 - Require admins to agree to the terms and conditions before registering or updating a library with a discovery service.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/components/LibraryRegistration.tsx
+++ b/src/components/LibraryRegistration.tsx
@@ -95,8 +95,9 @@ export default class LibraryRegistration extends React.Component<LibraryRegistra
   }
 
   statusSpan(status: string): JSX.Element {
+    let className = status === "failure" ? "bg-danger" : `bg-${status}`;
     return (
-      <span className={`bg-${status}`}>{this.MESSAGES[status].statusText}</span>
+      <span className={className}>{this.MESSAGES[status].statusText}</span>
     );
   }
 

--- a/src/components/__tests__/LibraryRegistration-test.tsx
+++ b/src/components/__tests__/LibraryRegistration-test.tsx
@@ -182,9 +182,9 @@ describe("LibraryRegistration", () => {
         expect(nyplRegistrationStatus.text()).to.equal("Registered");
         expect(nyplRegistrationStatus.prop("className")).to.equal("bg-success");
         expect(bplRegistrationStatus.text()).to.equal("Registration failed");
-        expect(bplRegistrationStatus.prop("className")).to.equal("bg-failure");
+        expect(bplRegistrationStatus.prop("className")).to.equal("bg-danger");
         expect(qplRegistrationStatus.text()).to.equal("Registration failed");
-        expect(qplRegistrationStatus.prop("className")).to.equal("bg-failure");
+        expect(qplRegistrationStatus.prop("className")).to.equal("bg-danger");
 
 
         expect(nyplRegistrationStatusBtn.length).to.equal(1);


### PR DESCRIPTION
Very minor bug (probably introduced by me in the last round of refactoring): in cases where the library registration failed, the class name needs to be set to "bg-danger" (which will turn the background red) not to "bg-failure" (which won't do anything).

I'm not sure it's worth publishing a new version just for this; what do you think?  Any other small things we can put into 0.1.5?