### PR TITLE
Complaint names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### v0.3.6
 #### Fixed
 - Fixed a minor button styling bug in the Complaints tab.
+- Improved formatting of complaint type names.
 
 ### v0.3.5
 #### Updated

--- a/src/components/ComplaintForm.tsx
+++ b/src/components/ComplaintForm.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import EditableInput from "./EditableInput";
 import { PostComplaint } from "../interfaces";
 import { Button, Form } from "library-simplified-reusable-components";
+import { formatString } from "./sharedFunctions";
 
 export interface ComplaintFormProps {
   disabled?: boolean;
@@ -34,12 +35,6 @@ export default class ComplaintForm extends React.Component<ComplaintFormProps, a
       "wrong-genre"
     ];
 
-    let formatType = (x) => {
-      let [firstWord, ...rest] = x.split("-");
-      firstWord = firstWord.substr(0, 1).toUpperCase() + firstWord.substr(1);
-      return [firstWord, ...rest].join(" ");
-    };
-
     return (
       <div className="complaint-form">
         <Form
@@ -62,7 +57,7 @@ export default class ComplaintForm extends React.Component<ComplaintFormProps, a
                 placeholder=""
                 disabled={this.props.disabled}>
                 <option value="">Complaint type</option>
-                { complaintTypes.map(type => <option key={type} value={type}>{formatType(type)}</option>) }
+                { complaintTypes.map(type => <option key={type} value={type}>{formatString(type, ["-"])}</option>) }
               </EditableInput>
             </fieldset>
           }

--- a/src/components/ComplaintForm.tsx
+++ b/src/components/ComplaintForm.tsx
@@ -34,6 +34,12 @@ export default class ComplaintForm extends React.Component<ComplaintFormProps, a
       "wrong-genre"
     ];
 
+    let formatType = (x) => {
+      let [firstWord, ...rest] = x.split("-");
+      firstWord = firstWord.substr(0, 1).toUpperCase() + firstWord.substr(1);
+      return [firstWord, ...rest].join(" ");
+    };
+
     return (
       <div className="complaint-form">
         <Form
@@ -55,8 +61,8 @@ export default class ComplaintForm extends React.Component<ComplaintFormProps, a
                 name="type"
                 placeholder=""
                 disabled={this.props.disabled}>
-                <option value="">complaint type</option>
-                { complaintTypes.map(type => <option key={type} value={type}>{type}</option>) }
+                <option value="">Complaint type</option>
+                { complaintTypes.map(type => <option key={type} value={type}>{formatType(type)}</option>) }
               </EditableInput>
             </fieldset>
           }

--- a/src/components/Complaints.tsx
+++ b/src/components/Complaints.tsx
@@ -124,7 +124,7 @@ export class Complaints extends React.Component<ComplaintsProps, {}> {
   readableComplaintType(type: string) {
     let match = type.match(/\/terms\/problem\/(.+)$/);
     if (match) {
-      return match[1].replace("-", " ");
+      return match[1].substr(0, 1).toUpperCase() + match[1].substr(1).replace(/-/g, " ");
     } else {
       return type;
     }

--- a/src/components/Complaints.tsx
+++ b/src/components/Complaints.tsx
@@ -9,6 +9,7 @@ import { Button } from "library-simplified-reusable-components";
 import { BookData, PostComplaint } from "../interfaces";
 import { FetchErrorData } from "opds-web-client/lib/interfaces";
 import { State } from "../reducers/index";
+import { formatString } from "./sharedFunctions";
 
 export interface ComplaintsStateProps {
   complaints?: any;
@@ -124,7 +125,7 @@ export class Complaints extends React.Component<ComplaintsProps, {}> {
   readableComplaintType(type: string) {
     let match = type.match(/\/terms\/problem\/(.+)$/);
     if (match) {
-      return match[1].substr(0, 1).toUpperCase() + match[1].substr(1).replace(/-/g, " ");
+      return formatString(match[1], ["-"]);
     } else {
       return type;
     }

--- a/src/components/__tests__/ComplaintForm-test.tsx
+++ b/src/components/__tests__/ComplaintForm-test.tsx
@@ -28,7 +28,7 @@ describe("ComplaintForm", () => {
       expect(select.length).to.equal(1);
       expect(select.prop("disabled")).to.equal(false);
       let option = select.find("option").at(0);
-      expect(option.text()).to.equal("complaint type");
+      expect(option.text()).to.equal("Complaint type");
     });
 
     it("shows complaint type options", () => {
@@ -48,6 +48,26 @@ describe("ComplaintForm", () => {
         "wrong-medium",
         "wrong-age-range",
         "wrong-genre"
+      ]);
+    });
+
+    it("formats complaint type options", () => {
+      let options = wrapper.find("option");
+      let types = options.map(option => option.text());
+      expect(types).to.eql([
+        "Complaint type",
+        "Cannot issue loan",
+        "Cannot render",
+        "Wrong title",
+        "Wrong author",
+        "Wrong audience",
+        "Cannot fulfill loan",
+        "Bad description",
+        "Cannot return",
+        "Bad cover image",
+        "Wrong medium",
+        "Wrong age range",
+        "Wrong genre"
       ]);
     });
 

--- a/src/components/__tests__/Complaints-test.tsx
+++ b/src/components/__tests__/Complaints-test.tsx
@@ -60,7 +60,7 @@ describe("Complaints", () => {
 
     it("shows simplified complaint types", () => {
       let types = wrapper.find(".complaint-type").map(type => type.text());
-      expect(types).to.deep.equal(["test type", "other type", "last type"]);
+      expect(types).to.deep.equal(["Test type", "Other type", "Last type"]);
     });
 
     it("shows resolve button for each complaint type", () => {

--- a/src/components/__tests__/sharedFunctions-test.ts
+++ b/src/components/__tests__/sharedFunctions-test.ts
@@ -77,6 +77,11 @@ describe("formatString", () => {
     expect(result).to.equal("This!is!a!sentence.");
   });
 
+  it("replaces multiple characters", () => {
+    let result = formatString("need-to-replace!multiple-characters", ["-", "!", " "]);
+    expect(result).to.equal("Need to replace multiple characters");
+  });
+
   it("defaults to replacing characters with a space", () => {
     let result = formatString(stringToFormat, ["-"]);
     expect(result).to.equal("This is a sentence.");

--- a/src/components/__tests__/sharedFunctions-test.ts
+++ b/src/components/__tests__/sharedFunctions-test.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { findDefault, clearForm } from "../sharedFunctions";
+import { findDefault, clearForm, formatString } from "../sharedFunctions";
 
 
 describe("findDefault", () => {
@@ -53,4 +53,32 @@ describe("findDefault", () => {
     expect(result[1].label).to.equal("This one too");
   });
 
+});
+
+describe("formatString", () => {
+  let stringToFormat = "this-is-a-sentence.";
+  it("capitalizes the first letter of a string by default", () => {
+    let result = formatString(stringToFormat);
+    expect(result).to.equal("This-is-a-sentence.");
+  });
+
+  it("can be prevented from capitalizing", () => {
+    let result = formatString(stringToFormat, null, false);
+    expect(result).to.equal("this-is-a-sentence.");
+  });
+
+  it("replaces characters", () => {
+    let result = formatString(stringToFormat, ["-", " "], false);
+    expect(result).to.equal("this is a sentence.");
+  });
+
+  it("replaces characters and capitalizes", () => {
+    let result = formatString(stringToFormat, ["-", "!"]);
+    expect(result).to.equal("This!is!a!sentence.");
+  });
+
+  it("defaults to replacing characters with a space", () => {
+    let result = formatString(stringToFormat, ["-"]);
+    expect(result).to.equal("This is a sentence.");
+  });
 });

--- a/src/components/sharedFunctions.ts
+++ b/src/components/sharedFunctions.ts
@@ -27,3 +27,14 @@ export function clearForm(refs) {
     }
   }
 }
+
+export function formatString(word: string, replacement?: string[], capitalize = true) {
+  if (capitalize) {
+    word = word.substr(0, 1).toUpperCase() + word.substr(1);
+  }
+  if (replacement) {
+    let replaceWith = replacement.length > 1 ? replacement[1] : " ";
+    word = word.replace(new RegExp(replacement[0], "g"), replaceWith);
+  }
+  return word;
+}

--- a/src/components/sharedFunctions.ts
+++ b/src/components/sharedFunctions.ts
@@ -33,8 +33,12 @@ export function formatString(word: string, replacement?: string[], capitalize = 
     word = word.substr(0, 1).toUpperCase() + word.substr(1);
   }
   if (replacement) {
-    let replaceWith = replacement.length > 1 ? replacement[1] : " ";
-    word = word.replace(new RegExp(replacement[0], "g"), replaceWith);
+    // If the replacement array contains more than one element, the last element will replace
+    // all of the previous ones.  Otherwise, the one element will be replaced with a space.
+    let replaceWith = replacement.length > 1 ? replacement.pop() : " ";
+    replacement.forEach((char) => {
+      word = word.replace(new RegExp(char, "g"), replaceWith);
+    });
   }
   return word;
 }


### PR DESCRIPTION
Resolves https://jira.nypl.org/browse/SIMPLY-2101; renders names of complaint types in a more user-friendly format.

Before:
<img width="661" alt="Screen Shot 2019-07-03 at 3 08 23 PM" src="https://user-images.githubusercontent.com/42178216/60734556-5a0ac000-9f1e-11e9-94e2-07adc2ea3298.png">
<img width="666" alt="Screen Shot 2019-07-03 at 3 38 59 PM" src="https://user-images.githubusercontent.com/42178216/60734500-3182c600-9f1e-11e9-964f-ccaa8b865e8e.png">

<hr></hr>

After:
<img width="686" alt="Screen Shot 2019-07-05 at 12 04 10 PM" src="https://user-images.githubusercontent.com/42178216/60734585-70188080-9f1e-11e9-8d39-5275269e7607.png">
<img width="693" alt="Screen Shot 2019-07-05 at 11 52 17 AM" src="https://user-images.githubusercontent.com/42178216/60734596-7a3a7f00-9f1e-11e9-8942-85dd01c43675.png">