### PR TITLE
Geographic areas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 ## Changelog
 
+### v0.1.5
+- Improved the process for specifying a library's service and focus areas.
+
 ### v0.1.4
 #### Added
-- Require admins to agree to the terms and conditions before registering or updating a library with a discovery service.
+- Required admins to agree to the terms and conditions before registering or updating a library with a discovery service.
 
 ### v0.1.3
 #### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.0.98",
+  "version": "0.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/components/EditableInput.tsx
+++ b/src/components/EditableInput.tsx
@@ -11,6 +11,7 @@ export interface EditableInputProps extends React.HTMLProps<EditableInput> {
   optionalText?: boolean;
   validation?: string;
   clientError?: boolean;
+  extraContent?: string | JSX.Element;
 }
 
 export interface EditableInputState {
@@ -60,7 +61,10 @@ export default class EditableInput extends React.Component<EditableInputProps, E
             { this.props.type === "radio" && <span>{this.props.label}</span> }
           </label>
         }
-        {!this.props.label && this.renderElement()}
+        <section className={this.props.extraContent ? "with-add-on" : ""}>
+          { this.props.extraContent }
+          {!this.props.label && this.renderElement()}
+        </section>
         {description.trim() && this.renderDescription(description)}
       </div>
     );

--- a/src/components/EditableInput.tsx
+++ b/src/components/EditableInput.tsx
@@ -61,10 +61,10 @@ export default class EditableInput extends React.Component<EditableInputProps, E
             { this.props.type === "radio" && <span>{this.props.label}</span> }
           </label>
         }
-        <section className={this.props.extraContent ? "with-add-on" : ""}>
+        <div className={this.props.extraContent ? "with-add-on" : ""}>
           { this.props.extraContent }
           {!this.props.label && this.renderElement()}
-        </section>
+        </div>
         {description.trim() && this.renderDescription(description)}
       </div>
     );

--- a/src/components/InputList.tsx
+++ b/src/components/InputList.tsx
@@ -9,7 +9,6 @@ export interface InputListProps {
   labelAndDescription: (SettingData) => JSX.Element[];
   setting: SettingData;
   disabled: boolean;
-  // renderToolTip: (item: {} | string, format: string) => JSX.Element;
   value: Array<string | {}>;
 }
 

--- a/src/components/InputList.tsx
+++ b/src/components/InputList.tsx
@@ -7,12 +7,12 @@ export interface InputListProps {
   labelAndDescription: (SettingData) => JSX.Element[];
   setting: SettingData;
   disabled: boolean;
-  toolTip: (item: any, format: string) => JSX.Element;
-  value: any;
+  renderToolTip: (item: {} | string, format: string) => JSX.Element;
+  value: Array<string | {}>;
 }
 
 export interface InputListState {
-  listItems: string[];
+  listItems: Array<string | {}>;
 }
 
 export default class InputList extends React.Component<InputListProps, InputListState> {
@@ -43,13 +43,27 @@ export default class InputList extends React.Component<InputListProps, InputList
               disabled={this.props.disabled}
               onRemove={() => this.removeListItem(listItem)}
             >
-              {this.props.createEditableInput(setting, {type: "text", description: null, disabled: this.props.disabled, value: value, name: setting.key, label: null, extraContent: this.props.toolTip(listItem, setting.format)})}
+              {this.props.createEditableInput(setting, {
+                type: "text",
+                description: null,
+                disabled: this.props.disabled,
+                value: value,
+                name: setting.key,
+                label: null,
+                extraContent: this.props.renderToolTip(listItem, setting.format)
+              })}
             </WithRemoveButton>
           );
         })}
         <div>
           <span className="add-list-item">
-            { this.props.createEditableInput(setting, {value: null, disabled: this.props.disabled, ref: "addListItem", label: null, description: null})}
+            { this.props.createEditableInput(setting, {
+              value: null,
+              disabled: this.props.disabled,
+              ref: "addListItem",
+              label: null,
+              description: null
+            })}
           </span>
           <button
             type="button"
@@ -62,7 +76,7 @@ export default class InputList extends React.Component<InputListProps, InputList
     );
   }
 
-  removeListItem(listItem: string) {
+  removeListItem(listItem: string | {}) {
     this.setState({ listItems: this.state.listItems.filter(stateListItem => stateListItem !== listItem) });
   }
 

--- a/src/components/InputList.tsx
+++ b/src/components/InputList.tsx
@@ -1,13 +1,15 @@
 import * as React from "react";
 import WithRemoveButton from "./WithRemoveButton";
 import { SettingData } from "../interfaces";
+import ToolTip from "./ToolTip";
+import { LocatorIcon } from "@nypl/dgx-svg-icons";
 
 export interface InputListProps {
   createEditableInput: (setting: SettingData, customProps?: any, children?: JSX.Element[]) => JSX.Element;
   labelAndDescription: (SettingData) => JSX.Element[];
   setting: SettingData;
   disabled: boolean;
-  renderToolTip: (item: {} | string, format: string) => JSX.Element;
+  // renderToolTip: (item: {} | string, format: string) => JSX.Element;
   value: Array<string | {}>;
 }
 
@@ -50,7 +52,7 @@ export default class InputList extends React.Component<InputListProps, InputList
                 value: value,
                 name: setting.key,
                 label: null,
-                extraContent: this.props.renderToolTip(listItem, setting.format)
+                extraContent: this.renderToolTip(listItem, setting.format)
               })}
             </WithRemoveButton>
           );
@@ -74,6 +76,20 @@ export default class InputList extends React.Component<InputListProps, InputList
         </div>
       </div>
     );
+  }
+
+  renderToolTip(item: {} | string, format: string) {
+    const icons = {
+      "geographic": <LocatorIcon />
+    };
+    if (typeof(item) === "object") {
+      return (
+        <span className="input-group-addon">
+          <ToolTip trigger={icons[format]} direction="point-right" text={Object.values(item)[0]}/>
+        </span>
+      );
+    }
+    return null;
   }
 
   removeListItem(listItem: string | {}) {

--- a/src/components/InputList.tsx
+++ b/src/components/InputList.tsx
@@ -1,0 +1,82 @@
+import * as React from "react";
+import WithRemoveButton from "./WithRemoveButton";
+import { SettingData } from "../interfaces";
+
+export interface InputListProps {
+  createEditableInput: (setting: SettingData, customProps?: any, children?: JSX.Element[]) => JSX.Element;
+  labelAndDescription: (SettingData) => JSX.Element[];
+  setting: SettingData;
+  disabled: boolean;
+  toolTip: (item: any, format: string) => JSX.Element;
+  value: any;
+}
+
+export interface InputListState {
+  listItems: string[];
+}
+
+export default class InputList extends React.Component<InputListProps, InputListState> {
+  constructor(props) {
+    super(props);
+    this.state = {
+      listItems: (props.value as string[] || [])
+    };
+    this.addListItem = this.addListItem.bind(this);
+    this.removeListItem = this.removeListItem.bind(this);
+    this.clear = this.clear.bind(this);
+  }
+
+  componentWillReceiveProps(newProps) {
+    this.setState({ listItems: (newProps.value || []) });
+  }
+
+  render(): JSX.Element {
+    const setting = this.props.setting;
+    return (
+      <div>
+        { this.props.labelAndDescription(setting) }
+        { this.state.listItems && this.state.listItems.map((listItem) => {
+          let value = typeof(listItem) === "string" ? listItem : Object.keys(listItem)[0];
+          return (
+            <WithRemoveButton
+              key={value}
+              disabled={this.props.disabled}
+              onRemove={() => this.removeListItem(listItem)}
+            >
+              {this.props.createEditableInput(setting, {type: "text", description: null, disabled: this.props.disabled, value: value, name: setting.key, label: null, extraContent: this.props.toolTip(listItem, setting.format)})}
+            </WithRemoveButton>
+          );
+        })}
+        <div>
+          <span className="add-list-item">
+            { this.props.createEditableInput(setting, {value: null, disabled: this.props.disabled, ref: "addListItem", label: null, description: null})}
+          </span>
+          <button
+            type="button"
+            className="btn btn-default add-list-item"
+            disabled={this.props.disabled}
+            onClick={this.addListItem}
+            >Add</button>
+        </div>
+      </div>
+    );
+  }
+
+  removeListItem(listItem: string) {
+    this.setState({ listItems: this.state.listItems.filter(stateListItem => stateListItem !== listItem) });
+  }
+
+  addListItem() {
+    const listItem = (this.refs["addListItem"] as any).getValue();
+    this.setState({ listItems: this.state.listItems.concat(listItem) });
+    (this.refs["addListItem"] as any).clear();
+  }
+
+  getValue() {
+    return this.state.listItems;
+  }
+
+  clear() {
+    this.setState({ listItems: [] });
+  }
+}

--- a/src/components/LibraryEditForm.tsx
+++ b/src/components/LibraryEditForm.tsx
@@ -26,9 +26,9 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
     this.submit = this.submit.bind(this);
   }
 
-  separateCategories(nonRequiredFields) {
+  separateCategories(otherFields) {
     let categories = {};
-    nonRequiredFields.forEach((setting) => {
+    otherFields.forEach((setting) => {
       categories[setting.category] = categories[setting.category] ? categories[setting.category].concat(setting) : [setting];
     });
     return categories;
@@ -70,15 +70,15 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
   }
 
   render(): JSX.Element {
-    let requiredFields = [];
-    let nonRequiredFields = [];
+    let basicInfo = [];
+    let otherFields = [];
 
     if (this.props.data && this.props.data.settings) {
-      nonRequiredFields = this.props.data.settings.filter(setting => !setting.required);
-      requiredFields = this.props.data.settings.filter(setting => setting.required);
+      basicInfo = this.props.data.settings.filter(setting => (setting.required || setting.category === "Basic Information"));
+      otherFields = this.props.data.settings.filter(setting => !(new Set(basicInfo).has(setting)));
     }
 
-    let categories = this.separateCategories(nonRequiredFields);
+    let categories = this.separateCategories(otherFields);
 
     return (
       <form ref="form" onSubmit={this.submit} className="edit-form">
@@ -88,11 +88,11 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
           value={this.props.item && this.props.item.uuid}
           />
         <Collapsible
-          title="Required Fields"
+          title="Basic Information"
           openByDefault={true}
           body={
             <fieldset>
-              <legend className="visuallyHidden">Required Fields</legend>
+              <legend className="visuallyHidden">Basic Information</legend>
               <EditableInput
                 elementType="input"
                 type="text"
@@ -117,7 +117,7 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
                 description="A short name of this library, to use when identifying it in scripts or URLs, e.g. 'NYPL'."
                 error={this.props.error}
                 />
-              { requiredFields.map(setting =>
+              { basicInfo.map(setting =>
                 <ProtocolFormField
                   key={setting.key}
                   ref={setting.key}

--- a/src/components/ProtocolFormField.tsx
+++ b/src/components/ProtocolFormField.tsx
@@ -2,10 +2,8 @@ import * as React from "react";
 import EditableInput from "./EditableInput";
 import WithRemoveButton from "./WithRemoveButton";
 import ColorPicker from "./ColorPicker";
-import ToolTip from "./ToolTip";
 import SaveButton from "./SaveButton";
 import InputList from "./InputList";
-import { LocatorIcon } from "@nypl/dgx-svg-icons";
 import { SettingData } from "../interfaces";
 import { FetchErrorData } from "opds-web-client/lib/interfaces";
 
@@ -130,7 +128,6 @@ export default class ProtocolFormField extends React.Component<ProtocolFormField
         createEditableInput={this.createEditableInput}
         labelAndDescription={this.labelAndDescription}
         disabled={this.props.disabled}
-        renderToolTip={this.renderToolTip}
         value={value}
       />
     );
@@ -162,20 +159,6 @@ export default class ProtocolFormField extends React.Component<ProtocolFormField
       <div className="well description" dangerouslySetInnerHTML={{__html: setting.instructions }}></div>
     );
     return [label, description, instructions];
-  }
-
-  renderToolTip(item: {} | string, format: string) {
-    const icons = {
-      "geographic": <LocatorIcon />
-    };
-    if (typeof(item) === "object") {
-      return (
-        <span className="input-group-addon">
-          <ToolTip trigger={icons[format]} direction="point-right" text={Object.values(item)[0]}/>
-        </span>
-      );
-    }
-    return null;
   }
 
   isDefault(option) {

--- a/src/components/ProtocolFormField.tsx
+++ b/src/components/ProtocolFormField.tsx
@@ -3,13 +3,15 @@ import EditableInput from "./EditableInput";
 import WithRemoveButton from "./WithRemoveButton";
 import ColorPicker from "./ColorPicker";
 import ToolTip from "./ToolTip";
+import SaveButton from "./SaveButton";
+import { LocatorIcon } from "@nypl/dgx-svg-icons";
 import { SettingData } from "../interfaces";
 import { FetchErrorData } from "opds-web-client/lib/interfaces";
 
 export interface ProtocolFormFieldProps {
   setting: SettingData;
   disabled: boolean;
-  value?: string | string[];
+  value?: string | any[];
   default?: any;
   error?: FetchErrorData;
 }
@@ -35,188 +37,168 @@ export default class ProtocolFormField extends React.Component<ProtocolFormField
 
   render(): JSX.Element {
     const setting = this.props.setting;
-    if (setting.type === "text" || setting.type === undefined) {
-      return (
-        <div className={setting.randomizable ? "randomizable" : ""}>
-          <EditableInput
-            elementType="input"
-            type="text"
-            disabled={this.props.disabled}
-            name={setting.key}
-            label={setting.label}
-            required={setting.required}
-            description={setting.description}
-            value={this.props.value || setting.default}
-            error={this.props.error}
-            ref="element"
-            />
-            { setting.randomizable && !this.props.value &&
-              <div className="text-right">
-                <button
-                  className="btn btn-default"
-                  disabled={this.props.disabled}
-                  onClick={this.randomize}
-                  type="button">
-                  Set to random value
-                </button>
-              </div>
-            }
-        </div>
-      );
-    } else if (setting.type === "number") {
-      return (
-        <EditableInput
-          elementType="input"
-          validation="number"
-          required={setting.required}
-          step={1}
-          disabled={this.props.disabled}
-          name={setting.key}
-          label={setting.label}
-          description={setting.description}
-          value={this.props.value || setting.default}
-          error={this.props.error}
-          ref="element"
-          />
-      );
-    } else if (setting.type === "textarea") {
-      return (
-        <EditableInput
-          elementType="textarea"
-          type="text"
-          disabled={this.props.disabled}
-          name={setting.key}
-          label={setting.label}
-          required={setting.required}
-          description={setting.description}
-          value={this.props.value || setting.default}
-          error={this.props.error}
-          ref="element"
-          />
-      );
-    } else if (setting.type === "select") {
-      return (
-        <EditableInput
-          elementType="select"
-          disabled={this.props.disabled}
-          name={setting.key}
-          required={setting.required}
-          label={setting.label}
-          description={setting.description}
-          value={this.props.value || setting.default}
-          ref="element"
-          >
-          { setting.options && setting.options.map(option =>
-              <option key={option.key} value={option.key}>{option.label}</option>
-            )
-          }
-        </EditableInput>
-      );
+    if (setting.type === "select") {
+      return this.renderSelectSetting(setting);
     } else if (setting.type === "list" && setting.options) {
-      return (
-        <div>
-          <label>{setting.label}</label>
-          { setting.description &&
-            <span className="description" dangerouslySetInnerHTML={{__html: setting.description}} />
-          }
-          { setting.options.map(option =>
-              <EditableInput
-                key={option.key}
-                elementType="input"
-                type="checkbox"
-                required={setting.required}
-                disabled={this.props.disabled}
-                name={`${setting.key}_${option.key}`}
-                label={option.label}
-                error={this.props.error}
-                checked={this.shouldBeChecked(option)}
-                />
-            )
-          }
-        </div>
-      );
+        return this.renderListSettingWithOptions(setting);
     } else if (setting.type === "list") {
-      return (
-        <div>
-          <label>
-            {setting.label}
-            {setting.instructions && <ToolTip trigger={<span className="badge">?</span>} text={setting.instructions} direction="vertical" />}
-          </label>
-          { setting.description &&
-            <span className="description" dangerouslySetInnerHTML={{__html: setting.description}} />
-          }
-          { this.state.listItems && this.state.listItems.map(listItem =>
-              <WithRemoveButton
-                disabled={this.props.disabled}
-                onRemove={() => this.removeListItem(listItem)}
-                >
-                <EditableInput
-                  elementType="input"
-                  type="text"
-                  required={setting.required}
-                  disabled={this.props.disabled}
-                  name={setting.key}
-                  value={listItem}
-                  error={this.props.error}
-                  />
-              </WithRemoveButton>
-            )
-          }
-          <div>
-            <span className="add-list-item">
-              <EditableInput
-                elementType="input"
-                type="text"
-                required={setting.required}
-                disabled={this.props.disabled}
-                name={setting.key}
-                ref="addListItem"
-                error={this.props.error}
-                />
-            </span>
-            <button
-              type="button"
-              className="btn btn-default add-list-item"
-              disabled={this.props.disabled}
-              onClick={this.addListItem}
-              >Add</button>
-          </div>
-        </div>
-      );
-    } else if (setting.type === "image") {
-      return (
-        <div>
-          <label>{setting.label}</label>
-          { this.props.value &&
-            <img src={String(this.props.value)} />
-          }
-          <EditableInput
-            elementType="input"
-            type="file"
-            disabled={this.props.disabled}
-            required={setting.required}
-            name={setting.key}
-            description={setting.description}
-            accept="image/*"
-            error={this.props.error}
-            />
-        </div>
-      );
+        return this.renderListSetting(setting);
     } else if (setting.type === "color-picker") {
-      return (
+        return this.renderColorPickerSetting(setting);
+    } else {
+        return this.renderSetting(setting);
+    }
+  }
+
+  renderSetting(setting: SettingData, customProps = null): JSX.Element {
+    return (
+      <div className={setting.randomizable ? "randomizable" : ""}>
+        {this.props.value && setting.type === "image" && <img src={String(this.props.value)} />}
+        {
+          this.createEditableInput(setting)
+        }
+        { setting.randomizable && !this.props.value &&
+          <div className="text-right">
+            <SaveButton disabled={this.props.disabled} submit={this.randomize} text={"Set to random value"} type="button" />
+          </div>
+        }
+      </div>
+    );
+  }
+
+  createEditableInput(setting: SettingData, customProps = null, children = null): JSX.Element {
+    let elementType = setting.type && ["text", "textarea", "select"].includes(setting.type) ? setting.type : "input";
+
+    const extraProps = {
+      "image": {
+        accept: "image/*",
+        type: "file",
+        value: undefined
+      },
+      "number": {
+        validation: "number",
+        step: 1
+      }
+    };
+
+    const basicProps = {
+      key: setting.key,
+      elementType: elementType,
+      type: "text",
+      disabled: this.props.disabled,
+      name: setting.key,
+      label: setting.label,
+      required: setting.required,
+      description: setting.description,
+      value: this.props.value || setting.default,
+      error: this.props.error,
+      ref: "element",
+    };
+
+    let props = extraProps[setting.type] ? {...basicProps, ...extraProps[setting.type]} : basicProps;
+    if (customProps) {
+      props = {...props, ...customProps};
+    }
+    return React.createElement(EditableInput, props, children);
+  }
+
+  renderSelectSetting(setting): JSX.Element {
+    let children = setting.options && setting.options.map(option =>
+      <option key={option.key} value={option.key}>{option.label}</option>
+    );
+    return this.createEditableInput(setting, null, children);
+  }
+
+  renderListSettingWithOptions(setting): JSX.Element {
+    return (
+      <div>
+        { this.labelAndDescription(setting) }
+        { setting.options.map((option) => {
+            return this.createEditableInput(option, {
+                type: "checkbox",
+                required: setting.required,
+                name: `${setting.key}_${option.key}`,
+                checked: this.shouldBeChecked(option)
+              });
+            })
+        }
+      </div>
+    );
+  }
+
+  renderListSetting(setting): JSX.Element {
+    return (
+      <div>
+        { this.labelAndDescription(setting) }
+        { this.state.listItems && this.state.listItems.map((listItem) => {
+              let value = typeof(listItem) === "string" ? listItem : Object.keys(listItem)[0];
+              return (
+                <WithRemoveButton
+                  key={value}
+                  disabled={this.props.disabled}
+                  onRemove={() => this.removeListItem(listItem)}
+                >
+                  {this.createEditableInput(setting, {type: "text", description: null, value: value, name: setting.key, label: null, extraContent: this.toolTip(listItem, setting.format)})}
+                </WithRemoveButton>
+              );
+            }
+          )
+        }
         <div>
-          <label>{setting.label}</label>
-          { setting.description &&
-            <span className="description" dangerouslySetInnerHTML={{__html: setting.description }} />
-          }
-          <ColorPicker
-            value={String(this.props.value || setting.default)}
-            setting={setting}
-            ref="element"
-            />
+          <span className="add-list-item">
+            { this.createEditableInput(setting, {value: null, ref: "addListItem", label: null, description: null})}
+          </span>
+          <button
+            type="button"
+            className="btn btn-default add-list-item"
+            disabled={this.props.disabled}
+            onClick={this.addListItem}
+            >Add</button>
         </div>
+      </div>
+    );
+  }
+
+  renderColorPickerSetting(setting): JSX.Element {
+    return (
+      <div>
+        { this.labelAndDescription(setting) }
+        <ColorPicker
+          value={String(this.props.value || setting.default)}
+          setting={setting}
+          ref="element"
+        />
+      </div>
+    );
+  }
+
+  labelAndDescription(setting: SettingData): JSX.Element[] {
+    let label = (
+      <label key={setting.label}>
+        {setting.label}
+        {setting.instructions && <ToolTip trigger={<span className="badge">?</span>} text={setting.instructions} direction="vertical" />}
+      </label>
+    );
+
+    let description = setting.description && (
+      <span key={setting.description} className="description" dangerouslySetInnerHTML={{__html: setting.description }} />
+    );
+    return [label, description];
+  }
+
+  toolTip(item, format) {
+    const icons = {
+      "geographic": <LocatorIcon />
+    };
+
+    if (typeof(item) === "object") {
+      return (
+        <span className="input-group-addon">
+          <ToolTip trigger={icons[format]} direction="point-right" text={Object.values(item)[0]}/>
+        </span>
       );
     }
+    return null;
   }
 
   isDefault(option) {
@@ -226,7 +208,9 @@ export default class ProtocolFormField extends React.Component<ProtocolFormField
   }
 
   shouldBeChecked(option) {
-    let isValue = (this.props.value && (this.props.value.indexOf(option.key) !== -1));
+    let isValue = this.props.value &&
+      (typeof(this.props.value) === "string" || (Array.isArray(this.props.value) && this.props.value.every(x => typeof(x) === "string"))) &&
+      (this.props.value === option.key || Array.isArray(this.props.value) && this.props.value.includes(option.key));
     let isDefault = (!this.props.value && this.isDefault(option));
     return isValue || isDefault;
   }
@@ -266,6 +250,4 @@ export default class ProtocolFormField extends React.Component<ProtocolFormField
     }
     this.setState({ listItems: [] });
   }
-
-
 }

--- a/src/components/ProtocolFormField.tsx
+++ b/src/components/ProtocolFormField.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import EditableInput from "./EditableInput";
 import WithRemoveButton from "./WithRemoveButton";
 import ColorPicker from "./ColorPicker";
+import ToolTip from "./ToolTip";
 import { SettingData } from "../interfaces";
 import { FetchErrorData } from "opds-web-client/lib/interfaces";
 
@@ -137,7 +138,10 @@ export default class ProtocolFormField extends React.Component<ProtocolFormField
     } else if (setting.type === "list") {
       return (
         <div>
-          <label>{setting.label}</label>
+          <label>
+            {setting.label}
+            {setting.instructions && <ToolTip trigger={<span className="badge">?</span>} text={setting.instructions} direction="vertical" />}
+          </label>
           { setting.description &&
             <span className="description" dangerouslySetInnerHTML={{__html: setting.description}} />
           }

--- a/src/components/ProtocolFormField.tsx
+++ b/src/components/ProtocolFormField.tsx
@@ -119,6 +119,8 @@ export default class ProtocolFormField extends React.Component<ProtocolFormField
   }
 
   renderListSetting(setting): JSX.Element {
+    // Flatten an object in which the values are arrays
+    let value = Array.isArray(this.props.value) ? this.props.value : (this.props.value && [].concat.apply([], Object.values(this.props.value)));
     return (
       <InputList
         ref="element"
@@ -127,7 +129,7 @@ export default class ProtocolFormField extends React.Component<ProtocolFormField
         labelAndDescription={this.labelAndDescription}
         disabled={this.props.disabled}
         toolTip={this.toolTip}
-        value={this.props.value}
+        value={value}
       />
     );
   }

--- a/src/components/SaveButton.tsx
+++ b/src/components/SaveButton.tsx
@@ -4,6 +4,7 @@ export interface SaveButtonProps {
   disabled: boolean;
   submit?: any;
   text?: string;
+  type?: string;
 }
 
 export default class SaveButton extends React.Component<SaveButtonProps, void> {
@@ -14,9 +15,10 @@ export default class SaveButton extends React.Component<SaveButtonProps, void> {
 
   render(): JSX.Element {
    let text = this.props.text || "Save";
+   let type = this.props.type || "submit";
    return (
      <button
-       type="submit"
+       type={type}
        className="btn btn-default"
        disabled={this.props.disabled}
        onClick={this.props.submit}

--- a/src/components/ToolTip.tsx
+++ b/src/components/ToolTip.tsx
@@ -7,6 +7,7 @@ export interface ToolTipState {
 export interface ToolTipProps {
   trigger: JSX.Element;
   text: string;
+  direction?: string;
 }
 
 export default class ToolTip extends React.Component <ToolTipProps, ToolTipState> {
@@ -24,8 +25,10 @@ export default class ToolTip extends React.Component <ToolTipProps, ToolTipState
     return(
       <div className="tool-tip-container" onMouseEnter={this.showToolTip} onMouseLeave={this.hideToolTip}>
         { this.props.trigger }
-        <span className={`tool-tip ${this.state.show ? "" : "hide"}`}>
-          {this.props.text}
+        <span
+          className={`tool-tip ${this.state.show ? "" : "hide"} ${this.props.direction ? this.props.direction : ""}`}
+          dangerouslySetInnerHTML={{__html: this.props.text}}
+        >
         </span>
       </div>
     );

--- a/src/components/__tests__/EditableInput-test.tsx
+++ b/src/components/__tests__/EditableInput-test.tsx
@@ -62,6 +62,17 @@ describe("EditableInput", () => {
     expect(input.prop("checked")).to.equal(true);
   });
 
+  it("optionally shows extra content", () => {
+    let extra = wrapper.find(".with-add-on");
+    expect(extra.length).to.equal(0);
+
+    wrapper.setProps({ extraContent: <span>Extra content!</span> });
+
+    extra = wrapper.find(".with-add-on");
+    expect(extra.length).to.equal(1);
+    expect(extra.text()).to.equal("Extra content!");
+  });
+
   it("shows children from props", () => {
     let option = wrapper.find("option");
     expect(option.text()).to.equal("option");

--- a/src/components/__tests__/InputList-test.tsx
+++ b/src/components/__tests__/InputList-test.tsx
@@ -1,0 +1,150 @@
+import { expect } from "chai";
+import * as React from "react";
+import { mount } from "enzyme";
+import { spy, stub } from "sinon";
+
+import InputList from "../InputList";
+import ProtocolFormField from "../ProtocolFormField";
+import EditableInput from "../EditableInput";
+import WithRemoveButton from "../WithRemoveButton";
+import ToolTip from "../ToolTip";
+
+describe("InputList", () => {
+  let wrapper;
+  let value = ["Thing 1", "Thing 2"];
+  let setting = {
+    key: "setting",
+    label: "label",
+    description: "description",
+    type: "list"
+  };
+  let parent;
+  let createEditableInput;
+  let labelAndDescription;
+  let toolTip;
+
+  beforeEach(() => {
+    parent = mount(<ProtocolFormField setting={setting} disabled={false} />);
+    createEditableInput = spy(parent.instance(), "createEditableInput");
+    labelAndDescription = spy(parent.instance(), "labelAndDescription");
+    toolTip = spy(parent.instance(), "toolTip");
+
+    wrapper = mount(
+      <InputList
+        createEditableInput={createEditableInput}
+        labelAndDescription={labelAndDescription}
+        toolTip={toolTip}
+        value={value}
+        setting={setting}
+        disabled={false}
+      />
+    );
+  });
+
+  it("renders a label and description", () => {
+    expect(labelAndDescription.callCount).to.equal(1);
+    expect(labelAndDescription.args[0][0]).to.deep.equal(setting);
+    let label = wrapper.find("label");
+    expect(label.length).to.equal(1);
+    expect(label.text()).to.equal("label");
+
+    let description = wrapper.find(".description").at(0);
+    expect(description.text()).to.equal("description");
+  });
+
+  it("renders a list of items", () => {
+    let inputs = wrapper.find(".form-control");
+    expect(inputs.length).to.equal(3);
+    expect(inputs.at(0).prop("value")).to.equal("Thing 1");
+    expect(inputs.at(0).prop("type")).to.equal("text");
+    expect(inputs.at(0).prop("name")).to.equal("setting");
+
+    expect(inputs.at(1).prop("value")).to.equal("Thing 2");
+    expect(inputs.at(1).prop("type")).to.equal("text");
+    expect(inputs.at(1).prop("name")).to.equal("setting");
+
+    expect(inputs.at(2).prop("value")).to.equal("");
+    expect(inputs.at(2).prop("type")).to.equal("text");
+    expect(inputs.at(2).prop("name")).to.equal("setting");
+
+    expect(createEditableInput.callCount).to.equal(3);
+  });
+
+  it("renders WithRemoveButton elements", () => {
+    let withRemoveButtons = wrapper.find(WithRemoveButton);
+    expect(withRemoveButtons.length).to.equal(2);
+    expect(withRemoveButtons.at(0).prop("disabled")).to.be.false;
+    expect(withRemoveButtons.at(0).find("input").prop("value")).to.equal("Thing 1");
+    expect(withRemoveButtons.at(1).prop("disabled")).to.be.false;
+    expect(withRemoveButtons.at(1).find("input").prop("value")).to.equal("Thing 2");
+  });
+
+  it("renders a button for adding a list item", () => {
+    let addListItem = wrapper.find("span.add-list-item");
+    expect(addListItem.length).to.equal(1);
+    expect(addListItem.find("input").prop("value")).to.equal("");
+    expect(addListItem.parent().find(WithRemoveButton).length).to.equal(0);
+    expect(addListItem.parent().find("button").text()).to.equal("Add");
+  });
+
+  it("optionally renders a tooltip with extra content", () => {
+    let valueWithObject = [{"Thing 3": "extra information!"}];
+    let geographicSetting = {...setting, ...{format: "geographic"}};
+
+    wrapper.setProps({ setting: geographicSetting, value: valueWithObject });
+
+    let withAddOn = wrapper.find(".with-add-on");
+    expect(withAddOn.length).to.equal(1);
+
+    let addOn = withAddOn.find(".input-group-addon");
+    expect(addOn.length).to.equal(1);
+    let toolTipElement = addOn.find(ToolTip);
+    expect(toolTipElement.length).to.equal(1);
+    expect(toolTipElement.find("svg").hasClass("locatorIcon")).to.be.true;
+    expect(toolTipElement.find(".tool-tip").hasClass("point-right")).to.be.true;
+    expect(toolTipElement.find(".tool-tip").text()).to.equal("extra information!");
+
+    expect(withAddOn.find("input").length).to.equal(1);
+    expect(withAddOn.find("input").prop("value")).to.equal("Thing 3");
+    expect(toolTip.args[2]).to.eql([valueWithObject[0], "geographic"]);
+  });
+
+  it("removes an item", () => {
+    let removables = wrapper.find(WithRemoveButton);
+    expect(removables.length).to.equal(2);
+    let button = removables.at(0).find(".remove");
+    button.simulate("click");
+    removables = wrapper.find(WithRemoveButton);
+    expect(removables.length).to.equal(1);
+  });
+
+  it("adds an item", () => {
+    let removables = wrapper.find(WithRemoveButton);
+    expect(removables.length).to.equal(2);
+
+    let blankInput = wrapper.find("span.add-list-item input");
+    blankInput.value = "Another thing...";
+    blankInput.simulate("change");
+    let addButton = wrapper.find("button.add-list-item");
+    addButton.simulate("click");
+
+    removables = wrapper.find(WithRemoveButton);
+    expect(removables.length).to.equal(3);
+
+    blankInput = wrapper.find("span.add-list-item input");
+    expect(blankInput.prop("value")).to.equal("");
+  });
+
+  it("gets the value", () => {
+      expect((wrapper.instance() as InputList).getValue()).to.eql(value);
+  });
+
+  it("clears all the items", () => {
+    let removables = wrapper.find(WithRemoveButton);
+    expect(removables.length).to.equal(2);
+
+    (wrapper.instance() as InputList).clear();
+    removables = wrapper.find(WithRemoveButton);
+    expect(removables.length).to.equal(0);
+  });
+});

--- a/src/components/__tests__/InputList-test.tsx
+++ b/src/components/__tests__/InputList-test.tsx
@@ -21,19 +21,19 @@ describe("InputList", () => {
   let parent;
   let createEditableInput;
   let labelAndDescription;
-  let toolTip;
+  let renderToolTip;
 
   beforeEach(() => {
     parent = mount(<ProtocolFormField setting={setting} disabled={false} />);
     createEditableInput = spy(parent.instance(), "createEditableInput");
     labelAndDescription = spy(parent.instance(), "labelAndDescription");
-    toolTip = spy(parent.instance(), "toolTip");
+    renderToolTip = spy(parent.instance(), "renderToolTip");
 
     wrapper = mount(
       <InputList
         createEditableInput={createEditableInput}
         labelAndDescription={labelAndDescription}
-        toolTip={toolTip}
+        renderToolTip={renderToolTip}
         value={value}
         setting={setting}
         disabled={false}
@@ -106,7 +106,7 @@ describe("InputList", () => {
 
     expect(withAddOn.find("input").length).to.equal(1);
     expect(withAddOn.find("input").prop("value")).to.equal("Thing 3");
-    expect(toolTip.args[2]).to.eql([valueWithObject[0], "geographic"]);
+    expect(renderToolTip.args[2]).to.eql([valueWithObject[0], "geographic"]);
   });
 
   it("removes an item", () => {

--- a/src/components/__tests__/InputList-test.tsx
+++ b/src/components/__tests__/InputList-test.tsx
@@ -21,19 +21,16 @@ describe("InputList", () => {
   let parent;
   let createEditableInput;
   let labelAndDescription;
-  let renderToolTip;
 
   beforeEach(() => {
     parent = mount(<ProtocolFormField setting={setting} disabled={false} />);
     createEditableInput = spy(parent.instance(), "createEditableInput");
     labelAndDescription = spy(parent.instance(), "labelAndDescription");
-    renderToolTip = spy(parent.instance(), "renderToolTip");
 
     wrapper = mount(
       <InputList
         createEditableInput={createEditableInput}
         labelAndDescription={labelAndDescription}
-        renderToolTip={renderToolTip}
         value={value}
         setting={setting}
         disabled={false}
@@ -90,6 +87,7 @@ describe("InputList", () => {
   it("optionally renders a tooltip with extra content", () => {
     let valueWithObject = [{"Thing 3": "extra information!"}];
     let geographicSetting = {...setting, ...{format: "geographic"}};
+    let spyToolTip = spy(wrapper.instance(), "renderToolTip");
 
     wrapper.setProps({ setting: geographicSetting, value: valueWithObject });
 
@@ -106,7 +104,7 @@ describe("InputList", () => {
 
     expect(withAddOn.find("input").length).to.equal(1);
     expect(withAddOn.find("input").prop("value")).to.equal("Thing 3");
-    expect(renderToolTip.args[2]).to.eql([valueWithObject[0], "geographic"]);
+    expect(spyToolTip.args[0]).to.eql([valueWithObject[0], "geographic"]);
   });
 
   it("removes an item", () => {

--- a/src/components/__tests__/LibraryEditForm-test.tsx
+++ b/src/components/__tests__/LibraryEditForm-test.tsx
@@ -25,8 +25,9 @@ describe("LibraryEditForm", () => {
   let settingFields = [
     { key: "privacy-policy", label: "Privacy Policy", category: "Links" },
     { key: "copyright", label: "Copyright", category: "Links" },
-    { key: "logo", label: "Logo", category: "Client Interface Customization"},
-    { key: "large_collection_languages", label: "Languages", category: "Languages" }
+    { key: "logo", label: "Logo", category: "Client Interface Customization" },
+    { key: "large_collection_languages", label: "Languages", category: "Languages" },
+    { key: "service_area", label: "Service Area", category: "Geographic Areas", type: "list" }
   ];
 
   let editableInputByName = (name) => {
@@ -45,6 +46,14 @@ describe("LibraryEditForm", () => {
     return [];
   };
 
+  let collapsibleByName = (name: string) => {
+    let collapsibles = wrapper.find(Collapsible);
+    if (collapsibles.length >= 1) {
+      return collapsibles.filterWhere(collapsible => collapsible.find(".panel-heading").text().startsWith(name));
+    }
+    return [];
+  };
+
   describe("rendering", () => {
     beforeEach(() => {
       save = stub();
@@ -55,7 +64,7 @@ describe("LibraryEditForm", () => {
           save={save}
           urlBase="url base"
           listDataKey="libraries"
-          />
+        />
       );
     });
 
@@ -103,23 +112,26 @@ describe("LibraryEditForm", () => {
 
     it("subdivides fields", () => {
       let collapsible = wrapper.find(".collapsible");
-      expect(collapsible.length).to.equal(4);
+      expect(collapsible.length).to.equal(5);
 
-      let required = collapsible.at(0).find(".panel-heading");
-      expect(required.text()).to.equal("Required Fields");
+      let basic = collapsible.at(0).find(".panel-heading");
+      expect(basic.text()).to.equal("Basic Information");
 
-      let optional = collapsible.slice(1, collapsible.length);
-      optional.map((form) => {
+      let other = collapsible.slice(1, collapsible.length);
+      other.map((form) => {
         let title = form.find(".panel-heading").text();
         expect(title).to.contain("(Optional)");
       });
 
-      let links = collapsible.filterWhere(form => form.find(".panel-heading").text() === "Links (Optional)");
-      expect(links.find(ProtocolFormField).length).to.equal(2);
-      let languages = collapsible.filterWhere(form => form.find(".panel-heading").text() === "Languages (Optional)");
-      expect(languages.find(ProtocolFormField).length).to.equal(1);
-      let customization = collapsible.filterWhere(form => form.find(".panel-heading").text() === "Client Interface Customization (Optional)");
-      expect(customization.find(ProtocolFormField).length).to.equal(1);
+      expect(collapsibleByName("Links").find(ProtocolFormField).length).to.equal(2);
+      expect(collapsibleByName("Languages").find(ProtocolFormField).length).to.equal(1);
+      expect(collapsibleByName("Client Interface Customization").find(ProtocolFormField).length).to.equal(1);
+
+      let geographic = collapsibleByName("Geographic Areas");
+      expect(geographic.find(ProtocolFormField).length).to.equal(1);
+      expect(geographic.find(".add-list-item").length).to.equal(2);
+      expect(geographic.find(".add-list-item").at(0).type()).to.equal("span");
+      expect(geographic.find(".add-list-item").at(1).type()).to.equal("button");
     });
 
     it("has a save button", () => {

--- a/src/components/__tests__/ProtocolFormField-test.tsx
+++ b/src/components/__tests__/ProtocolFormField-test.tsx
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 
 import * as React from "react";
-import { shallow, mount } from "enzyme";
+import { mount } from "enzyme";
 
 import ProtocolFormField from "../ProtocolFormField";
 import EditableInput from "../EditableInput";
@@ -9,30 +9,30 @@ import WithRemoveButton from "../WithRemoveButton";
 import ColorPicker from "../ColorPicker";
 
 describe("ProtocolFormField", () => {
-  it("renders text setting", () => {
-    const setting = {
-      key: "setting",
-      label: "label",
-      description: "<p>description</p>"
-    };
-    const wrapper = mount(
-      <ProtocolFormField
-        setting={setting}
-        disabled={true}
-        />
-    );
+  let setting = {
+    key: "setting",
+    label: "label",
+    description: "<p>description</p>"
+  };
+  let wrapper;
 
+  beforeEach(() => {
+    wrapper = mount(<ProtocolFormField setting={setting} disabled={false} />);
+  });
+
+  it("renders text setting", () => {
     let input = wrapper.find(EditableInput);
     expect(input.length).to.equal(1);
     expect(input.prop("type")).to.equal("text");
-    expect(input.prop("disabled")).to.equal(true);
+    expect(input.prop("disabled")).to.equal(false);
     expect(input.prop("name")).to.equal("setting");
     expect(input.prop("label")).to.equal("label");
     expect(input.prop("description")).to.equal("<p>description</p>");
     expect(input.prop("value")).to.be.undefined;
 
-    wrapper.setProps({ value: "test" });
+    wrapper.setProps({ value: "test", disabled: true });
     input = wrapper.find(EditableInput);
+    expect(input.prop("disabled")).to.equal(true);
     expect(input.prop("value")).to.equal("test");
     let inputElement = input.find("input").get(0) as any;
     expect(inputElement.value).to.equal("test");
@@ -42,17 +42,8 @@ describe("ProtocolFormField", () => {
   });
 
   it("renders optional setting", () => {
-    const setting = {
-      key: "setting",
-      label: "label",
-      optional: true
-    };
-    const wrapper = mount(
-      <ProtocolFormField
-        setting={setting}
-        disabled={false}
-        />
-    );
+    const optionalSetting = {...setting, ...{optional: true}};
+    wrapper.setProps({ setting, optionalSetting });
 
     let input = wrapper.find(EditableInput);
     let description = wrapper.find(".description");
@@ -60,21 +51,12 @@ describe("ProtocolFormField", () => {
     expect(input.prop("disabled")).to.equal(false);
     expect(input.prop("name")).to.equal("setting");
     expect(input.prop("label")).to.equal("label");
-    expect(description.text()).to.equal("(Optional) ");
+    expect(description.text()).to.equal("(Optional) description");
   });
 
   it("renders randomizable setting", () => {
-    const setting = {
-      key: "setting",
-      label: "label",
-      randomizable: true
-    };
-    const wrapper = mount(
-      <ProtocolFormField
-        setting={setting}
-        disabled={false}
-        />
-    );
+    let randomizableSetting = {...setting, ...{randomizable: true}};
+    wrapper.setProps({ setting: randomizableSetting });
 
     let input = wrapper.find(EditableInput);
     expect(input.length).to.equal(1);
@@ -99,18 +81,8 @@ describe("ProtocolFormField", () => {
   });
 
   it("renders setting with default", () => {
-    const setting = {
-      key: "setting",
-      label: "label",
-      default: "default"
-    };
-    const wrapper = shallow(
-      <ProtocolFormField
-        setting={setting}
-        disabled={true}
-        />
-    );
-
+    let defaultSetting = {...setting, ...{default: "default"}};
+    wrapper.setProps({ setting: defaultSetting });
     let input = wrapper.find(EditableInput);
     expect(input.length).to.equal(1);
     expect(input.prop("name")).to.equal("setting");
@@ -123,26 +95,11 @@ describe("ProtocolFormField", () => {
 
   it("calculates whether checkbox should be checked by default", () => {
     const defaultOptions = ["box2"];
-    const setting = {
-      key: "setting",
-      label: "label",
-      description: "<p>description</p>",
-      type: "list",
-      options: [
-        { key: "box1", label: "don't check" },
-        { key: "box2", label: "check" },
-      ]
-    };
-    const wrapper = mount(
-      <ProtocolFormField
-        setting={setting}
-        disabled={false}
-        default={defaultOptions}
-        />
-    );
+    let defaultOptionsSetting = {...setting, ...{type: "list", options: [{ key: "box1", label: "don't check" }, { key: "box2", label: "check" }]}};
+    wrapper.setProps({ setting: defaultOptionsSetting, default: defaultOptions });
 
-    expect((wrapper.instance() as ProtocolFormField).shouldBeChecked(setting.options[0])).to.be.false;
-    expect((wrapper.instance() as ProtocolFormField).shouldBeChecked(setting.options[1])).to.be.true;
+    expect((wrapper.instance() as ProtocolFormField).shouldBeChecked(defaultOptionsSetting.options[0])).to.be.false;
+    expect((wrapper.instance() as ProtocolFormField).shouldBeChecked(defaultOptionsSetting.options[1])).to.be.true;
 
     let input = wrapper.find(EditableInput);
     expect(input.length).to.equal(2);
@@ -160,23 +117,12 @@ describe("ProtocolFormField", () => {
   });
 
   it("renders number setting", () => {
-    const setting = {
-      key: "setting",
-      type: "number",
-      label: "label",
-      description: "<p>description</p>"
-    };
-    const wrapper = shallow(
-      <ProtocolFormField
-        setting={setting}
-        disabled={true}
-        />
-    );
-
+    let numberSetting = {...setting, ...{"type": "number"}};
+    wrapper.setProps({ setting: numberSetting });
     let input = wrapper.find(EditableInput);
     expect(input.length).to.equal(1);
     expect(input.prop("validation")).to.equal("number");
-    expect(input.prop("disabled")).to.equal(true);
+    expect(input.prop("disabled")).to.equal(false);
     expect(input.prop("name")).to.equal("setting");
     expect(input.prop("label")).to.equal("label");
     expect(input.prop("description")).to.equal("<p>description</p>");
@@ -188,21 +134,8 @@ describe("ProtocolFormField", () => {
   });
 
   it("renders select setting", () => {
-    const setting = {
-      key: "setting",
-      label: "label",
-      type: "select",
-      options: [
-        { key: "option1", label: "option 1" },
-        { key: "option2", label: "option 2" }
-      ]
-    };
-    const wrapper = shallow(
-      <ProtocolFormField
-        setting={setting}
-        disabled={false}
-        />
-    );
+    let selectSetting = {...setting, ...{type: "select", options: [{ key: "option1", label: "option 1" }, { key: "option2", label: "option 2" }]}};
+    wrapper.setProps({ setting: selectSetting });
 
     let input = wrapper.find(EditableInput);
     expect(input.length).to.equal(1);
@@ -219,18 +152,8 @@ describe("ProtocolFormField", () => {
   });
 
   it("renders textarea setting", () => {
-    const setting = {
-      key: "setting",
-      label: "label",
-      type: "textarea",
-      description: "<p>Textarea</p>"
-    };
-    const wrapper = mount(
-      <ProtocolFormField
-        setting={setting}
-        disabled={false}
-        />
-    );
+    let textareaSetting = {...setting, ...{type: "textarea", description: "<p>Textarea</p>"}};
+    wrapper.setProps({ setting: textareaSetting });
 
     let input = wrapper.find(EditableInput);
     expect(input.length).to.equal(1);
@@ -255,25 +178,8 @@ describe("ProtocolFormField", () => {
 
   it("renders list setting with options", () => {
     const defaultOptions = ["option2", "option3"];
-    const setting = {
-      key: "setting",
-      label: "label",
-      description: "<p>description</p>",
-      type: "list",
-      options: [
-        { key: "option1", label: "option 1" },
-        { key: "option2", label: "option 2" },
-        { key: "option3", label: "option 3" }
-      ],
-      default: defaultOptions
-    };
-    const wrapper = mount(
-      <ProtocolFormField
-        setting={setting}
-        disabled={false}
-        default={defaultOptions}
-        />
-    );
+    let listSettingWithOptions = {...setting, ...{type: "list", options: [{ key: "option1", label: "option 1" }, { key: "option2", label: "option 2" }, { key: "option3", label: "option 3" }], default: defaultOptions}};
+    wrapper.setProps({ setting: listSettingWithOptions, default: defaultOptions });
 
     expect(wrapper.find("div").at(0).text()).to.contain("label");
     let description = wrapper.find(".description");
@@ -305,86 +211,14 @@ describe("ProtocolFormField", () => {
     expect(input.at(2).prop("checked")).to.be.ok;
   });
 
-  it("renders list setting without options", () => {
-    const setting = {
-      key: "setting",
-      label: "label",
-      description: "<p>description</p>",
-      type: "list"
-    };
-    let wrapper = mount(
-      <ProtocolFormField
-        setting={setting}
-        disabled={false}
-        />
-    );
-
-    expect(wrapper.text()).to.contain("label");
-    let input = wrapper.find("input[name='setting']") as any;
-    expect(input.length).to.equal(1);
-    let button = wrapper.find("button");
-    expect(button.length).to.equal(1);
-    let description = wrapper.find(".description");
-    expect(description.at(0).html()).to.contain("<p>description</p>");
-
-    wrapper = mount(
-      <ProtocolFormField
-        setting={setting}
-        disabled={false}
-        value={["option1", "option2"]}
-        />
-    );
-    input = wrapper.find("input[name='setting']") as any;
-    expect(input.length).to.equal(3);
-    expect(input.at(0).props().value).to.equal("option1");
-    expect(input.at(1).props().value).to.equal("option2");
-
-    input.at(2).get(0).value = "option3";
-    button = wrapper.find("button");
-    button.simulate("click");
-
-    input = wrapper.find("input[name='setting']") as any;
-    expect(input.length).to.equal(4);
-    expect(input.at(0).props().value).to.equal("option1");
-    expect(input.at(1).props().value).to.equal("option2");
-    expect(input.at(2).props().value).to.equal("option3");
-
-    let removables = wrapper.find(WithRemoveButton);
-    expect(removables.length).to.equal(3);
-    let remove = removables.at(0).find(".remove");
-    remove.simulate("click");
-
-    input = wrapper.find("input[name='setting']") as any;
-    expect(input.length).to.equal(3);
-    expect(input.at(0).props().value).to.equal("option2");
-    expect(input.at(1).props().value).to.equal("option3");
-
-    removables = wrapper.find(WithRemoveButton);
-    expect(removables.length).to.equal(2);
-
-    (wrapper.instance() as ProtocolFormField).clear();
-    removables = wrapper.find(WithRemoveButton);
-    expect(removables.length).to.equal(0);
-  });
-
   it("renders image setting", () => {
-    const setting = {
-      key: "setting",
-      label: "label",
-      description: "<p>description</p>",
-      type: "image"
-    };
-    const wrapper = mount(
-      <ProtocolFormField
-        setting={setting}
-        disabled={true}
-        />
-    );
+    let imageSetting = {...setting, ...{type: "image"}};
+    wrapper.setProps({ setting: imageSetting });
 
     let input = wrapper.find(EditableInput);
     expect(input.length).to.equal(1);
     expect(input.prop("type")).to.equal("file");
-    expect(input.prop("disabled")).to.equal(true);
+    expect(input.prop("disabled")).to.equal(false);
     expect(input.prop("name")).to.equal("setting");
     expect(input.prop("label")).to.equal("label");
     expect(input.prop("description")).to.equal("<p>description</p>");
@@ -403,23 +237,12 @@ describe("ProtocolFormField", () => {
   });
 
   it("renders color picker setting", () => {
-    const setting = {
-      key: "setting",
-      label: "label",
-      description: "<p>description</p>",
-      type: "color-picker",
-      default: "#aaaaaa"
-    };
-    const wrapper = shallow(
-      <ProtocolFormField
-        setting={setting}
-        disabled={true}
-        />
-    );
+    let colorPickerSetting = {...setting, ...{type: "color-picker", default: "#aaaaaa"}};
+    wrapper.setProps({ setting: colorPickerSetting });
 
     let picker = wrapper.find(ColorPicker);
     expect(picker.length).to.equal(1);
-    expect(picker.prop("setting")).to.equal(setting);
+    expect(picker.prop("setting")).to.equal(colorPickerSetting);
     expect(picker.prop("value")).to.equal("#aaaaaa");
     let label = wrapper.find("label");
     expect(label.text()).to.equal("label");
@@ -430,56 +253,27 @@ describe("ProtocolFormField", () => {
   });
 
   it("gets value of list setting without options", () => {
-    const setting = {
-      key: "setting",
-      label: "label",
-      description: "<p>description</p>",
-      type: "list"
-    };
-    let wrapper = mount(
-      <ProtocolFormField
-        setting={setting}
-        disabled={false}
-        value={["item 1", "item 2"]}
-        />
-    );
+    wrapper.setProps({ setting: {...setting, ...{type: "list"}}, value: ["item 1", "item 2"] });
     expect((wrapper.instance() as ProtocolFormField).getValue()).to.deep.equal(["item 1", "item 2"]);
   });
 
-  it("optionally gets extra content", () => {
-    const setting = {
-      key: "setting",
-      label: "label",
-      type: "list",
-      format: "geographic"
-    };
-    const value = [{ "item name": "Extra content!" }];
-    let wrapper = mount(
-      <ProtocolFormField
-        setting={setting}
-        value={value}
-        disabled={false}
-      />
-    );
-    expect(wrapper.find(".with-add-on").length).to.equal(1);
-    expect(wrapper.find(".tool-tip-container").length).to.equal(1);
-    expect(wrapper.text()).to.include("Extra content!");
-    expect(wrapper.find("input").at(0).prop("value")).to.equal("item name");
+  it("optionally renders instructions", () => {
+    let instructionsSetting = {...setting, ...{instructions: "<ul><li>Step 1</li></ul>", type: "list"}};
+    wrapper.setProps({ setting: instructionsSetting });
+
+    let toolTip = wrapper.find(".tool-tip-container");
+    expect(toolTip.length).to.equal(1);
+    let trigger = toolTip.find(".badge");
+    expect(trigger.length).to.equal(1);
+    expect(trigger.text()).to.equal("?");
+    let text = toolTip.find(".tool-tip");
+    expect(text.length).to.equal(1);
+    expect(text.hasClass("vertical")).to.be.true;
+    expect(text.text()).to.equal("Step 1");
   });
 
   it("gets value of text setting", () => {
-    const setting = {
-      key: "setting",
-      label: "label",
-      description: "<p>description</p>"
-    };
-    const wrapper = mount(
-      <ProtocolFormField
-        setting={setting}
-        disabled={true}
-        value="test"
-        />
-    );
+    wrapper.setProps({ value: "test" });
     expect((wrapper.instance() as ProtocolFormField).getValue()).to.equal("test");
   });
 });

--- a/src/components/__tests__/ProtocolFormField-test.tsx
+++ b/src/components/__tests__/ProtocolFormField-test.tsx
@@ -300,7 +300,6 @@ describe("ProtocolFormField", () => {
 
     input = wrapper.find(EditableInput);
     expect(input.length).to.equal(3);
-
     expect(input.at(0).prop("checked")).to.be.ok;
     expect(input.at(1).prop("checked")).not.to.be.ok;
     expect(input.at(2).prop("checked")).to.be.ok;
@@ -375,7 +374,7 @@ describe("ProtocolFormField", () => {
       description: "<p>description</p>",
       type: "image"
     };
-    const wrapper = shallow(
+    const wrapper = mount(
       <ProtocolFormField
         setting={setting}
         disabled={true}
@@ -387,7 +386,7 @@ describe("ProtocolFormField", () => {
     expect(input.prop("type")).to.equal("file");
     expect(input.prop("disabled")).to.equal(true);
     expect(input.prop("name")).to.equal("setting");
-    expect(input.prop("label")).to.be.undefined;
+    expect(input.prop("label")).to.equal("label");
     expect(input.prop("description")).to.equal("<p>description</p>");
     expect(input.prop("value")).to.be.undefined;
     expect(input.prop("accept")).to.equal("image/*");
@@ -445,6 +444,27 @@ describe("ProtocolFormField", () => {
         />
     );
     expect((wrapper.instance() as ProtocolFormField).getValue()).to.deep.equal(["item 1", "item 2"]);
+  });
+
+  it("optionally gets extra content", () => {
+    const setting = {
+      key: "setting",
+      label: "label",
+      type: "list",
+      format: "geographic"
+    };
+    const value = [{ "item name": "Extra content!" }];
+    let wrapper = mount(
+      <ProtocolFormField
+        setting={setting}
+        value={value}
+        disabled={false}
+      />
+    );
+    expect(wrapper.find(".with-add-on").length).to.equal(1);
+    expect(wrapper.find(".tool-tip-container").length).to.equal(1);
+    expect(wrapper.text()).to.include("Extra content!");
+    expect(wrapper.find("input").at(0).prop("value")).to.equal("item name");
   });
 
   it("gets value of text setting", () => {

--- a/src/components/__tests__/ProtocolFormField-test.tsx
+++ b/src/components/__tests__/ProtocolFormField-test.tsx
@@ -261,15 +261,10 @@ describe("ProtocolFormField", () => {
     let instructionsSetting = {...setting, ...{instructions: "<ul><li>Step 1</li></ul>", type: "list"}};
     wrapper.setProps({ setting: instructionsSetting });
 
-    let toolTip = wrapper.find(".tool-tip-container");
-    expect(toolTip.length).to.equal(1);
-    let trigger = toolTip.find(".badge");
-    expect(trigger.length).to.equal(1);
-    expect(trigger.text()).to.equal("?");
-    let text = toolTip.find(".tool-tip");
-    expect(text.length).to.equal(1);
-    expect(text.hasClass("vertical")).to.be.true;
-    expect(text.text()).to.equal("Step 1");
+    let instructions = wrapper.find(".well");
+    expect(instructions.length).to.equal(1);
+    expect(instructions.hasClass("description")).to.be.true;
+    expect(instructions.text()).to.equal("Step 1");
   });
 
   it("gets value of text setting", () => {

--- a/src/components/__tests__/ToolTip-test.tsx
+++ b/src/components/__tests__/ToolTip-test.tsx
@@ -25,7 +25,8 @@ describe("ToolTip", () => {
   it("renders the tooltip", () => {
     let tooltip = wrapper.find(".tool-tip");
     expect(tooltip.length).to.equal(1);
-    expect(tooltip.text()).to.equal("ToolTip Content");
+    expect(tooltip.prop("dangerouslySetInnerHTML")["__html"]).to.equal("ToolTip Content");
+    expect(tooltip.html()).to.include("ToolTip Content");
   });
 
   it("initially hides the tooltip", () => {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -200,12 +200,13 @@ export interface SettingData {
   key: string;
   label: string;
   description?: string;
-  default?: string | string[];
+  default?: string | string[] | Object[];
   required?: boolean;
   randomizable?: boolean;
   type?: string;
   options?: SettingData[];
   instructions?: string;
+  format?: string;
 }
 
 export interface ProtocolData {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -205,6 +205,7 @@ export interface SettingData {
   randomizable?: boolean;
   type?: string;
   options?: SettingData[];
+  instructions?: string;
 }
 
 export interface ProtocolData {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -183,6 +183,7 @@ export interface LibrarySettingField {
   key: string;
   label: string;
   required?: boolean;
+  category?: string;
 }
 
 export interface LibrariesData {

--- a/src/stylesheets/app.scss
+++ b/src/stylesheets/app.scss
@@ -7,6 +7,7 @@
 @import "global";
 
 @import "admin_auth_service_edit_form";
+@import "badge";
 @import "book_details_container";
 @import "book_details_tab_container";
 @import "button_form";

--- a/src/stylesheets/badge.scss
+++ b/src/stylesheets/badge.scss
@@ -1,0 +1,10 @@
+.badge {
+  display: block;
+  float: right;
+  margin-top: 2px;
+  background: $green-bright;
+  cursor: pointer;
+  &.danger {
+    background: $red;
+  }
+}

--- a/src/stylesheets/diagnostics.scss
+++ b/src/stylesheets/diagnostics.scss
@@ -90,15 +90,4 @@
       background: inherit;
     }
   }
-
-  .badge {
-    display: block;
-    float: right;
-    margin-top: 2px;
-    background: $green-bright;
-    &.danger {
-      background: $red;
-    }
-  }
-
 }

--- a/src/stylesheets/edit_form.scss
+++ b/src/stylesheets/edit_form.scss
@@ -19,7 +19,7 @@
     display: flex;
     flex-direction: row;
     justify-content: flex-start;
-    align-items: baseline;
+    align-items: flex-start;
   }
 
   .contributor-form {

--- a/src/stylesheets/edit_form.scss
+++ b/src/stylesheets/edit_form.scss
@@ -1,6 +1,9 @@
 .edit-form {
   label {
     width: 100%;
+    .form-control {
+      font-weight: normal;
+    }
   }
 
   input[name=series] {

--- a/src/stylesheets/editable_input.scss
+++ b/src/stylesheets/editable_input.scss
@@ -13,6 +13,23 @@
 
 .description {
   font-size: 0.8rem;
+  &.well {
+    margin-top: 10px;
+  }
+  ol {
+    list-style: disc;
+    padding: 0 10px;
+    text-align: left;
+    li {
+      display: list-item;
+      padding-top: 8px;
+      border-bottom: 1px solid $dark-gray;
+      i {
+        display: inline-block;
+        float: right;
+      }
+    }
+  }
 }
 
 .field-error {

--- a/src/stylesheets/protocol_form_field.scss
+++ b/src/stylesheets/protocol_form_field.scss
@@ -15,3 +15,28 @@ span.add-list-item {
 .btn.add-list-item {
   vertical-align: top;
 }
+
+span.input-group-addon {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: auto;
+  padding: 2px;
+  border-color: $linkcolor;
+
+}
+.with-add-on {
+  display: flex;
+  .tool-tip-container {
+    height: 100%;
+    cursor: pointer;
+  }
+  input {
+    flex: 1;
+  }
+  svg {
+    height: 100%;
+    width: 80%;
+    fill: $linkcolor;
+  }
+}

--- a/src/stylesheets/tool_tip.scss
+++ b/src/stylesheets/tool_tip.scss
@@ -26,6 +26,10 @@
       top: 28px;
     }
 
+    &.point-right {
+      left: -975%;
+    }
+
     ol {
       list-style: disc;
       padding: 5px 20px 0 30px;
@@ -55,5 +59,9 @@
     border-color: transparent transparent $dark-gray transparent;
     top: -5px;
     left: 5px;
+  }
+  .tool-tip.point-right::after {
+    border-color: transparent transparent transparent $dark-gray;
+    left: 100%;
   }
 }

--- a/src/stylesheets/tool_tip.scss
+++ b/src/stylesheets/tool_tip.scss
@@ -18,6 +18,28 @@
     color: white;
     background: $dark-gray;
     opacity: .75;
+
+    &.vertical {
+      height: auto;
+      min-width: 500px;
+      left: 0;
+      top: 28px;
+    }
+
+    ol {
+      list-style: disc;
+      padding: 5px 20px 0 30px;
+      text-align: left;
+      li {
+        display: list-item;
+        padding-top: 8px;
+        border-bottom: 1px solid white;
+        i {
+          display: inline-block;
+          float: right;
+        }
+      }
+    }
   }
   .tool-tip::after {
     content: "";
@@ -28,5 +50,10 @@
     border-width: 5px;
     border-style: solid;
     border-color: transparent $dark-gray transparent transparent;
+  }
+  .tool-tip.vertical::after {
+    border-color: transparent transparent $dark-gray transparent;
+    top: -5px;
+    left: 5px;
   }
 }

--- a/src/stylesheets/with_remove_button.scss
+++ b/src/stylesheets/with_remove_button.scss
@@ -5,6 +5,7 @@
   }
 
   .remove {
+    padding: 9px 0;
     color: #AAA;
     cursor: pointer;
   }


### PR DESCRIPTION
Goes with the server-side `geographic-areas` branch.

Library edit form now:
1) contains a "Geographic Areas" section
2) lets you put in multiple values for each area
3) displays a tooltip with instructions about how to format the input 
4) if you've entered a zip code, displays a tooltip telling you where it corresponds to, so you can make sure you entered it correctly.  (That's kind of a placeholder; if/when we add a map component, I figure that's where it will go.)

Lots of refactoring in `ProtocolFormField`, including making the thing for entering multiple values its own component (`InputList`); except for the tooltip stuff, this was just so I could see what I was doing, and doesn't affect functionality.

<img width="697" alt="Screen Shot 2019-03-15 at 12 36 07 PM" src="https://user-images.githubusercontent.com/42178216/54447102-eea6a380-471e-11e9-82d7-4d2f602e570b.png">
<img width="1136" alt="Screen Shot 2019-03-15 at 12 35 37 PM" src="https://user-images.githubusercontent.com/42178216/54447111-f36b5780-471e-11e9-81e8-383d969b6ce1.png">
<img width="776" alt="Screen Shot 2019-03-15 at 12 35 26 PM" src="https://user-images.githubusercontent.com/42178216/54447113-f5cdb180-471e-11e9-9c42-49bccf472ef5.png">
