### PR TITLE
Update circulation events report UI by library

### DIFF
--- a/src/components/CirculationEvents.tsx
+++ b/src/components/CirculationEvents.tsx
@@ -25,6 +25,7 @@ export interface CirculationEventsDispatchProps {
 export interface CirculationEventsOwnProps {
   store?: Store<State>;
   wait?: number;
+  library?: string;
 }
 
 export interface CirculationEventsProps extends CirculationEventsStateProps, CirculationEventsDispatchProps, CirculationEventsOwnProps {}
@@ -65,6 +66,7 @@ export class CirculationEvents extends React.Component<CirculationEventsProps, C
         <CirculationEventsDownloadForm
           show={this.state.showDownloadForm}
           hide={this.hideDownloadForm}
+          library={this.props.library}
         />
 
         { this.props.fetchError &&

--- a/src/components/CirculationEvents.tsx
+++ b/src/components/CirculationEvents.tsx
@@ -55,7 +55,8 @@ export class CirculationEvents extends React.Component<CirculationEventsProps, C
   };
 
   render(): JSX.Element {
-    return(
+    const { library, fetchError, isLoaded, events } = this.props;
+    return (
       <div className="circulation-events">
         <h3>Circulation Events</h3>
 
@@ -66,50 +67,58 @@ export class CirculationEvents extends React.Component<CirculationEventsProps, C
         <CirculationEventsDownloadForm
           show={this.state.showDownloadForm}
           hide={this.hideDownloadForm}
-          library={this.props.library}
+          library={library}
         />
 
-        { this.props.fetchError &&
-          <ErrorMessage error={this.props.fetchError} />
+        { fetchError &&
+          <ErrorMessage error={fetchError} />
         }
 
-        { !this.props.isLoaded &&
+        { (!isLoaded && !library) &&
           <LoadingIndicator />
         }
 
-        <table className="table table-striped">
-          <thead>
-            <tr>
-              <th>Book</th>
-              <th>Event</th>
-              <th>Time</th>
-            </tr>
-          </thead>
-          <tbody>
-            { this.props.events.map(event =>
-              <tr key={event.id}>
-                <td>
-                  <CatalogLink bookUrl={event.book.url}>
-                    {event.book.title}
-                  </CatalogLink>
-                </td>
-                <td>{this.formatType(event.type)}</td>
-                <td>{this.formatTime(event.time)}</td>
-              </tr>
-            ) }
-          </tbody>
-        </table>
+        {
+          !library && (
+              <table className="table table-striped">
+                <thead>
+                  <tr>
+                    <th>Book</th>
+                    <th>Event</th>
+                    <th>Time</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  { events.map(event =>
+                    <tr key={event.id}>
+                      <td>
+                        <CatalogLink bookUrl={event.book.url}>
+                          {event.book.title}
+                        </CatalogLink>
+                      </td>
+                      <td>{this.formatType(event.type)}</td>
+                      <td>{this.formatTime(event.time)}</td>
+                    </tr>
+                  ) }
+                </tbody>
+              </table>
+            )
+        }
       </div>
     );
   }
 
   componentWillMount() {
     this._isMounted = true;
-    this.fetchAndQueue();
+    if (!this.props.library) {
+      this.fetchAndQueue();
+    }
   }
 
   componentWillUnmount() {
-    clearTimeout(this.timer);
+    if (!this.props.library) {
+      clearTimeout(this.timer);
+    }
     this._isMounted = false;
   }
 

--- a/src/components/CirculationEventsDownloadForm.tsx
+++ b/src/components/CirculationEventsDownloadForm.tsx
@@ -7,6 +7,7 @@ import * as qs from "qs";
 export interface CirculationEventsDownloadFormProps extends React.Props<CirculationEventsDownloadForm> {
   show: boolean;
   hide: () => void;
+  library?: string;
 }
 
 export interface CirculationEventsDownloadFormState {
@@ -164,7 +165,8 @@ export default class CirculationEventsDownloadForm extends React.Component<Circu
     const date = this.getRefValue(this.dateStart);
     const dateEnd = this.getRefValue(this.dateEnd);
     const locations = this.getRefValue(this.locations);
-    const paramValues = { date, dateEnd, locations };
+    const library = this.props.library;
+    const paramValues = { date, dateEnd, locations, library };
 
     let url = "/admin/bulk_circulation_events";
     let params = qs.stringify(paramValues, { skipNulls: true });

--- a/src/components/CirculationEventsDownloadForm.tsx
+++ b/src/components/CirculationEventsDownloadForm.tsx
@@ -165,10 +165,14 @@ export default class CirculationEventsDownloadForm extends React.Component<Circu
     const date = this.getRefValue(this.dateStart);
     const dateEnd = this.getRefValue(this.dateEnd);
     const locations = this.getRefValue(this.locations);
-    const library = this.props.library;
-    const paramValues = { date, dateEnd, locations, library };
+    const paramValues = { date, dateEnd, locations };
+    let library = "";
 
-    let url = "/admin/bulk_circulation_events";
+    if (this.props.library) {
+      library = "/" + this.props.library;
+    }
+
+    let url = library + "/admin/bulk_circulation_events";
     let params = qs.stringify(paramValues, { skipNulls: true });
 
     if (params) {

--- a/src/components/DashboardPage.tsx
+++ b/src/components/DashboardPage.tsx
@@ -36,14 +36,13 @@ export default class DashboardPage extends React.Component<DashboardPageProps, {
   }
 
   render(): JSX.Element {
+    const { library } = this.props.params;
     return (
       <div className="dashboard">
         <Header />
         <div className="body">
-          <Stats store={this.context.editorStore} library={this.props.params.library}/>
-          { !this.props.params.library &&
-            <CirculationEvents store={this.context.editorStore} />
-          }
+          <Stats store={this.context.editorStore} library={library} />
+          <CirculationEvents store={this.context.editorStore} library={library} />
         </div>
       </div>
     );

--- a/src/components/__tests__/CirculationEvents-test.tsx
+++ b/src/components/__tests__/CirculationEvents-test.tsx
@@ -12,7 +12,7 @@ import CatalogLink from "opds-web-client/lib/components/CatalogLink";
 import { Button } from "library-simplified-reusable-components";
 import { CirculationEventData } from "../../interfaces";
 
-describe.only("CirculationEvents", () => {
+describe("CirculationEvents", () => {
   let eventsData: CirculationEventData[] = [
     {
       id: 1,

--- a/src/components/__tests__/DashboardPage-test.tsx
+++ b/src/components/__tests__/DashboardPage-test.tsx
@@ -25,14 +25,16 @@ describe("DashboardPage", () => {
     expect(header.length).to.equal(1);
   });
 
-  it("shows CirculationEvents when there is no library", () => {
+  it("shows CirculationEvents ", () => {
     let events = wrapper.find(CirculationEvents);
     expect(events.length).to.equal(1);
     expect(events.prop("store")).to.equal(store);
+    expect(events.prop("library")).to.equal(undefined);
 
     wrapper.setProps({ params: { library: "NYPL" } });
     events = wrapper.find(CirculationEvents);
-    expect(events.length).to.equal(0);
+    expect(events.length).to.equal(1);
+    expect(events.prop("library")).to.equal("NYPL");
   });
 
   it("shows Stats", () => {

--- a/src/stylesheets/circulation_events_download_form.scss
+++ b/src/stylesheets/circulation_events_download_form.scss
@@ -1,3 +1,7 @@
+.circulation-events {
+  min-height: 150px;
+}
+
 .circ-events-download-form {
 
   form {


### PR DESCRIPTION
This is the second part for #266 and goes along with [circulation #1316](https://github.com/NYPL-Simplified/circulation/pull/1316). Resolves [SIMPLY-2274](https://jira.nypl.org/browse/SIMPLY-2274).

For this PR, if a library short name is passed to the `CirculationEvents` component, then it will use that in its request URL. This means that `CirculationEvents` will always render in the `Dashboard` component regardless if it is in the context of a library or not.

If it is not in the context of a library, then it will query for events for all libraries.
If it is in the context of a library's dashboard, then it will query for events associated with that library.

This is okay but I think `CirculationEvents` could be refactored. The real-time stream of events may not be needed per library and was not part of the ticket so I removed it only when in the context of a library (along with the function call to the server).