### PR TITLE
Updating the link color in the tabs for catalog and book detail pages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v0.3.14
+#### Updated
+- Updated the catalog book default colors as well as book detail tabs and entrypoint tabs link color.
+
 ### v0.3.13
 #### Updated
 - Refactored the BookEditForm code.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -65,7 +65,7 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
     const currentPathname = (this.context.router &&
       this.context.router.getCurrentLocation() &&
       this.context.router.getCurrentLocation().pathname) || "";
-      let currentLibrary = this.context.library && this.context.library();
+    let currentLibrary = this.context.library && this.context.library();
     let isLibraryManager = this.context.admin.isLibraryManager(currentLibrary);
     let isSystemAdmin = this.context.admin.isSystemAdmin();
     return (

--- a/src/stylesheets/app.scss
+++ b/src/stylesheets/app.scss
@@ -10,6 +10,7 @@
 @import "badge";
 @import "book_details_container";
 @import "book_details_tab_container";
+@import "catalog_overrides";
 @import "change_password_form";
 @import "circulation_events_download_form";
 @import "classifications";

--- a/src/stylesheets/book_details_tab_container.scss
+++ b/src/stylesheets/book_details_tab_container.scss
@@ -1,60 +1,84 @@
-.book-details-tab-container .tab-content {
-  .form-inline {
-    display: flex;
+.book-details-tab-container {
+  .nav-tabs {
+    li {
+      a {
+        color: $blue;
+        &:active,
+        &:visited,
+        &:hover {
+          color: $blue-dark;
+        }
+      }
+
+      &.active {
+        a,
+        a:hover,
+        a:focus,
+        a:visited {
+          color: $blue-dark;
+        }
+      }
+    }
   }
 
-  // First Tab
-  .book-details {
-    padding-top: 2em;
-    .right-column-links {
-      display: none;
+  .tab-content {
+    .form-inline {
+      display: flex;
     }
 
-    .main .row {
-      display: flex;
-      justify-content: center;
-      margin: 0;
-      padding-bottom: 2em;
-      border-bottom: 1px solid $gray-border;
+    // First Tab
+    .book-details {
+      padding-top: 2em;
+      .right-column-links {
+        display: none;
+      }
 
-      .top {
-        width: 60%;
-        margin: auto;
-        .circulation-links {
-          padding-bottom: 1em;
-          border-bottom: 1px solid $blue;
-          .btn {
-            color: $blue;
-            border-color: $blue;
-            margin: 5px 10px;
-            &:hover {
-              color: $white;
+      .main .row {
+        display: flex;
+        justify-content: center;
+        margin: 0;
+        padding-bottom: 2em;
+        border-bottom: 1px solid $gray-border;
+
+        .top {
+          width: 60%;
+          margin: auto;
+          .circulation-links {
+            padding-bottom: 1em;
+            border-bottom: 1px solid $blue;
+            .btn {
+              color: $blue;
+              border-color: $blue;
+              margin: 5px 10px;
+              &:hover {
+                color: $white;
+              }
             }
           }
-        }
-        .open-access-info {
-          padding-top: .75em;
-          width: 100%;
+          .open-access-info {
+            padding-top: .75em;
+            width: 100%;
+          }
         }
       }
     }
-  }
 
-  // For all forms on the Book edit tab page
-  .edit-form {
-    width: 100%;
-  }
+    // For all forms on the Book edit tab page
+    .edit-form {
+      width: 100%;
+    }
 
-  .cover-edit-form {
-    margin: 0;
-    padding: 0;
-    form {
-      height: auto;
-      .alert h4 {
-        margin-bottom: 0;
-      }
-      button.btn.top-align {
-        margin: unset;
+    .cover-edit-form {
+      margin: 0;
+      padding: 0;
+      form {
+        height: auto;
+        .alert h4 {
+          margin-bottom: 0;
+        }
+        button.btn.top-align {
+          margin: unset;
+        }
       }
     }
   }

--- a/src/stylesheets/catalog_overrides.scss
+++ b/src/stylesheets/catalog_overrides.scss
@@ -1,0 +1,22 @@
+.collection-container {
+  .book {
+    .item-icon svg {
+      fill: $blue-dark;
+    }
+    .item-details {
+      color: $blue-dark;
+    }
+  }
+  .more-link div {
+    color: $blue;
+    svg {
+      fill: $blue;
+    }
+    &:hover {
+      color: $blue-dark;
+      svg {
+        fill: $blue-dark;
+      }
+    }
+  }
+}

--- a/src/stylesheets/catalog_overrides.scss
+++ b/src/stylesheets/catalog_overrides.scss
@@ -1,10 +1,15 @@
 .collection-container {
-  .book {
+  .book a {
     .item-icon svg {
-      fill: $blue-dark;
+      fill: $blue;
     }
-    .item-details {
-      color: $blue-dark;
+    &:hover {
+      .item-icon svg {
+        fill: $blue-dark;
+      }
+      .item-details {
+        color: $blue-dark;
+      }
     }
   }
   .more-link div {

--- a/src/stylesheets/entry_points_container.scss
+++ b/src/stylesheets/entry_points_container.scss
@@ -27,20 +27,6 @@
         }
       }
     }
-    .item-icon svg {
-      fill: $blue;
-      &:hover {
-        fill: $blue-dark;
-      }
-    }
-    .item-details {
-      color: $blue;
-      .title, span {
-        &:hover {
-          color: $blue-dark;
-        }
-      }
-    }
   }
 
   .nav-tabs {
@@ -50,6 +36,19 @@
   // EntryPointsTabs
   .entry-points-list {
     li {
+      a {
+        color: $blue;
+        svg {
+          fill: $blue;
+        }
+        &:hover {
+          color: $blue-dark;
+          svg {
+            fill: $blue-dark;
+          }
+        }
+      }
+
       &.no-svg {
         a {
           padding: 11px;
@@ -63,9 +62,10 @@
         a:visited {
           border: 1px solid $dark;
           border-bottom-color: transparent;
+          color: $blue-dark;
 
           svg {
-            fill: $dark;
+            fill: $blue-dark;
           }
         }
       }
@@ -73,24 +73,12 @@
       a {
         min-width: 100px;
         text-align: center;
-
-        &:visited {
-          svg {
-            fill: $linkvisitedcolor;
-          }
-        }
-        &:hover {
-          svg {
-            fill: $linkhovercolor;
-          }
-        }
       }
 
       svg {
         height: 28px;
         width: 28px;
         margin: 0 3px -9px 0;
-        fill: $linkcolor;
       }
     }
   }


### PR DESCRIPTION
Resolves [SIMPLY-2280](https://jira.nypl.org/browse/SIMPLY-2280). Just updating link colors that were missed to be the default blue we are using. I created a new scss file since same elements get rendered in different pages (the catalog, the book detail, the hidden, and the complaints pages).