### PR TITLE
Using buttons where they should be used, updating the Reusable Compon…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changelog
 
+### v0.3.9
+#### Updated
+- Using the Button components for elements that should be buttons instead of anchors or divs.
+#### Fixed
+- Styling for the book edit components and related buttons.
+
 ### v0.3.8
 #### Added
 - Added a basic WYSIWYG editor to the summary field in the book details form.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5446,9 +5446,9 @@
       }
     },
     "library-simplified-reusable-components": {
-      "version": "1.3.10",
-      "resolved": "https://registry.npmjs.org/library-simplified-reusable-components/-/library-simplified-reusable-components-1.3.10.tgz",
-      "integrity": "sha512-hMXO5o+AnfnWS4m+vZXZKHehnYV5KkMoLRL62gy5gl66MJ0P+CIO9CDmAFdJvvkOF2l5wOwHYBqCX+IQs5QVzQ==",
+      "version": "1.3.11",
+      "resolved": "https://registry.npmjs.org/library-simplified-reusable-components/-/library-simplified-reusable-components-1.3.11.tgz",
+      "integrity": "sha512-kH/a7YsSdfv7beTYoeu2VuFD/V+skl9V6Cter48HA0v5HwDLUy7tzeSRhGx1b6HHu83E3n2H229tO8YTEVKRVA==",
       "requires": {
         "@nypl/dgx-svg-icons": "0.3.9",
         "react": "16.8.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "draft-js": "^0.11.0",
     "font-awesome": "^4.6.3",
     "isomorphic-fetch": "^2.2.1",
-    "library-simplified-reusable-components": "1.3.10",
+    "library-simplified-reusable-components": "1.3.11",
     "numeral": "^2.0.6",
     "opds-feed-parser": "0.0.17",
     "opds-web-client": "0.2.6",

--- a/src/components/BookEditForm.tsx
+++ b/src/components/BookEditForm.tsx
@@ -127,7 +127,7 @@ export default class BookEditForm extends React.Component<BookEditFormProps, Boo
               />
             <Button
               type="button"
-              className="add-contributor"
+              className="add-contributor small"
               disabled={this.props.disabled}
               callback={this.addContributor}
               content="Add"

--- a/src/components/CustomListsForBook.tsx
+++ b/src/components/CustomListsForBook.tsx
@@ -64,9 +64,9 @@ export class CustomListsForBook extends React.Component<CustomListsForBookProps,
           <ErrorMessage error={this.props.fetchError} tryAgain={this.refresh} />
         }
 
-        { this.state.customLists && this.state.customLists.map((list, idx) =>
+        { this.state.customLists && this.state.customLists.map(list =>
             <WithRemoveButton
-              key={`${list.id}-${idx}`}
+              key={list.id}
               disabled={this.props.isFetching}
               onRemove={() => this.removeList(list) }
               >

--- a/src/components/CustomListsForBook.tsx
+++ b/src/components/CustomListsForBook.tsx
@@ -55,7 +55,7 @@ export class CustomListsForBook extends React.Component<CustomListsForBookProps,
 
   render(): JSX.Element {
     return (
-      <div>
+      <div className="custom-list-for-book">
         { this.props.book &&
           <h2>{this.props.book.title}</h2>
         }

--- a/src/components/CustomListsForBook.tsx
+++ b/src/components/CustomListsForBook.tsx
@@ -64,9 +64,9 @@ export class CustomListsForBook extends React.Component<CustomListsForBookProps,
           <ErrorMessage error={this.props.fetchError} tryAgain={this.refresh} />
         }
 
-        { this.state.customLists && this.state.customLists.map(list =>
+        { this.state.customLists && this.state.customLists.map((list, idx) =>
             <WithRemoveButton
-              key={list.id}
+              key={`${list.id}-${idx}`}
               disabled={this.props.isFetching}
               onRemove={() => this.removeList(list) }
               >
@@ -92,7 +92,7 @@ export class CustomListsForBook extends React.Component<CustomListsForBookProps,
               value=""
               ref="addList"
               />
-            <Button className="left-align" callback={this.addList} content="Add" />
+            <Button className="left-align add-list-btn" callback={this.addList} content="Add" />
           </div>
         }
       </div>

--- a/src/components/CustomListsForBook.tsx
+++ b/src/components/CustomListsForBook.tsx
@@ -92,7 +92,7 @@ export class CustomListsForBook extends React.Component<CustomListsForBookProps,
               value=""
               ref="addList"
               />
-            <Button className="left-align add-list-btn" callback={this.addList} content="Add" />
+            <Button className="left-align add-list-btn" callback={this.addList} content="Add" type="button" />
           </div>
         }
       </div>

--- a/src/components/ErrorMessage.tsx
+++ b/src/components/ErrorMessage.tsx
@@ -23,6 +23,13 @@ export default class ErrorMessage extends React.Component<ErrorMessageProps, {}>
         <Alert bsStyle="danger">
           <h4>You have been logged out.<br />
             <a target="_blank" href="/admin/sign_in_again">Log in again</a>
+            { this.props.tryAgain &&
+              <Button
+                className="left-align"
+                callback={this.tryAgain.bind(this)}
+                content="Try again"
+              />
+            }
           </h4>
         </Alert>
       );

--- a/src/components/ErrorMessage.tsx
+++ b/src/components/ErrorMessage.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import * as ReactDOM from "react-dom";
 import { Alert } from "react-bootstrap";
 import { FetchErrorData } from "opds-web-client/lib/interfaces";
+import { Button } from "library-simplified-reusable-components";
 
 export interface ErrorMessageProps {
   error: FetchErrorData;
@@ -21,10 +22,7 @@ export default class ErrorMessage extends React.Component<ErrorMessageProps, {}>
       alertElement = (
         <Alert bsStyle="danger">
           <h4>You have been logged out.<br />
-            <a target="_blank" href="/admin/sign_in_again">Log in again</a><br />
-            { this.props.tryAgain &&
-              <a role="button" onClick={this.tryAgain.bind(this)}>Try again</a>
-            }
+            <a target="_blank" href="/admin/sign_in_again">Log in again</a>
           </h4>
         </Alert>
       );
@@ -55,7 +53,11 @@ export default class ErrorMessage extends React.Component<ErrorMessageProps, {}>
             }
             <span dangerouslySetInnerHTML={{ __html: errorMessageText }} /><br />
             { this.props.tryAgain &&
-              <a role="button" onClick={this.tryAgain.bind(this)}>Try again</a>
+              <Button
+                className="left-align"
+                callback={this.tryAgain.bind(this)}
+                content="Try again"
+              />
             }
           </h4>
         </Alert>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 import { connect } from "react-redux";
 import { Store } from "redux";
 import * as PropTypes from "prop-types";
@@ -13,6 +12,7 @@ import { Link } from "react-router";
 import { Navbar, Nav, NavItem } from "react-bootstrap";
 import { Router } from "opds-web-client/lib/interfaces";
 import { Button } from "library-simplified-reusable-components";
+import { GenericWedgeIcon } from "@nypl/dgx-svg-icons";
 
 export interface HeaderStateProps {
   libraries?: LibraryData[];
@@ -190,7 +190,7 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
                   aria-haspopup="true"
                   aria-expanded={this.state.showAccountDropdown}
                   callback={this.toggleAccountDropdown}
-                  content={this.context.admin.email}
+                  content={<span>{this.context.admin.email} <GenericWedgeIcon /></span>}
                 />
                 { this.state.showAccountDropdown &&
                   <ul className="dropdown-menu">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -12,6 +12,7 @@ import CatalogLink from "opds-web-client/lib/components/CatalogLink";
 import { Link } from "react-router";
 import { Navbar, Nav, NavItem } from "react-bootstrap";
 import { Router } from "opds-web-client/lib/interfaces";
+import { Button } from "library-simplified-reusable-components";
 
 export interface HeaderStateProps {
   libraries?: LibraryData[];
@@ -53,7 +54,8 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
     this.toggleAccountDropdown = this.toggleAccountDropdown.bind(this);
 
     document.body.addEventListener("click", (event: MouseEvent) => {
-      if (this.state.showAccountDropdown && (event.target as any).className !== "account-dropdown-toggle") {
+      if (this.state.showAccountDropdown &&
+        ((event.target as any).className).indexOf("account-dropdown-toggle") === -1) {
         this.toggleAccountDropdown();
       }
     });
@@ -182,13 +184,14 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
             }
             { this.context.admin.email &&
               <li className="dropdown">
-                <a
-                  className="account-dropdown-toggle"
-                  role="button"
+                <Button
+                  className="account-dropdown-toggle transparent"
+                  type="button"
                   aria-haspopup="true"
                   aria-expanded={this.state.showAccountDropdown}
-                  onClick={this.toggleAccountDropdown}
-                  >{ this.context.admin.email } &#9660;</a>
+                  callback={this.toggleAccountDropdown}
+                  content={this.context.admin.email}
+                />
                 { this.state.showAccountDropdown &&
                   <ul className="dropdown-menu">
                     <li>

--- a/src/components/Lane.tsx
+++ b/src/components/Lane.tsx
@@ -39,7 +39,7 @@ export default class Lane extends React.Component<LaneProps, LaneState> {
   }
 
   render(): JSX.Element {
-    let {lane, active, snapshot, provided, orderChanged, toggleLaneVisibility, parent, library, renderLanes} = this.props;
+    let { lane, active, snapshot, provided, renderLanes } = this.props;
     let hasSublanes = lane.sublanes && !!lane.sublanes.length;
     let hasCustomLists = lane.custom_list_ids && !!lane.custom_list_ids.length;
 
@@ -58,13 +58,12 @@ export default class Lane extends React.Component<LaneProps, LaneState> {
           <div className={"lane-info" + (provided ? " draggable" : "")}>
             <span>
               { snapshot && <GrabIcon /> }
-              <div
-                className={this.state.expanded ? "collapse-button" :  "expand-button"}
-                onClick={this.toggleExpanded}
-                role="button"
-              >
-                <PyramidIcon />
-              </div>
+              <Button
+                className={`transparent ${this.state.expanded ? "collapse-button" :  "expand-button"}`}
+                type="button"
+                callback={this.toggleExpanded}
+                content={<PyramidIcon />}
+              />
               { lane.display_name + " (" + lane.count + ")" }
             </span>
             { this.renderVisibilityToggle() }

--- a/src/components/LaneCustomListsEditor.tsx
+++ b/src/components/LaneCustomListsEditor.tsx
@@ -4,6 +4,7 @@ import { CustomListData } from "../interfaces";
 import AddIcon from "./icons/AddIcon";
 import TrashIcon from "./icons/TrashIcon";
 import GrabIcon from "./icons/GrabIcon";
+import { Button } from "library-simplified-reusable-components";
 
 export interface LaneCustomListsEditorProps extends React.Props<LaneCustomListsEditor> {
   allCustomLists: CustomListData[];
@@ -65,13 +66,11 @@ export default class LaneCustomListsEditor extends React.Component<LaneCustomLis
                               <div className="list-id">ID-{list.id}</div>
                             </div>
                             <div className="links">
-                              <a
-                                className="btn inverted"
-                                role="button"
-                                onClick={() => { this.add(list.id); }}
-                                >Add to lane
-                                  <AddIcon />
-                              </a>
+                              <Button
+                                className="inverted"
+                                callback={() => { this.add(list.id); }}
+                                content={<span>Add to lane <AddIcon /></span>}
+                              />
                             </div>
                           </div>
                           { provided.placeholder }
@@ -116,13 +115,11 @@ export default class LaneCustomListsEditor extends React.Component<LaneCustomLis
                               <div className="list-id">ID-{list.id}</div>
                             </div>
                             <div className="links">
-                              <a
-                                className="btn danger"
-                                role="button"
-                                onClick={() => { this.remove(list.id); }}
-                                >Remove from lane
-                                  <TrashIcon />
-                              </a>
+                              <Button
+                                className="danger"
+                                callback={() => { this.remove(list.id); }}
+                                content={<span>Remove from lane <TrashIcon /></span>}
+                              />
                             </div>
                           </div>
                           { provided.placeholder }

--- a/src/components/Lanes.tsx
+++ b/src/components/Lanes.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import { Link } from "react-router";
-import { DragDropContext, Droppable, Draggable } from "react-beautiful-dnd";
 import { Store } from "redux";
 import { connect } from "react-redux";
 import { State } from "../reducers/index";
@@ -15,7 +14,6 @@ import ErrorMessage from "./ErrorMessage";
 import EditableInput from "./EditableInput";
 import { Button } from "library-simplified-reusable-components";
 import ResetIcon from "./icons/ResetIcon";
-import XCloseIcon from "./icons/XCloseIcon";
 
 export interface LanesStateProps {
   lanes: LaneData[];

--- a/src/components/LanesSidebar.tsx
+++ b/src/components/LanesSidebar.tsx
@@ -1,11 +1,6 @@
 import * as React from "react";
-import { Button } from "library-simplified-reusable-components";
 import AddIcon from "./icons/AddIcon";
-import PencilIcon from "./icons/PencilIcon";
 import ResetIcon from "./icons/ResetIcon";
-import VisibleIcon from "./icons/VisibleIcon";
-import HiddenIcon from "./icons/HiddenIcon";
-import XCloseIcon from "./icons/XCloseIcon";
 import { DragDropContext, Droppable, Draggable } from "react-beautiful-dnd";
 import { Link } from "react-router";
 import { LaneData } from "../interfaces";

--- a/src/components/ServiceEditForm.tsx
+++ b/src/components/ServiceEditForm.tsx
@@ -5,7 +5,6 @@ import { Panel, Button, Form } from "library-simplified-reusable-components";
 import WithEditButton from "./WithEditButton";
 import WithRemoveButton from "./WithRemoveButton";
 import { LibraryData, LibraryWithSettingsData, ProtocolData, ServiceData, ServicesData } from "../interfaces";
-import { EditFormProps } from "./EditableConfigList";
 import { clearForm } from "./sharedFunctions";
 import { FetchErrorData } from "opds-web-client/lib/interfaces";
 
@@ -235,7 +234,7 @@ export default class ServiceEditForm<T extends ServicesData> extends React.Compo
 
   renderLibrariesForm() {
     return (
-      <fieldset>
+      <fieldset className="update-libraries">
         <legend className="visuallyHidden">Libraries</legend>
         <div className="form-group">
           { this.state.libraries.map(library =>

--- a/src/components/WithEditButton.tsx
+++ b/src/components/WithEditButton.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
-import * as ReactDOM from "react-dom";
+import { Button } from "library-simplified-reusable-components";
+import { PencilIcon } from "@nypl/dgx-svg-icons";
 
 export interface WithEditButtonProps {
   disabled: boolean;
@@ -9,23 +10,23 @@ export interface WithEditButtonProps {
 /** When wrapped around an element, renders an edit button next to the element. */
 export default class WithEditButton extends React.Component<WithEditButtonProps, {}> {
   render(): JSX.Element {
+    const editContent = <span>Edit <PencilIcon title="Edit library" /></span>;
     return (
       <div className="with-edit-button">
         <span>
           { this.props.children }
         </span>
-        <i
-          className="fa fa-pencil-square-o edit"
-          aria-hidden="true"
-          role="button"
-          onClick={() => !this.props.disabled && this.props.onEdit()}
-          ></i>
-        <a
-          className="sr-only"
-          role="button"
-          onClick={() => !this.props.disabled && this.props.onEdit()}
-          >edit</a>
+        <Button
+          className="edit-btn"
+          callback={this.onClick.bind(this)}
+          content={editContent}
+        />
       </div>
     );
+  }
+
+  onClick(e: Event) {
+    e.preventDefault();
+    !this.props.disabled && this.props.onEdit();
   }
 }

--- a/src/components/WithEditButton.tsx
+++ b/src/components/WithEditButton.tsx
@@ -20,6 +20,7 @@ export default class WithEditButton extends React.Component<WithEditButtonProps,
           className="edit-btn"
           callback={this.onClick.bind(this)}
           content={editContent}
+          type="button"
         />
       </div>
     );

--- a/src/components/WithEditButton.tsx
+++ b/src/components/WithEditButton.tsx
@@ -17,7 +17,7 @@ export default class WithEditButton extends React.Component<WithEditButtonProps,
           { this.props.children }
         </span>
         <Button
-          className="edit-btn"
+          className="edit-btn small"
           callback={this.onClick.bind(this)}
           content={editContent}
           type="button"

--- a/src/components/WithRemoveButton.tsx
+++ b/src/components/WithRemoveButton.tsx
@@ -20,6 +20,7 @@ export default class WithRemoveButton extends React.Component<WithRemoveButtonPr
           className="remove-btn danger"
           callback={this.onClick.bind(this)}
           content={removeContent}
+          type="button"
         />
       </div>
     );

--- a/src/components/WithRemoveButton.tsx
+++ b/src/components/WithRemoveButton.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
-import * as ReactDOM from "react-dom";
+import { Button } from "library-simplified-reusable-components";
+import { XIcon } from "@nypl/dgx-svg-icons";
 
 export interface WithRemoveButtonProps {
   disabled: boolean;
@@ -9,23 +10,23 @@ export interface WithRemoveButtonProps {
 /** When wrapped around an element, renders a remove button next to the element. */
 export default class WithRemoveButton extends React.Component<WithRemoveButtonProps, {}> {
   render(): JSX.Element {
+    const removeContent = <span>Remove <XIcon title="Remove library" /></span>;
     return (
       <div className="with-remove-button">
         <span>
           { this.props.children }
         </span>
-        <i
-          className="fa fa-times remove"
-          aria-hidden="true"
-          role="button"
-          onClick={() => !this.props.disabled && this.props.onRemove()}
-          ></i>
-        <a
-          className="sr-only"
-          role="button"
-          onClick={() => !this.props.disabled && this.props.onRemove()}
-          >remove</a>
+        <Button
+          className="remove-btn danger"
+          callback={this.onClick.bind(this)}
+          content={removeContent}
+        />
       </div>
     );
+  }
+
+  onClick(e: Event) {
+    e.preventDefault();
+    !this.props.disabled && this.props.onRemove();
   }
 }

--- a/src/components/WithRemoveButton.tsx
+++ b/src/components/WithRemoveButton.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { Button } from "library-simplified-reusable-components";
-import { XIcon } from "@nypl/dgx-svg-icons";
+import TrashIcon from "./icons/TrashIcon";
 
 export interface WithRemoveButtonProps {
   disabled: boolean;
@@ -10,14 +10,14 @@ export interface WithRemoveButtonProps {
 /** When wrapped around an element, renders a remove button next to the element. */
 export default class WithRemoveButton extends React.Component<WithRemoveButtonProps, {}> {
   render(): JSX.Element {
-    const removeContent = <span>Remove <XIcon title="Remove library" /></span>;
+    const removeContent = <span>Delete <TrashIcon /></span>;
     return (
       <div className="with-remove-button">
         <span>
           { this.props.children }
         </span>
         <Button
-          className="remove-btn danger"
+          className="remove-btn danger small"
           callback={this.onClick.bind(this)}
           content={removeContent}
           type="button"

--- a/src/components/__tests__/ClassificationsForm-test.tsx
+++ b/src/components/__tests__/ClassificationsForm-test.tsx
@@ -322,7 +322,8 @@ describe("ClassificationsForm", () => {
       instance.addGenre("Erotica");
       let newGenres = wrapper.find(WithRemoveButton).map(name => name.text());
       expect(newGenres.length).to.equal(1);
-      expect(newGenres[0]).to.contain(instance.fullGenre(bookData.categories[0]) + "remove");
+      // The button contains an icon with a title of "Remove library"
+      expect(newGenres[0]).to.contain(instance.fullGenre(bookData.categories[0]) + "Remove Remove library");
       expect(newGenres[0]).not.to.contain("Erotica");
 
       instance.validateAudience = stub().returns(true);
@@ -333,7 +334,8 @@ describe("ClassificationsForm", () => {
 
       expect(instance.validateAudience.callCount).to.equal(1);
       newGenres = wrapper.find(WithRemoveButton).map(name => name.text());
-      expect(newGenres).to.contain(instance.fullGenre("Folklore") + "remove");
+      console.log(newGenres);
+      expect(newGenres).to.contain(instance.fullGenre("Folklore") + "Remove Remove library");
     });
 
     it("removes genre when remove button is clicked", () => {

--- a/src/components/__tests__/ClassificationsForm-test.tsx
+++ b/src/components/__tests__/ClassificationsForm-test.tsx
@@ -322,20 +322,17 @@ describe("ClassificationsForm", () => {
       instance.addGenre("Erotica");
       let newGenres = wrapper.find(WithRemoveButton).map(name => name.text());
       expect(newGenres.length).to.equal(1);
-      // The button contains an icon with a title of "Remove library"
-      expect(newGenres[0]).to.contain(instance.fullGenre(bookData.categories[0]) + "Remove Remove library");
+      expect(newGenres[0]).to.contain(instance.fullGenre(bookData.categories[0]) + "Delete");
       expect(newGenres[0]).not.to.contain("Erotica");
 
       instance.validateAudience = stub().returns(true);
       expect(instance.validateAudience.callCount).to.equal(0);
-
       instance.addGenre("Folklore");
       wrapper.update();
 
       expect(instance.validateAudience.callCount).to.equal(1);
       newGenres = wrapper.find(WithRemoveButton).map(name => name.text());
-      console.log(newGenres);
-      expect(newGenres).to.contain(instance.fullGenre("Folklore") + "Remove Remove library");
+      expect(newGenres[0]).to.contain(instance.fullGenre("Folklore") + "Delete");
     });
 
     it("removes genre when remove button is clicked", () => {

--- a/src/components/__tests__/CustomListsForBook-test.tsx
+++ b/src/components/__tests__/CustomListsForBook-test.tsx
@@ -139,7 +139,7 @@ describe("CustomListsForBook", () => {
       );
       // Add one of the existing lists.
       autocompleteStub.returns("list 1");
-      let addButton = wrapper.find("button");
+      let addButton = wrapper.find(".add-list-btn").hostNodes();
       addButton.simulate("click");
 
       let removables = wrapper.find(WithRemoveButton);
@@ -204,7 +204,7 @@ describe("CustomListsForBook", () => {
 
       let removable = wrapper.find(WithRemoveButton);
       expect(removable.length).to.equal(1);
-      let removeButton = removable.find(".remove");
+      let removeButton = removable.find(".remove-btn").hostNodes();
       removeButton.simulate("click");
 
       let removables = wrapper.find(WithRemoveButton);

--- a/src/components/__tests__/ErrorMessage-test.tsx
+++ b/src/components/__tests__/ErrorMessage-test.tsx
@@ -129,17 +129,4 @@ describe("ErrorMessage", () => {
     tryAgainLink.simulate("click");
     expect(tryAgain.callCount).to.equal(1);
   });
-
-  it("does not show try again button for logged out message", () => {
-    let error = {
-      status: 401,
-      response: "",
-      url: ""
-    };
-    let tryAgain = stub();
-    let wrapper = mount(<ErrorMessage error={error} tryAgain={tryAgain} />);
-    let tryAgainLink = wrapper.find("button");
-
-    expect(tryAgainLink.length).to.equal(0);
-  });
 });

--- a/src/components/__tests__/ErrorMessage-test.tsx
+++ b/src/components/__tests__/ErrorMessage-test.tsx
@@ -124,9 +124,22 @@ describe("ErrorMessage", () => {
     let wrapper = mount(
       <ErrorMessage error={error} tryAgain={tryAgain} />
     );
-    let tryAgainLink = wrapper.find("a");
+    let tryAgainLink = wrapper.find("button");
     expect(tryAgainLink.text()).to.contain("Try again");
     tryAgainLink.simulate("click");
     expect(tryAgain.callCount).to.equal(1);
+  });
+
+  it("does not show try again button for logged out message", () => {
+    let error = {
+      status: 401,
+      response: "",
+      url: ""
+    };
+    let tryAgain = stub();
+    let wrapper = mount(<ErrorMessage error={error} tryAgain={tryAgain} />);
+    let tryAgainLink = wrapper.find("button");
+
+    expect(tryAgainLink.length).to.equal(0);
   });
 });

--- a/src/components/__tests__/InputList-test.tsx
+++ b/src/components/__tests__/InputList-test.tsx
@@ -138,7 +138,7 @@ describe("InputList", () => {
   it("removes an item", () => {
     let removables = wrapper.find(WithRemoveButton);
     expect(removables.length).to.equal(2);
-    let button = removables.at(0).find(".remove");
+    let button = removables.at(0).find(".remove-btn").hostNodes();
     button.simulate("click");
     removables = wrapper.find(WithRemoveButton);
     expect(removables.length).to.equal(1);

--- a/src/components/__tests__/LaneCustomListsEditor-test.tsx
+++ b/src/components/__tests__/LaneCustomListsEditor-test.tsx
@@ -285,7 +285,7 @@ describe("LaneCustomListsEditor", () => {
         />
     );
 
-    let addLink = wrapper.find(".available-lists .links a");
+    let addLink = wrapper.find(".available-lists .links button");
     addLink.at(0).simulate("click");
 
     // the item has been added to the current lists
@@ -308,7 +308,7 @@ describe("LaneCustomListsEditor", () => {
         />
     );
 
-    let deleteLink = wrapper.find(".current-lists .links a");
+    let deleteLink = wrapper.find(".current-lists .links button");
     deleteLink.at(0).simulate("click");
     wrapper.setProps({customListIds: onUpdate.args[0][0]});
     // this list has been removed from the current lists

--- a/src/components/__tests__/Lanes-test.tsx
+++ b/src/components/__tests__/Lanes-test.tsx
@@ -283,7 +283,7 @@ describe("Lanes", () => {
     let topLevelLanes = getTopLevelLanes();
     let lane1 = topLevelLanes.at(0).find(".lane-parent").at(0);
     let sublane2 = lane1.find("li .lane-parent").at(0);
-    let sublane2Expand = sublane2.find(".expand-button");
+    let sublane2Expand = sublane2.find(".expand-button").hostNodes();
     sublane2Expand.simulate("click");
     let sublane2Droppable = getDroppableById("2");
     expect(sublane2Droppable.props().isDropDisabled).to.be.true;

--- a/src/components/__tests__/LanesSidebar-test.tsx
+++ b/src/components/__tests__/LanesSidebar-test.tsx
@@ -178,17 +178,17 @@ describe("LanesSidebar", () => {
 
   it("renders and expands and collapses lanes and sublanes", () => {
     const expectExpanded = (lane) => {
-      let collapse = lane.find(".lane-info").at(0).find(".collapse-button");
+      let collapse = lane.find(".lane-info").at(0).find(".collapse-button").hostNodes();
       expect(collapse.length).to.equal(1);
-      let expand = lane.find(".lane-info").at(0).find(".expand-button");
+      let expand = lane.find(".lane-info").at(0).find(".expand-button").hostNodes();
       expect(expand.length).to.equal(0);
       return collapse;
     };
 
     const expectCollapsed = (lane) => {
-      let collapse = lane.find(".lane-info").at(0).find(".collapse-button");
+      let collapse = lane.find(".lane-info").at(0).find(".collapse-button").hostNodes();
       expect(collapse.length).to.equal(0);
-      let expand = lane.find(".lane-info").at(0).find(".expand-button");
+      let expand = lane.find(".lane-info").at(0).find(".expand-button").hostNodes();
       expect(expand.length).to.equal(1);
       return expand;
     };
@@ -306,7 +306,7 @@ describe("LanesSidebar", () => {
     ];
 
     let expand = (lane) => {
-      lane.find(".expand-button").at(0).props().onClick();
+      lane.find(".expand-button").hostNodes().at(0).props().onClick();
     };
     let isDraggable = (lane) => {
       return lane.find(".lane-info").at(0).hasClass("draggable");

--- a/src/components/__tests__/ServiceEditForm-test.tsx
+++ b/src/components/__tests__/ServiceEditForm-test.tsx
@@ -688,8 +688,8 @@ describe("ServiceEditForm", () => {
       library = wrapper.find(WithRemoveButton);
       expect(library.length).to.equal(1);
       expect(library.text()).to.contain("Brooklyn Public Library");
-      expect(library.text()).to.contain("remove");
-      expect(library.text()).to.contain("edit");
+      expect(library.text()).to.contain("Remove");
+      expect(library.text()).to.contain("Edit");
 
       let stateLibraries = wrapper.state().libraries;
       expect(stateLibraries.length).to.equal(1);
@@ -745,7 +745,7 @@ describe("ServiceEditForm", () => {
       expect(library.length).to.equal(1);
       expect(library.text()).to.contain("New York Public Library");
 
-      let onEdit = library.find("a");
+      let onEdit = library.find("button");
       onEdit.simulate("click");
 
       let settings = wrapper.find(".edit-library-settings");
@@ -812,7 +812,9 @@ describe("ServiceEditForm", () => {
     it("calls handleData", () => {
       let handleData = spy(wrapper.instance(), "handleData");
       wrapper.setProps({ item: serviceData });
-      wrapper.find(Button).simulate("click");
+      // The first two buttons are the edit and remove buttons for this component
+      // which only contains one object as data.
+      wrapper.find(Button).at(2).simulate("click");
 
       expect(handleData.callCount).to.equal(1);
 
@@ -822,7 +824,9 @@ describe("ServiceEditForm", () => {
     it("submits data", () => {
       wrapper.setProps({ item: serviceData });
 
-      let saveButton = wrapper.find(Button);
+      // The first two buttons are the edit and remove buttons for this component
+      // which only contains one object as data.
+      let saveButton = wrapper.find(Button).at(2);
       saveButton.simulate("click");
 
       expect(save.callCount).to.equal(1);

--- a/src/components/__tests__/ServiceEditForm-test.tsx
+++ b/src/components/__tests__/ServiceEditForm-test.tsx
@@ -688,7 +688,7 @@ describe("ServiceEditForm", () => {
       library = wrapper.find(WithRemoveButton);
       expect(library.length).to.equal(1);
       expect(library.text()).to.contain("Brooklyn Public Library");
-      expect(library.text()).to.contain("Remove");
+      expect(library.text()).to.contain("Delete");
       expect(library.text()).to.contain("Edit");
 
       let stateLibraries = wrapper.state().libraries;

--- a/src/components/__tests__/WithEditButton-test.tsx
+++ b/src/components/__tests__/WithEditButton-test.tsx
@@ -2,7 +2,7 @@ import { expect } from "chai";
 import { stub } from "sinon";
 
 import * as React from "react";
-import { shallow } from "enzyme";
+import { mount } from "enzyme";
 
 import WithEditButton from "../WithEditButton";
 
@@ -12,7 +12,7 @@ describe("WithEditButton", () => {
 
   beforeEach(() => {
     onEdit = stub();
-    wrapper = shallow(
+    wrapper = mount(
       <WithEditButton
         disabled={false}
         onEdit={onEdit}
@@ -28,33 +28,22 @@ describe("WithEditButton", () => {
     });
 
     it("shows edit buttons", () => {
-      let icon = wrapper.find(".edit");
-      expect(icon.length).to.equal(1);
-
-      let srLink = wrapper.find("a.sr-only");
-      expect(srLink.length).to.equal(1);
+      let editBtn = wrapper.find(".edit-btn").hostNodes();
+      expect(editBtn.length).to.equal(1);
     });
   });
 
   describe("behavior", () => {
     it("calls onEdit", () => {
-      let icon = wrapper.find(".edit");
-      icon.simulate("click");
+      let editBtn = wrapper.find(".edit-btn").hostNodes();
+      editBtn.simulate("click");
       expect(onEdit.callCount).to.equal(1);
-
-      let srLink = wrapper.find("a.sr-only");
-      srLink.simulate("click");
-      expect(onEdit.callCount).to.equal(2);
     });
 
     it("does nothing when disabled", () => {
       wrapper.setProps({ disabled: true });
-      let icon = wrapper.find(".edit");
-      icon.simulate("click");
-      expect(onEdit.callCount).to.equal(0);
-
-      let srLink = wrapper.find("a.sr-only");
-      srLink.simulate("click");
+      let editBtn = wrapper.find(".edit-btn").hostNodes();
+      editBtn.simulate("click");
       expect(onEdit.callCount).to.equal(0);
     });
   });

--- a/src/components/__tests__/WithRemoveButton-test.tsx
+++ b/src/components/__tests__/WithRemoveButton-test.tsx
@@ -2,7 +2,7 @@ import { expect } from "chai";
 import { stub } from "sinon";
 
 import * as React from "react";
-import { shallow } from "enzyme";
+import { mount } from "enzyme";
 
 import WithRemoveButton from "../WithRemoveButton";
 
@@ -12,11 +12,11 @@ describe("WithRemoveButton", () => {
 
   beforeEach(() => {
     onRemove = stub();
-    wrapper = shallow(
+    wrapper = mount(
       <WithRemoveButton
         disabled={false}
         onRemove={onRemove}
-        >
+      >
         child
       </WithRemoveButton>
     );
@@ -28,33 +28,22 @@ describe("WithRemoveButton", () => {
     });
 
     it("shows remove buttons", () => {
-      let icon = wrapper.find(".remove");
-      expect(icon.length).to.equal(1);
-
-      let srLink = wrapper.find("a.sr-only");
-      expect(srLink.length).to.equal(1);
+      let removeBtn = wrapper.find(".remove-btn").hostNodes();
+      expect(removeBtn.length).to.equal(1);
     });
   });
 
   describe("behavior", () => {
     it("calls onRemove", () => {
-      let icon = wrapper.find(".remove");
-      icon.simulate("click");
+      let removeBtn = wrapper.find(".remove-btn").hostNodes();
+      removeBtn.simulate("click");
       expect(onRemove.callCount).to.equal(1);
-
-      let srLink = wrapper.find("a.sr-only");
-      srLink.simulate("click");
-      expect(onRemove.callCount).to.equal(2);
     });
 
     it("does nothing when disabled", () => {
       wrapper.setProps({ disabled: true });
-      let icon = wrapper.find(".remove");
-      icon.simulate("click");
-      expect(onRemove.callCount).to.equal(0);
-
-      let srLink = wrapper.find("a.sr-only");
-      srLink.simulate("click");
+      let removeBtn = wrapper.find(".remove-btn").hostNodes();
+      removeBtn.simulate("click");
       expect(onRemove.callCount).to.equal(0);
     });
   });

--- a/src/stylesheets/app.scss
+++ b/src/stylesheets/app.scss
@@ -22,6 +22,7 @@
 @import "complaints";
 @import "config_tab_container";
 @import "custom_list_editor";
+@import "custom_list_for_book";
 @import "custom_lists";
 @import "dashboard";
 @import "diagnostics";

--- a/src/stylesheets/classifications_form.scss
+++ b/src/stylesheets/classifications_form.scss
@@ -21,4 +21,11 @@
       margin-top: 15px;
     }
   }
+
+  .with-remove-button {
+    button {
+      font-size: 12px;
+      padding: 5px;
+    }
+  }
 }

--- a/src/stylesheets/config_tab_container.scss
+++ b/src/stylesheets/config_tab_container.scss
@@ -49,7 +49,7 @@ $dangercolor: #D9534F;
         }
       }
 
-      a.btn-default, button.btn-default:not(.btn), a.danger, button.danger {
+      a.btn-default, a.danger {
         display: unset;
         margin: 12px 12px 12px 0;
         color: $pagecolor;
@@ -63,7 +63,7 @@ $dangercolor: #D9534F;
         }
       }
 
-      a.danger, button.danger {
+      a.danger {
         &:hover {
           background-color: white;
           border-color: $dangercolor;

--- a/src/stylesheets/custom_list_for_book.scss
+++ b/src/stylesheets/custom_list_for_book.scss
@@ -1,0 +1,8 @@
+.custom-list-for-book {
+  .with-remove-button {
+    button {
+      font-size: 12px;
+      padding: 5px;
+    }
+  }
+}

--- a/src/stylesheets/edit_form.scss
+++ b/src/stylesheets/edit_form.scss
@@ -24,7 +24,7 @@
     display: flex;
     flex-direction: row;
     justify-content: flex-start;
-    align-items: flex-start;
+    align-items: baseline;
   }
 
   .contributor-form {

--- a/src/stylesheets/edit_form.scss
+++ b/src/stylesheets/edit_form.scss
@@ -20,11 +20,18 @@
     height: 300px;
   }
 
-  .with-remove-button {
-    display: flex;
-    flex-direction: row;
-    justify-content: flex-start;
-    align-items: baseline;
+  .update-libraries {
+    .with-remove-button,
+    .with-edit-button {
+      display: flex;
+      flex-direction: row;
+      justify-content: flex-start;
+      align-items: baseline;
+
+      > span {
+        width: 100%;
+      }
+    }
   }
 
   .contributor-form {
@@ -35,6 +42,10 @@
 
     .form-group {
       margin-right: 10px;
+
+      &:last-child {
+        margin-right: 0;
+      }
     }
   }
 

--- a/src/stylesheets/header.scss
+++ b/src/stylesheets/header.scss
@@ -27,9 +27,15 @@
     margin-left: 3px;
 
     .dropdown {
-      > a:focus {
-        @include basic-focus;
-        outline-color: $white;
+      > button {
+        color: $white;
+        padding: 13px 10px;
+        margin: 0;
+
+        &:focus {
+          @include basic-focus;
+          outline-color: $white;
+        }
       }
     }
 

--- a/src/stylesheets/header.scss
+++ b/src/stylesheets/header.scss
@@ -32,6 +32,12 @@
         padding: 13px 10px;
         margin: 0;
 
+        svg {
+          transform: rotate(270deg);
+          fill: $white;
+          height: 0.9em;
+        }
+
         &:focus {
           @include basic-focus;
           outline-color: $white;

--- a/src/stylesheets/lane_editor.scss
+++ b/src/stylesheets/lane_editor.scss
@@ -132,7 +132,7 @@
           margin-right: 10px;
         }
 
-        a {
+        button {
           font-size: .8em;
 
           svg {

--- a/src/stylesheets/protocol_form_field.scss
+++ b/src/stylesheets/protocol_form_field.scss
@@ -8,6 +8,11 @@
 }
 
 .add-list-item-container {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  align-items: baseline;
+
   span.add-list-item {
     display: inline-block;
     margin-right: 10px;
@@ -15,7 +20,6 @@
   
   .btn.add-list-item {
     vertical-align: top;
-    margin: unset;
   }
 }
 

--- a/src/stylesheets/with_edit_button.scss
+++ b/src/stylesheets/with_edit_button.scss
@@ -4,8 +4,13 @@
     margin-right: 10px;
   }
 
-  .edit {
-    color: #AAA;
-    cursor: pointer;
+  .edit-btn {
+    display: inline-block;
+    color: $white;
+    font-size: 14px;
+
+    svg {
+      width: 1em;
+    }
   }
 }

--- a/src/stylesheets/with_remove_button.scss
+++ b/src/stylesheets/with_remove_button.scss
@@ -1,6 +1,7 @@
 .with-remove-button {
   > span {
     display: inline-block;
+    margin-right: 10px;
   }
 
   .remove-btn {

--- a/src/stylesheets/with_remove_button.scss
+++ b/src/stylesheets/with_remove_button.scss
@@ -1,12 +1,16 @@
 .with-remove-button {
   > span {
     display: inline-block;
-    margin-right: 10px;
   }
 
-  .remove {
-    padding: 9px 0;
-    color: #AAA;
-    cursor: pointer;
+  .remove-btn {
+    display: inline-block;
+    color: $white;
+    font-size: 14px;
+    margin: 0.5em;
+
+    svg {
+      width: 1em;
+    }
   }
 }


### PR DESCRIPTION
…ents package, cleaning up files and css.

This depends on [Resuable Components PR](https://github.com/NYPL-Simplified/reusable-components/pull/23) and resolves [SIMPLY-2136](https://jira.nypl.org/browse/SIMPLY-2136).

Updating elements that were either anchors or divs to buttons, but needed to update the `Button` component first to allow `aria-*` attributes as props.

A big but subtle change is the `Header`'s email button dropdown. The biggest changes are in the `WithEditButton` and `WithRemoveButton` components. In the book edit page it now appears like so:
![Screen Shot 2019-07-23 at 11 26 04 AM](https://user-images.githubusercontent.com/1280564/61725695-3fb64c00-ad3e-11e9-969e-ca0fd5c67ef7.png)
![Screen Shot 2019-07-23 at 11 26 13 AM](https://user-images.githubusercontent.com/1280564/61725699-4218a600-ad3e-11e9-8d3a-6fa5520715c9.png)
![Screen Shot 2019-07-23 at 11 26 18 AM](https://user-images.githubusercontent.com/1280564/61725705-45ac2d00-ad3e-11e9-8063-f780f3f26d5c.png)

And in the Collections edit page:
![Screen Shot 2019-07-23 at 11 26 32 AM](https://user-images.githubusercontent.com/1280564/61725718-4c3aa480-ad3e-11e9-9fba-4bdd12c3c3de.png)

Also fixed/cleaned up styling issues:
<img width="217" alt="Screen Shot 2019-07-19 at 4 32 57 PM" src="https://user-images.githubusercontent.com/1280564/61725747-5ceb1a80-ad3e-11e9-91bf-851e54bb598e.png">
