### PR TITLE
Fixing list editor bugs for new lists.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Changelog
 
+### v0.3.3
+#### Fixed
+- Fixed a bug where new lists were unable to save even when new entries were added to them.
+- Fixed a bug where saving a newly created list did not redirect to its edit page.
+
 ### v0.3.2
 #### Fixed
 - Deleting a list now also deletes any lanes which contained only that list. Previously, there was no functionality in place to edit or remove any custom lanes when all their custom lists had been deleted.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/components/CustomListEditor.tsx
+++ b/src/components/CustomListEditor.tsx
@@ -243,7 +243,7 @@ export default class CustomListEditor extends React.Component<CustomListEditorPr
       }
     }
 
-    return (titleChanged || entriesChanged || collectionsChanged);
+    return titleChanged || entriesChanged || collectionsChanged;
   }
 
   changeTitle(title: string) {

--- a/src/components/CustomListEditor.tsx
+++ b/src/components/CustomListEditor.tsx
@@ -57,6 +57,7 @@ export default class CustomListEditor extends React.Component<CustomListEditorPr
     const listTitle = this.props.list && this.props.list.title ? this.props.list.title : "";
     const nextPageUrl = this.props.list && this.props.list.nextPageUrl;
     const opdsFeedUrl = `${this.props.library}/lists/${listTitle}/crawlable`;
+    const hasChanges = this.hasChanges();
     return (
       <div className="custom-list-editor">
         <div className="custom-list-editor-header">
@@ -77,10 +78,10 @@ export default class CustomListEditor extends React.Component<CustomListEditorPr
           <div className="save-or-cancel-list">
             <Button
               callback={this.save}
-              disabled={!this.hasChanges()}
+              disabled={!hasChanges}
               content="Save this list"
             />
-            { this.hasChanges() &&
+            { hasChanges &&
               <Button
                 className="inverted"
                 callback={this.reset}
@@ -168,9 +169,11 @@ export default class CustomListEditor extends React.Component<CustomListEditorPr
 
   componentWillReceiveProps(nextProps) {
     if (!nextProps.list) {
-      this.setState({ title: "", entries: [], collections: [] });
-    }
-    else if (nextProps.list && (nextProps.listId !== this.props.listId)) {
+      // If there's no list then a new one is being created, but there could already
+      // be a list title in the state.
+      this.setState({ title: this.state.title || "", entries: [], collections: [] });
+    } else if (nextProps.list && (nextProps.listId !== this.props.listId)) {
+      // Update the state with the next list to edit.
       this.setState({
         title: nextProps.list && nextProps.list.title,
         entries: (nextProps.list && nextProps.list.books) || [],

--- a/src/components/CustomListEditor.tsx
+++ b/src/components/CustomListEditor.tsx
@@ -236,7 +236,7 @@ export default class CustomListEditor extends React.Component<CustomListEditorPr
       }
     }
 
-    return (this.state.title !== "") && (titleChanged || entriesChanged || collectionsChanged);
+    return !!(this.state.title && this.state.title !== "") && (titleChanged || entriesChanged || collectionsChanged);
   }
 
   changeTitle(title: string) {

--- a/src/components/CustomListEditor.tsx
+++ b/src/components/CustomListEditor.tsx
@@ -58,6 +58,9 @@ export default class CustomListEditor extends React.Component<CustomListEditorPr
     const nextPageUrl = this.props.list && this.props.list.nextPageUrl;
     const opdsFeedUrl = `${this.props.library}/lists/${listTitle}/crawlable`;
     const hasChanges = this.hasChanges();
+    // The "save this list" button should be disabled if there are no changes
+    // or if the list's title is empty.
+    const disableSave = this.isTitleEmpty() || !hasChanges;
     return (
       <div className="custom-list-editor">
         <div className="custom-list-editor-header">
@@ -78,7 +81,7 @@ export default class CustomListEditor extends React.Component<CustomListEditorPr
           <div className="save-or-cancel-list">
             <Button
               callback={this.save}
-              disabled={!hasChanges}
+              disabled={disableSave}
               content="Save this list"
             />
             { hasChanges &&
@@ -201,12 +204,16 @@ export default class CustomListEditor extends React.Component<CustomListEditorPr
     }
   }
 
+  isTitleEmpty(): boolean {
+    return this.state.title === "";
+  }
+
   hasChanges(): boolean {
     let titleChanged = (this.props.list && this.props.list.title !== this.state.title);
     let entriesChanged = this.props.list && !!this.props.list.books &&
       (this.props.list.books.length !== this.state.entries.length);
-    // If the current list is new then this.props.list will be undefined, but the
-    // state for the entries and the title can be populated so there's a need to check.
+    // If the current list is new then this.props.list will be undefined, but
+    // the state for the entries or title can be populated so there's a need to check.
     if (!this.props.list) {
       titleChanged = this.state.title && this.state.title !== "";
       entriesChanged = this.state.entries.length > 0;
@@ -236,7 +243,7 @@ export default class CustomListEditor extends React.Component<CustomListEditorPr
       }
     }
 
-    return !!(this.state.title && this.state.title !== "") && (titleChanged || entriesChanged || collectionsChanged);
+    return (titleChanged || entriesChanged || collectionsChanged);
   }
 
   changeTitle(title: string) {

--- a/src/components/CustomLists.tsx
+++ b/src/components/CustomLists.tsx
@@ -313,7 +313,7 @@ function mapStateToProps(state, ownProps) {
     lists: state.editor.customLists && state.editor.customLists.data && state.editor.customLists.data.custom_lists,
     listDetails: state.editor.customListDetails && state.editor.customListDetails.data,
     isFetchingMoreCustomListEntries: state.editor.customListDetails && state.editor.customListDetails.isFetchingMoreEntries,
-    responseBody: state.editor.customLists && state.editor.customLists.responseBody,
+    responseBody: state.editor.customLists && state.editor.customLists.successMessage,
     fetchError: state.editor.customLists.fetchError || state.editor.collections.fetchError,
     isFetching: state.editor.customLists.isFetching || state.editor.customLists.isEditing || state.editor.customListDetails.isFetching || state.editor.customListDetails.isEditing || !ownProps.editOrCreate || (state.editor.collection && state.editor.collection.isFetching) || state.editor.collections.isFetching,
     searchResults: state.editor.collection && state.editor.collection.data,

--- a/src/components/__tests__/CustomListEditor-test.tsx
+++ b/src/components/__tests__/CustomListEditor-test.tsx
@@ -212,7 +212,6 @@ describe("CustomListEditor", () => {
     wrapper.setState({ title: "list title" });
     saveButton = wrapper.find(".save-or-cancel-list").find(Button).at(0);
 
-    // console.log(wrapper.state());
     expect(saveButton.props().disabled).to.equal(false);
   });
 

--- a/src/components/__tests__/CustomListEditor-test.tsx
+++ b/src/components/__tests__/CustomListEditor-test.tsx
@@ -212,6 +212,7 @@ describe("CustomListEditor", () => {
     wrapper.setState({ title: "list title" });
     saveButton = wrapper.find(".save-or-cancel-list").find(Button).at(0);
 
+    // console.log(wrapper.state());
     expect(saveButton.props().disabled).to.equal(false);
   });
 
@@ -586,8 +587,7 @@ describe("CustomListEditor", () => {
         [{ id: "1234", title: "a", authors: [] }]
       );
       hasChanges = (wrapper.instance() as CustomListEditor).hasChanges();
-      // There are entries but the title hasn't been updated.
-      expect(hasChanges).to.equal(false);
+      expect(hasChanges).to.equal(true);
 
       // Now add a title
       wrapper.setState({ title: "Updated title" });

--- a/src/components/__tests__/CustomListEditor-test.tsx
+++ b/src/components/__tests__/CustomListEditor-test.tsx
@@ -532,4 +532,68 @@ describe("CustomListEditor", () => {
     expect(textInput.getDOMNode().value).to.equal("oliver twist");
     expect(wrapper.state("entryPointSelected")).to.equal("Audio");
   });
+
+  describe("hasChanges", () => {
+    it("should update correctly", () => {
+      wrapper = mount(
+        <CustomListEditor
+          library="library"
+          searchResults={searchResults}
+          editCustomList={editCustomList}
+          search={search}
+          loadMoreSearchResults={loadMoreSearchResults}
+          loadMoreEntries={loadMoreEntries}
+          isFetchingMoreSearchResults={false}
+          isFetchingMoreCustomListEntries={false}
+          entryPoints={entryPoints}
+        />,
+        { context: fullContext, childContextTypes }
+      );
+
+      let hasChanges = (wrapper.instance() as CustomListEditor).hasChanges();
+
+      expect(hasChanges).to.equal(false);
+
+      // A new list with a new title
+      wrapper.setState({ title: "Updated title" });
+      hasChanges = (wrapper.instance() as CustomListEditor).hasChanges();
+
+      expect(hasChanges).to.equal(true);
+
+      // We decided to add an entry
+      (wrapper.instance() as CustomListEditor).changeEntries(
+        [{ id: "1234", title: "a", authors: [] }]
+      );
+      hasChanges = (wrapper.instance() as CustomListEditor).hasChanges();
+      expect(hasChanges).to.equal(true);
+
+      wrapper = mount(
+        <CustomListEditor
+          library="library"
+          searchResults={searchResults}
+          editCustomList={editCustomList}
+          search={search}
+          loadMoreSearchResults={loadMoreSearchResults}
+          loadMoreEntries={loadMoreEntries}
+          isFetchingMoreSearchResults={false}
+          isFetchingMoreCustomListEntries={false}
+          entryPoints={entryPoints}
+        />,
+        { context: fullContext, childContextTypes }
+      );
+
+      (wrapper.instance() as CustomListEditor).changeEntries(
+        [{ id: "1234", title: "a", authors: [] }]
+      );
+      hasChanges = (wrapper.instance() as CustomListEditor).hasChanges();
+      // There are entries but the title hasn't been updated.
+      expect(hasChanges).to.equal(false);
+
+      // Now add a title
+      wrapper.setState({ title: "Updated title" });
+      hasChanges = (wrapper.instance() as CustomListEditor).hasChanges();
+
+      expect(hasChanges).to.equal(true);
+    });
+  });
 });


### PR DESCRIPTION
Fixes [SIMPLY-2041](https://jira.nypl.org/browse/SIMPLY-2041).
First bug (also found in ticket):
Steps to reproduce:
* Create a new list `/admin/web/lists/.../create`.
* Give it a title. The "Save this list" button is enabled.
* Search for items. Now the save button is disabled. If you add any searched items to the entries list the save button is still disabled.

The other fix is redirecting to a new list's edit page after saving it. It seems that `successMessage` is the appropriate property instead of `responseBody`. This doesn't seem right though so is the server not returning the right thing? I noticed that it does get the right value but then becomes `null` right away.