### PR TITLE
Adjust catalog page styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### v0.3.11
 #### Added
 - Created a Troubleshooting page, comprising Diagnostics and Self-tests.
+#### Updated
+- Made the buttons, icons, and links on the catalog page visually consistent with the rest of the interface.
 
 ### v0.3.10
 #### Updated

--- a/src/stylesheets/colors.scss
+++ b/src/stylesheets/colors.scss
@@ -12,4 +12,5 @@ $dark-gray: #080807;
 $gray-tint: #F5F5F4;
 $white: #FFF;
 $blue: #1B7FA7;
+$blue-dark: #135772;
 $yellow: #FEE24A;

--- a/src/stylesheets/entry_points_container.scss
+++ b/src/stylesheets/entry_points_container.scss
@@ -2,6 +2,46 @@
   height: 100%;
   margin: 10px 0 15px;
   padding: 0 15px;
+  .lane {
+    a.title {
+      color: $blue;
+      &:hover {
+        color: $blue-dark;
+      }
+    }
+    .lane-books-container {
+      .scroll-button {
+        background: $blue;
+        &:hover {
+          background: $blue-dark;
+          color: $white;
+          transition: background .5s;
+        }
+        &.right {
+          border-top-right-radius: .25em;
+          border-bottom-right-radius: .25em;
+        }
+        &.left {
+          border-top-left-radius: .25em;
+          border-bottom-left-radius: .25em;
+        }
+      }
+    }
+    .item-icon svg {
+      fill: $blue;
+      &:hover {
+        fill: $blue-dark;
+      }
+    }
+    .item-details {
+      color: $blue;
+      .title, span {
+        &:hover {
+          color: $blue-dark;
+        }
+      }
+    }
+  }
 
   .nav-tabs {
     border-bottom: 1px solid $dark;

--- a/src/stylesheets/global.scss
+++ b/src/stylesheets/global.scss
@@ -36,6 +36,12 @@
 }
 
 .breadcrumbs-or-search-wrapper {
+  a {
+    color: $blue;
+    &:hover {
+      color: $blue-dark;
+    }
+  }
   .search {
     button {
       margin-top: 0;


### PR DESCRIPTION
Resolves https://jira.nypl.org/browse/SIMPLY-2085; I made the catalog page elements that are coming from the OPDS component (breadcrumb links, lane titles, arrow buttons) visually consistent with the rest of the interface.

<img width="1320" alt="Screen Shot 2019-08-12 at 1 04 05 PM" src="https://user-images.githubusercontent.com/42178216/62883415-fedca200-bd01-11e9-8446-73e2d8cd88a3.png">
