### PR TITLE
First pass (no access_problem yet)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v0.3.15
+#### Updated
+- Displayed additional terms-of-service information on the library registration form.
+
 ### v0.3.14
 #### Updated
 - Updated the catalog book default colors as well as book detail tabs and entrypoint tabs link color.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.3.14",
+  "version": "0.3.15",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/components/LibraryRegistration.tsx
+++ b/src/components/LibraryRegistration.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { ServiceEditFormProps } from "./ServiceEditForm";
 import EditableInput from "./EditableInput";
 import LibraryRegistrationForm from "./LibraryRegistrationForm";
-import { ServicesWithRegistrationsData, LibraryDataWithStatus, LibraryData } from "../interfaces";
+import { ServicesWithRegistrationsData, LibraryDataWithStatus, LibraryRegistrationData, LibraryData } from "../interfaces";
 
 export interface LibraryRegistrationState {
   registration_stage?: { [key: string]: string } | null;
@@ -50,7 +50,7 @@ export default class LibraryRegistration extends React.Component<LibraryRegistra
         <div>
           <h2>Register libraries</h2>
           <ul>
-          { this.props.data.allLibraries.map(library => this.libraryRegistrationItem(library)) }
+          { this.props.data.allLibraries.map((library, idx) => this.libraryRegistrationItem(library, idx)) }
           </ul>
         </div>
       );
@@ -70,7 +70,7 @@ export default class LibraryRegistration extends React.Component<LibraryRegistra
     return libraryRegistrationStatus;
   }
 
-  libraryRegistrationItem(library: LibraryData): JSX.Element {
+  libraryRegistrationItem(library: LibraryData, idx: number): JSX.Element {
     let statusString = this.getStatus(library);
     return (
       <li className="service-with-registrations-library" key={library.short_name}>
@@ -78,7 +78,7 @@ export default class LibraryRegistration extends React.Component<LibraryRegistra
         <div className="library-registration-info">
           { this.currentStage(library, statusString) }
           { this.statusSpan(statusString) }
-          { this.libraryRegistrationForm(library, statusString) }
+          { this.libraryRegistrationForm(library, statusString, this.props.data.libraryRegistrations && this.props.data.libraryRegistrations[idx]) }
         </div>
       </li>
     );
@@ -136,7 +136,7 @@ export default class LibraryRegistration extends React.Component<LibraryRegistra
     );
   }
 
-  libraryRegistrationForm(library: LibraryData, status: string): JSX.Element {
+  libraryRegistrationForm(library: LibraryData, status: string, registrationData: LibraryRegistrationData): JSX.Element {
     return (
       <LibraryRegistrationForm
         library={library}
@@ -144,6 +144,7 @@ export default class LibraryRegistration extends React.Component<LibraryRegistra
         buttonText={this.MESSAGES[status].buttonText}
         checked={status === "success"}
         disabled={this.props.disabled}
+        registrationData={registrationData}
       />
     );
   }

--- a/src/components/LibraryRegistrationForm.tsx
+++ b/src/components/LibraryRegistrationForm.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
-import { LibraryData } from "../interfaces";
+import { LibraryData, LibraryRegistrationData } from "../interfaces";
 import EditableInput from "./EditableInput";
-import { Button, Form } from "library-simplified-reusable-components";
+import { Form } from "library-simplified-reusable-components";
 
 export interface LibraryRegistrationFormState {
   checked: boolean;
@@ -13,6 +13,7 @@ export interface LibraryRegistrationFormProps {
   checked: boolean;
   buttonText: string;
   disabled: boolean;
+  registrationData?: LibraryRegistrationData;
 }
 
 export default class LibraryRegistrationForm extends React.Component<LibraryRegistrationFormProps, LibraryRegistrationFormState> {
@@ -28,16 +29,17 @@ export default class LibraryRegistrationForm extends React.Component<LibraryRegi
   }
 
   render(): JSX.Element {
-    const termsLink = !!this.props.library.settings &&
-                      !!this.props.library.settings["terms-of-service"] &&
-                      (this.props.library.settings["terms-of-service"] as string);
-
-    let disabled = this.props.disabled || (termsLink && !this.state.checked);
+    const hasTerms = this.props.registrationData && (
+      this.props.registrationData.terms_of_service_html ||
+      this.props.registrationData.terms_of_service_link ||
+      this.props.registrationData.access_problem
+    );
+    let disabled = this.props.disabled || (hasTerms && !this.state.checked);
 
     return (
       <Form
         className="inline registration-status"
-        content={termsLink && this.checkbox(this.props.library, termsLink)}
+        content={hasTerms && this.checkbox(this.props.library)}
         disableButton={disabled}
         onSubmit={() => this.props.register(this.props.library)}
         buttonContent={this.props.buttonText}
@@ -45,10 +47,15 @@ export default class LibraryRegistrationForm extends React.Component<LibraryRegi
     );
   }
 
-  checkbox(library: LibraryData, termsLink: string): JSX.Element {
+  checkbox(library: LibraryData): JSX.Element {
+    let { access_problem, terms_of_service_html, terms_of_service_link } = this.props.registrationData;
     return (
       <section className="registration-checkbox">
-        <label>I have read and agree to the <a href={termsLink}>terms and conditions</a></label>
+        {
+          terms_of_service_html ?
+          <label dangerouslySetInnerHTML={{__html: terms_of_service_html}}></label> :
+          <label>I have read and agree to the <a href={terms_of_service_link}>terms and conditions</a>.</label>
+        }
         <EditableInput
           elementType="input"
           type="checkbox"

--- a/src/components/LibraryRegistrationForm.tsx
+++ b/src/components/LibraryRegistrationForm.tsx
@@ -43,26 +43,35 @@ export default class LibraryRegistrationForm extends React.Component<LibraryRegi
         disableButton={disabled}
         onSubmit={() => this.props.register(this.props.library)}
         buttonContent={this.props.buttonText}
+        withoutButton={this.props.registrationData && this.props.registrationData.access_problem}
       />
     );
   }
 
   checkbox(library: LibraryData): JSX.Element {
     let { access_problem, terms_of_service_html, terms_of_service_link } = this.props.registrationData;
+    let element;
+    if (access_problem) {
+      element = <p className="bg-danger">{access_problem.detail}</p>;
+    } else if (terms_of_service_html) {
+      element = <p dangerouslySetInnerHTML={{__html: terms_of_service_html}}></p>;
+    } else {
+      element = <p>You must read the <a href={terms_of_service_link}>terms of service</a> before registering your library.</p>;
+    }
     return (
-      <section className="registration-checkbox">
+      <section className="registration-checkbox" key={library.uuid}>
+        { element }
         {
-          terms_of_service_html ?
-          <label dangerouslySetInnerHTML={{__html: terms_of_service_html}}></label> :
-          <label>I have read and agree to the <a href={terms_of_service_link}>terms and conditions</a>.</label>
+          !access_problem &&
+          <EditableInput
+            elementType="input"
+            type="checkbox"
+            onChange={this.toggleChecked}
+            checked={this.state.checked}
+            label="I agree to the terms of service."
+          >
+          </EditableInput>
         }
-        <EditableInput
-          elementType="input"
-          type="checkbox"
-          onChange={this.toggleChecked}
-          checked={this.state.checked}
-        >
-        </EditableInput>
       </section>
     );
   }

--- a/src/components/__tests__/LibraryRegistrationForm-test.tsx
+++ b/src/components/__tests__/LibraryRegistrationForm-test.tsx
@@ -14,7 +14,7 @@ describe("LibraryRegistrationForm", () => {
     status: "success",
     stage: "production"
   };
-  let registrationDataWithHTML = {
+  let registrationData = {
     id: 1,
     libraries: [library],
     access_problem: null,
@@ -32,7 +32,7 @@ describe("LibraryRegistrationForm", () => {
         buttonText={"Update registration"}
         register={register}
         disabled={false}
-        registrationData={registrationDataWithHTML}
+        registrationData={registrationData}
       />
     );
   });
@@ -45,27 +45,42 @@ describe("LibraryRegistrationForm", () => {
     expect(wrapper.find(".registration-status").find("input").length).to.equal(0);
   });
 
-  it("displays a label and checkbox if there is terms-of-service HTML", () => {
+  it("displays an error message if there is a problem with the terms-of-service data", () => {
+    let dataWithProblem = {...registrationData, ...{access_problem: {detail: "Something went wrong."}}};
+    wrapper.setProps({ registrationData: dataWithProblem });
+    expect(wrapper.find(".registration-checkbox").find(".bg-danger").text()).to.equal("Something went wrong.");
+    // If the terms can't be displayed, there's no point showing the checkbox and button.
+    expect(wrapper.find(".registration-status").find("input").length).to.equal(0);
+    expect(wrapper.find(".registration-status").find("button").length).to.equal(0);
+  });
+
+  it("displays content and a checkbox with a label if there is terms-of-service HTML", () => {
     let termsSection = wrapper.find(".registration-checkbox");
     expect(termsSection.length).to.equal(1);
-    let label = termsSection.find("label");
+    let content = termsSection.find("p");
+    expect(content.length).to.equal(1);
+    expect(content.text()).to.equal("Here are the terms of service!");
+    let label = wrapper.find("label");
     expect(label.length).to.equal(1);
-    expect(label.text()).to.equal("Here are the terms of service!");
+    expect(label.text()).to.equal("I agree to the terms of service.");
     let checkbox = wrapper.find("input");
     expect(checkbox.length).to.equal(1);
     expect(checkbox.prop("type")).to.equal("checkbox");
   });
 
-  it("displays a label and checkbox if there is a terms-of-service link", () => {
-    wrapper.setProps({ registrationData: {...registrationDataWithHTML, ...{terms_of_service_html: null}} });
+  it("displays content and a checkbox with a label if there is a terms-of-service link", () => {
+    wrapper.setProps({ registrationData: {...registrationData, ...{terms_of_service_html: null}} });
     let termsSection = wrapper.find(".registration-checkbox");
     expect(termsSection.length).to.equal(1);
-    let label = termsSection.find("label");
-    expect(label.length).to.equal(1);
-    expect(label.text()).to.equal("I have read and agree to the terms and conditions.");
+    let content = termsSection.find("p");
+    expect(content.length).to.equal(1);
+    expect(content.text()).to.equal("You must read the terms of service before registering your library.");
     let link = wrapper.find("a");
     expect(link.length).to.equal(1);
     expect(link.prop("href")).to.equal("terms.html");
+    let label = wrapper.find("label");
+    expect(label.length).to.equal(1);
+    expect(label.text()).to.equal("I agree to the terms of service.");
     let checkbox = wrapper.find("input");
     expect(checkbox.length).to.equal(1);
     expect(checkbox.prop("type")).to.equal("checkbox");

--- a/src/components/__tests__/LibraryRegistrationForm-test.tsx
+++ b/src/components/__tests__/LibraryRegistrationForm-test.tsx
@@ -12,13 +12,15 @@ describe("LibraryRegistrationForm", () => {
   let library = {
     name: "Test Library",
     status: "success",
-    stage: "production",
-    settings: {
-      "terms-of-service": "terms_url"
-    }
+    stage: "production"
   };
-
-  let libraryNoLink = { ...library, ...{ settings: [] }};
+  let registrationDataWithHTML = {
+    id: 1,
+    libraries: [library],
+    access_problem: null,
+    terms_of_service_html: "Here are the <a href='terms.html'>terms of service</a>!",
+    terms_of_service_link: "terms.html"
+  };
   let register = stub();
 
   beforeEach(() => {
@@ -30,30 +32,43 @@ describe("LibraryRegistrationForm", () => {
         buttonText={"Update registration"}
         register={register}
         disabled={false}
+        registrationData={registrationDataWithHTML}
       />
     );
   });
 
-  it("displays a label and checkbox if there is a terms-of-service link", () => {
+  it("does not display a label and checkbox if there is no terms-of-service data", () => {
+    wrapper.setProps({ registrationData: null });
+    expect(wrapper.find(".registration-checkbox").length).to.equal(0);
+    expect(wrapper.find(".registration-status").find("label").length).to.equal(0);
+    expect(wrapper.find(".registration-status").find("a").length).to.equal(0);
+    expect(wrapper.find(".registration-status").find("input").length).to.equal(0);
+  });
+
+  it("displays a label and checkbox if there is terms-of-service HTML", () => {
     let termsSection = wrapper.find(".registration-checkbox");
     expect(termsSection.length).to.equal(1);
     let label = termsSection.find("label");
     expect(label.length).to.equal(1);
-    expect(label.text()).to.equal("I have read and agree to the terms and conditions");
-    let link = label.find("a");
-    expect(link.length).to.equal(1);
-    expect(link.prop("href")).to.equal("terms_url");
+    expect(label.text()).to.equal("Here are the terms of service!");
     let checkbox = wrapper.find("input");
     expect(checkbox.length).to.equal(1);
     expect(checkbox.prop("type")).to.equal("checkbox");
   });
 
-  it("does not display a label and checkbox if there is no terms-of-service link", () => {
-    wrapper.setProps({ library: libraryNoLink });
-    expect(wrapper.find(".registration-checkbox").length).to.equal(0);
-    expect(wrapper.find(".registration-status").find("label").length).to.equal(0);
-    expect(wrapper.find(".registration-status").find("a").length).to.equal(0);
-    expect(wrapper.find(".registration-status").find("input").length).to.equal(0);
+  it("displays a label and checkbox if there is a terms-of-service link", () => {
+    wrapper.setProps({ registrationData: {...registrationDataWithHTML, ...{terms_of_service_html: null}} });
+    let termsSection = wrapper.find(".registration-checkbox");
+    expect(termsSection.length).to.equal(1);
+    let label = termsSection.find("label");
+    expect(label.length).to.equal(1);
+    expect(label.text()).to.equal("I have read and agree to the terms and conditions.");
+    let link = wrapper.find("a");
+    expect(link.length).to.equal(1);
+    expect(link.prop("href")).to.equal("terms.html");
+    let checkbox = wrapper.find("input");
+    expect(checkbox.length).to.equal(1);
+    expect(checkbox.prop("type")).to.equal("checkbox");
   });
 
   it("displays a registration button", () => {
@@ -72,7 +87,7 @@ describe("LibraryRegistrationForm", () => {
   it("disables the button if there is a checkbox and it is unchecked", () => {
     expect(wrapper.state()["checked"]).to.be.true;
     let button = wrapper.find(Button);
-    expect(button.prop("disabled")).to.be.false;
+    expect(button.prop("disabled")).not.to.be.true;
 
     wrapper.setState({ checked: false });
     button = wrapper.find(Button);
@@ -85,13 +100,9 @@ describe("LibraryRegistrationForm", () => {
     let button = wrapper.find(Button);
     expect(button.prop("disabled")).to.be.true;
 
-    wrapper.setProps({ library: libraryNoLink });
-    button = wrapper.find(Button);
-    expect(button.prop("disabled")).to.be.true;
-
     wrapper.setProps({ disabled: false });
     button = wrapper.find(Button);
-    expect(button.prop("disabled")).to.be.false;
+    expect(button.prop("disabled")).not.to.be.true;
   });
 
 
@@ -101,7 +112,7 @@ describe("LibraryRegistrationForm", () => {
 
     wrapper.setProps({ checked: false });
     checkbox = wrapper.find("input");
-    expect(checkbox.prop("checked")).to.be.false;
+    expect(checkbox.prop("checked")).not.to.be.true;
   });
 
   it("calls register", () => {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -387,9 +387,16 @@ export interface LibraryDataWithStatus extends LibraryData {
 export interface LibraryRegistrationData {
   id: string | number;
   libraries: LibraryDataWithStatus[];
-  access_problem?: any;
+  access_problem?: ProblemDetail;
   terms_of_service_html?: string;
   terms_of_service_link?: string;
+}
+
+export interface ProblemDetail {
+  status: number;
+  title: string;
+  type: string;
+  detail: string;
 }
 
 export interface LibraryRegistrationsData {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -387,6 +387,9 @@ export interface LibraryDataWithStatus extends LibraryData {
 export interface LibraryRegistrationData {
   id: string | number;
   libraries: LibraryDataWithStatus[];
+  access_problem?: any;
+  terms_of_service_html?: string;
+  terms_of_service_link?: string;
 }
 
 export interface LibraryRegistrationsData {

--- a/src/stylesheets/library_registration.scss
+++ b/src/stylesheets/library_registration.scss
@@ -40,19 +40,35 @@
         background: $medium-gray;
         padding: 10px;
         margin: 15px 5px 0px 5px;
-        label {
-          margin: 0 0 4px 0;
+        width: 100%;
+        p {
+          margin: 0 0 8px 0;
           width: 100%;
+          &.bg-danger {
+            margin: 0;
+            padding: 4px;
+            color: $red-dark;
+            border: 1px solid $red-dark;
+          }
         }
-        input {
+        label {
+          width: 100%;
+          background: white;
+          padding: 4px;
+          border: 1px solid $medium-gray;
           margin: 0;
+          input {
+            margin: 0;
+            width: 10%;
+            &:focus {
+              box-shadow: none;
+            }
+          }
         }
       }
     }
     button {
-      margin-left: 5px;
-      margin-right: 10px;
-      margin-top: 15px;
+      margin: 15px 10px 10px 5px;
     }
   }
 

--- a/src/stylesheets/library_registration.scss
+++ b/src/stylesheets/library_registration.scss
@@ -35,13 +35,14 @@
     .registration-status {
       .registration-checkbox {
         display: flex;
+        flex-direction: column;
         justify-content: space-between;
-        align-items: center;
         background: $medium-gray;
         padding: 10px;
         margin: 15px 5px 0px 5px;
         label {
-          margin: 0;
+          margin: 0 0 4px 0;
+          width: 100%;
         }
         input {
           margin: 0;


### PR DESCRIPTION
Resolves https://jira.nypl.org/browse/SIMPLY-2283

<img width="662" alt="Screen Shot 2019-09-11 at 4 11 15 PM" src="https://user-images.githubusercontent.com/42178216/64731395-1fd61580-d4af-11e9-9b6b-46c2093a7895.png">

Do we already know for sure what format the `access_problem` would be in, whether the format would always be the same, whether the problem would always be effectively the same (i.e. do we need the actual content of the `access_problem`, or is it safe to say that, if there is a problem, we should always display something to the effect of "there are terms but we're having trouble showing them"), etc.?  I've held off on implementing the error behavior for now.