### PR TITLE
Refactor book edit form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v0.3.13
+#### Updated
+- Refactored the BookEditForm code.
+
 ### v0.3.12
 #### Added
 - Typedoc for generating code documentation.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/components/BookEditForm.tsx
+++ b/src/components/BookEditForm.tsx
@@ -1,10 +1,11 @@
 import * as React from "react";
 import EditableInput from "./EditableInput";
 import EditorField from "./EditorField";
-import { Button, Form } from "library-simplified-reusable-components";
+import { Form } from "library-simplified-reusable-components";
 import { BookData, ContributorData, RolesData, MediaData, LanguagesData } from "../interfaces";
-import WithRemoveButton from "./WithRemoveButton";
 import LanguageField from "./LanguageField";
+import { formatString } from "./sharedFunctions";
+import ContributorForm from "./ContributorForm";
 
 export interface BookEditFormProps extends BookData {
   roles: RolesData;
@@ -28,8 +29,6 @@ export default class BookEditForm extends React.Component<BookEditFormProps, Boo
     this.state = {
       contributors: (props.authors || []).concat(props.contributors || [])
     };
-    this.addContributor = this.addContributor.bind(this);
-    this.removeContributor = this.removeContributor.bind(this);
     this.renderForm = this.renderForm.bind(this);
   }
 
@@ -44,118 +43,36 @@ export default class BookEditForm extends React.Component<BookEditFormProps, Boo
     );
   }
 
+  renderTextField(name: string, placeholder?: string, value?: string, hasLabel = true): JSX.Element {
+    return (
+      <EditableInput
+        elementType="input"
+        type="text"
+        disabled={this.props.disabled}
+        name={name}
+        label={hasLabel && formatString(name)}
+        value={value || this.props[name]}
+        optionalText={false}
+        placeholder={placeholder}
+      />
+    );
+  }
+
   renderForm() {
-    const newRoleRef = this.refs["addContributorRole"] as any;
-    const newRoleValue = newRoleRef && newRoleRef.getValue();
     const mediumValue = this.getMedium(this.props.medium);
+    const seriesPosition = this.props.seriesPosition !== undefined && this.props.seriesPosition !== null && String(this.props.seriesPosition);
     return (
       <fieldset key="book-info">
         <legend className="visuallyHidden">Edit Book Metadata</legend>
-        <EditableInput
-          elementType="input"
-          type="text"
-          disabled={this.props.disabled}
-          name="title"
-          label="Title"
-          value={this.props.title}
-          optionalText={false}
-          />
-        <EditableInput
-          elementType="input"
-          type="text"
-          disabled={this.props.disabled}
-          name="subtitle"
-          label="Subtitle"
-          value={this.props.subtitle}
-          optionalText={false}
-          />
-        <div className="form-group">
-          <label>Authors and Contributors</label>
-          { this.state.contributors.map(contributor => {
-              const contributorRole = this.getContributorRole(contributor);
-              return (
-                <WithRemoveButton
-                  key={contributor.name + contributor.role}
-                  disabled={this.props.disabled}
-                  onRemove={() => this.removeContributor(contributor)}
-                  >
-                  <span className="contributor-form">
-                    <EditableInput
-                      elementType="select"
-                      disabled={this.props.disabled}
-                      name="contributor-role"
-                      value={contributorRole}
-                      >
-                      { this.props.roles && Object.values(this.props.roles).map(role =>
-                          <option value={role} key={role} aria-selected={contributorRole === role}>{role}</option>
-                        )
-                      }
-                    </EditableInput>
-                    <EditableInput
-                      elementType="input"
-                      type="text"
-                      disabled={this.props.disabled}
-                      name="contributor-name"
-                      value={contributor.name}
-                      optionalText={false}
-                      />
-                  </span>
-                </WithRemoveButton>)
-              ;
-            })
-          }
-          <span className="contributor-form">
-            <EditableInput
-              elementType="select"
-              disabled={this.props.disabled}
-              name="contributor-role"
-              value="Author"
-              ref="addContributorRole"
-              >
-              { this.props.roles && Object.values(this.props.roles).map(role =>
-                 <option value={role} key={role} aria-selected={newRoleValue === role}>{role}</option>
-                )
-              }
-            </EditableInput>
-            <EditableInput
-              elementType="input"
-              type="text"
-              disabled={this.props.disabled}
-              name="contributor-name"
-              ref="addContributorName"
-              optionalText={false}
-              />
-            <Button
-              type="button"
-              className="add-contributor small"
-              disabled={this.props.disabled}
-              callback={this.addContributor}
-              content="Add"
-            />
-          </span>
-        </div>
+        { this.renderTextField("title") }
+        { this.renderTextField("subtitle") }
+        <ContributorForm disabled={this.props.disabled} roles={this.props.roles} contributors={this.state.contributors} />
         <div className="form-group">
           <label>Series</label>
           <div className="form-inline">
-            <EditableInput
-              elementType="input"
-              type="text"
-              disabled={this.props.disabled}
-              name="series"
-              placeholder="Name"
-              value={this.props.series}
-              optionalText={false}
-              />
+            { this.renderTextField("series", "Name", null, false) }
             <span>&nbsp;&nbsp;</span>
-            <EditableInput
-              elementType="input"
-              type="text"
-              disabled={this.props.disabled}
-              name="series_position"
-              placeholder="#"
-              value={this.props.seriesPosition !== undefined && this.props.seriesPosition !== null && String(this.props.seriesPosition)}
-              optionalText={false}
-              />
+            { this.renderTextField("series_position", "#", seriesPosition, false) }
           </div>
         </div>
         <EditableInput
@@ -164,7 +81,7 @@ export default class BookEditForm extends React.Component<BookEditFormProps, Boo
           name="medium"
           label="Medium"
           value={mediumValue}
-          >
+        >
           { this.props.media && Object.values(this.props.media).map(medium =>
               <option value={medium} key={medium} aria-selected={mediumValue === medium}>{medium}</option>
             )
@@ -177,24 +94,8 @@ export default class BookEditForm extends React.Component<BookEditFormProps, Boo
           label="Language"
           value={this.props.language}
         />
-        <EditableInput
-          elementType="input"
-          type="text"
-          disabled={this.props.disabled}
-          name="publisher"
-          label="Publisher"
-          value={this.props.publisher}
-          optionalText={false}
-          />
-        <EditableInput
-          elementType="input"
-          type="text"
-          disabled={this.props.disabled}
-          name="imprint"
-          label="Imprint"
-          value={this.props.imprint}
-          optionalText={false}
-          />
+        { this.renderTextField("publisher") }
+        { this.renderTextField("imprint") }
         <EditableInput
           elementType="input"
           type="date"
@@ -203,7 +104,7 @@ export default class BookEditForm extends React.Component<BookEditFormProps, Boo
           label="Publication Date"
           value={this.props.issued}
           optionalText={false}
-          />
+        />
         <EditableInput
           elementType="input"
           type="number"
@@ -214,7 +115,7 @@ export default class BookEditForm extends React.Component<BookEditFormProps, Boo
           max={5}
           value={this.props.rating && String(Math.round(this.props.rating))}
           optionalText={false}
-          />
+        />
         <div className="editor form-group">
           <label className="control-label">Summary</label>
           <EditorField ref={this.summaryRef} content={this.props.summary} disabled={this.props.disabled}/>
@@ -230,30 +131,6 @@ export default class BookEditForm extends React.Component<BookEditFormProps, Boo
       }
     }
     return additionalTypeOrMedium;
-  }
-
-  getContributorRole(contributor) {
-    if (this.props.roles) {
-      if (this.props.roles[contributor.role]) {
-        return this.props.roles[contributor.role];
-      }
-    }
-    return contributor.role;
-  }
-
-  removeContributor(contributor) {
-    const remainingContributors = this.state.contributors.filter(stateContributor => {
-      return !(stateContributor.name === contributor.name && stateContributor.role === contributor.role);
-    });
-    this.setState({ contributors: remainingContributors });
-  }
-
-  addContributor() {
-    const name = (this.refs["addContributorName"] as any).getValue();
-    const role = (this.refs["addContributorRole"] as any).getValue();
-    this.setState({ contributors: this.state.contributors.concat({ role, name }) });
-    (this.refs["addContributorName"] as any).clear();
-    (this.refs["addContributorRole"] as any).clear();
   }
 
   save(data: FormData) {

--- a/src/components/ContributorForm.tsx
+++ b/src/components/ContributorForm.tsx
@@ -33,6 +33,7 @@ export default class ContributorForm extends React.Component<ContributorFormProp
   }
 
   newContributor(): JSX.Element {
+    // The component for adding a new contributor; menu, input field, and add button.
     const newRoleRef = this.refs["addContributorRole"] as any;
     const newRoleValue = newRoleRef && newRoleRef.getValue();
     return (
@@ -51,6 +52,7 @@ export default class ContributorForm extends React.Component<ContributorFormProp
   }
 
   contributorSelect(contributorRole?: string, isNew = false): JSX.Element {
+    // The drop-down list of all the possible contributor roles.
     return (
       <EditableInput
         elementType="select"
@@ -68,6 +70,7 @@ export default class ContributorForm extends React.Component<ContributorFormProp
   }
 
   contributorField(contributor?) {
+    // The input field containing the name of the contributor.
     return(
       <EditableInput
         elementType="input"
@@ -82,6 +85,7 @@ export default class ContributorForm extends React.Component<ContributorFormProp
   }
 
   existingContributors() {
+    // The list of one or more existing contributors; each row has menu, input field, and delete button.
     return this.state.contributors.map(contributor => {
       const contributorRole = this.getContributorRole(contributor);
       return (

--- a/src/components/ContributorForm.tsx
+++ b/src/components/ContributorForm.tsx
@@ -1,0 +1,126 @@
+import * as React from "react";
+import EditableInput from "./EditableInput";
+import { Button } from "library-simplified-reusable-components";
+import { ContributorData, RolesData } from "../interfaces";
+import WithRemoveButton from "./WithRemoveButton";
+
+export interface ContributorFormProps {
+  roles: RolesData;
+  contributors?: ContributorData[];
+  disabled?: boolean;
+}
+
+export interface ContributorFormState {
+  contributors: ContributorData[];
+}
+
+export default class ContributorForm extends React.Component<ContributorFormProps, ContributorFormState> {
+  constructor(props) {
+    super(props);
+    this.state = { contributors: this.props.contributors || [] };
+    this.addContributor = this.addContributor.bind(this);
+    this.removeContributor = this.removeContributor.bind(this);
+  }
+
+  render(): JSX.Element {
+    return (
+      <div className="form-group">
+        <label>Authors and Contributors</label>
+        { this.existingContributors() }
+        { this.newContributor() }
+      </div>
+    );
+  }
+
+  newContributor(): JSX.Element {
+    const newRoleRef = this.refs["addContributorRole"] as any;
+    const newRoleValue = newRoleRef && newRoleRef.getValue();
+    return (
+      <span className="contributor-form">
+        { this.contributorSelect(newRoleValue, true) }
+        { this.contributorField() }
+        <Button
+          type="button"
+          className="add-contributor small"
+          disabled={this.props.disabled}
+          callback={this.addContributor}
+          content="Add"
+        />
+      </span>
+    );
+  }
+
+  contributorSelect(contributorRole?: string, isNew = false): JSX.Element {
+    return (
+      <EditableInput
+        elementType="select"
+        disabled={this.props.disabled}
+        name="contributor-role"
+        value={contributorRole || "Author"}
+        ref={isNew && "addContributorRole"}
+       >
+        { this.props.roles && Object.values(this.props.roles).map(role =>
+            <option value={role} key={role} aria-selected={contributorRole === role}>{role}</option>
+          )
+        }
+      </EditableInput>
+    );
+  }
+
+  contributorField(contributor?) {
+    return(
+      <EditableInput
+        elementType="input"
+        type="text"
+        disabled={this.props.disabled}
+        name="contributor-name"
+        value={contributor && contributor.name}
+        ref={!contributor && "addContributorName"}
+        optionalText={false}
+      />
+    );
+  }
+
+  existingContributors() {
+    return this.state.contributors.map(contributor => {
+      const contributorRole = this.getContributorRole(contributor);
+      return (
+        <WithRemoveButton
+          key={contributor.name + contributor.role}
+          disabled={this.props.disabled}
+          onRemove={() => this.removeContributor(contributor)}
+        >
+          <span className="contributor-form">
+            { this.contributorSelect(contributorRole) }
+            { this.contributorField(contributor) }
+          </span>
+        </WithRemoveButton>
+      );
+    });
+  }
+
+  getContributorRole(contributor) {
+    if (this.props.roles) {
+      if (this.props.roles[contributor.role]) {
+        return this.props.roles[contributor.role];
+      }
+    }
+    return contributor.role;
+  }
+
+  removeContributor(contributor) {
+    const remainingContributors = this.state.contributors.filter(stateContributor => {
+      return !(stateContributor.name === contributor.name && stateContributor.role === contributor.role);
+    });
+    this.setState({ contributors: remainingContributors });
+  }
+
+  addContributor() {
+    const name = (this.refs["addContributorName"] as any).getValue();
+    const role = (this.refs["addContributorRole"] as any).getValue();
+    this.setState({ contributors: this.state.contributors.concat({ role, name }) });
+    (this.refs["addContributorName"] as any).clear();
+    (this.refs["addContributorRole"] as any).clear();
+  }
+
+}

--- a/src/components/__tests__/ContributorForm-test.tsx
+++ b/src/components/__tests__/ContributorForm-test.tsx
@@ -1,16 +1,11 @@
 import { expect } from "chai";
-import { stub } from "sinon";
-
 import * as React from "react";
-import { shallow, mount } from "enzyme";
+import { mount } from "enzyme";
 
 import ContributorForm from "../ContributorForm";
-import EditableInput from "../EditableInput";
-import WithRemoveButton from "../WithRemoveButton";
-import { Button } from "library-simplified-reusable-components";
 import { RolesData, ContributorData } from "../../interfaces";
 
-describe.only("ContributorForm", () => {
+describe("ContributorForm", () => {
   let roles: RolesData = {
     "aut": "Author",
     "ill": "Illustrator",
@@ -81,7 +76,7 @@ describe.only("ContributorForm", () => {
     expect(hasInput(existingContributors.first(), contributors[1].name));
   });
 
-  it.only("adds a contributor", () => {
+  it("adds a contributor", () => {
     expect(wrapper.state()["contributors"]).to.eql(contributors);
     let existingContributors = wrapper.find(".with-remove-button");
     expect(existingContributors.length).to.equal(2);
@@ -98,7 +93,13 @@ describe.only("ContributorForm", () => {
     expect(existingContributors.length).to.equal(3);
     expect(existingContributors.last().find("select").prop("value")).to.equal("Illustrator");
     expect(existingContributors.last().find("input").prop("value")).to.equal("An Illustrator");
+  });
 
+  it("looks up the full name of a contributor's role", () => {
+    expect(wrapper.instance().getContributorRole(contributors[0])).to.equal("Translator");
+    // If the look-up doesn't yield anything, it just uses the abbreviated version.
+    let adapter = { name: "An Adapter", role: "adp" };
+    expect(wrapper.instance().getContributorRole(adapter)).to.equal("adp");
   });
 
 });

--- a/src/components/__tests__/ContributorForm-test.tsx
+++ b/src/components/__tests__/ContributorForm-test.tsx
@@ -1,0 +1,74 @@
+import { expect } from "chai";
+import { stub } from "sinon";
+
+import * as React from "react";
+import { shallow, mount } from "enzyme";
+
+import ContributorForm from "../ContributorForm";
+import EditableInput from "../EditableInput";
+import WithRemoveButton from "../WithRemoveButton";
+import { Button } from "library-simplified-reusable-components";
+import { RolesData, ContributorData } from "../../interfaces";
+
+describe.only("ContributorForm", () => {
+  let roles: RolesData = {
+    "aut": "Author",
+    "ill": "Illustrator",
+    "nrt": "Narrator",
+    "trl": "Translator"
+  };
+  let contributors: ContributorData[] = [
+    { name: "A Translator", role: "trl" },
+    { name: "A Narrator", role: "nrt" }
+  ];
+  let wrapper;
+
+  let hasSelect = (element, value: string) => {
+    let select = element.find("select");
+    expect(select.length).to.equal(1);
+    expect(select.prop("name")).to.equal("contributor-role");
+    expect(select.prop("value")).to.equal(value);
+    expect(select.find("option").map(o => o.prop("value"))).to.eql(Object.values(roles));
+  };
+
+  let hasInput = (element, value = "") => {
+    let input = element.find("input");
+    expect(element.length).to.equal(1);
+    expect(input.prop("name")).to.equal("contributor-name");
+    expect(input.prop("value")).to.equal(value);
+  };
+
+  beforeEach(() => {
+    wrapper = mount(
+      <ContributorForm roles={roles} contributors={contributors}/>
+    );
+  });
+
+  it("displays a label", () => {
+    let label = wrapper.find("label").at(0);
+    expect(label.text()).to.equal("Authors and Contributors");
+  });
+
+  it("displays a list of existing contributors", () => {
+    let removables = wrapper.find(".with-remove-button");
+    expect(removables.length).to.equal(2);
+    removables.forEach((el, idx) => {
+      expect(hasSelect(el, roles[contributors[idx].role]));
+      expect(hasInput(el, contributors[idx].name));
+    });
+  });
+
+  it("displays a blank field for adding a new contributor", () => {
+    let newContributorForm = wrapper.find(".contributor-form").last();
+    expect(hasSelect(newContributorForm, "Author"));
+    expect(hasInput(newContributorForm));
+    let button = newContributorForm.find(".btn.add-contributor");
+    expect(button.length).to.equal(1);
+    expect(button.text()).to.equal("Add");
+  });
+
+  it.only("deletes a contributor", () => {
+
+  });
+
+});

--- a/src/components/__tests__/ContributorForm-test.tsx
+++ b/src/components/__tests__/ContributorForm-test.tsx
@@ -67,7 +67,37 @@ describe.only("ContributorForm", () => {
     expect(button.text()).to.equal("Add");
   });
 
-  it.only("deletes a contributor", () => {
+  it("deletes a contributor", () => {
+    expect(wrapper.state()["contributors"]).to.eql(contributors);
+    let existingContributors = wrapper.find(".with-remove-button");
+    expect(existingContributors.length).to.equal(2);
+    expect(hasSelect(existingContributors.first(), roles[contributors[0].role]));
+    expect(hasInput(existingContributors.first(), contributors[0].name));
+    existingContributors.first().find("button").simulate("click");
+    expect(wrapper.state()["contributors"]).to.eql([contributors[1]]);
+    existingContributors = wrapper.find(".with-remove-button");
+    expect(existingContributors.length).to.equal(1);
+    expect(hasSelect(existingContributors.first(), roles[contributors[1].role]));
+    expect(hasInput(existingContributors.first(), contributors[1].name));
+  });
+
+  it.only("adds a contributor", () => {
+    expect(wrapper.state()["contributors"]).to.eql(contributors);
+    let existingContributors = wrapper.find(".with-remove-button");
+    expect(existingContributors.length).to.equal(2);
+    let newContributorForm = wrapper.find(".contributor-form").last();
+    newContributorForm.find("select").getDOMNode().value = "Illustrator";
+    newContributorForm.find("select").simulate("change");
+    newContributorForm.find("input").getDOMNode().value = "An Illustrator";
+    newContributorForm.find("input").simulate("change");
+    newContributorForm.find("button").simulate("click");
+    expect(wrapper.state()["contributors"]).to.eql(
+      contributors.concat({ role: "Illustrator", name: "An Illustrator" })
+    );
+    existingContributors = wrapper.find(".with-remove-button");
+    expect(existingContributors.length).to.equal(3);
+    expect(existingContributors.last().find("select").prop("value")).to.equal("Illustrator");
+    expect(existingContributors.last().find("input").prop("value")).to.equal("An Illustrator");
 
   });
 


### PR DESCRIPTION
This is just for stuff in the Details tab.  Two big changes:

1) The form for listing/adding/deleting contributors is its own component now.

2) Rather than copy-pasting the HTML for every single input field, BookEditForm now has a `renderTextField` function to generate most of them. 