### PR TITLE
Router fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v0.3.17
+#### Fixed
+- Fixed a bug where the catalog navigation links were not styled as "active" when they were on the correct page.
+
 ### v0.3.16
 #### Updated
 - Added a date end, event type, and locations input fields to the report form for circulation events in the Dashboard.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.3.16",
+  "version": "0.3.17",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6747,9 +6747,9 @@
       }
     },
     "opds-web-client": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/opds-web-client/-/opds-web-client-0.2.6.tgz",
-      "integrity": "sha512-3RhgvP+uG8M4jbc1sZUE9ANewwc+r7VBkUlMEP5xc+CeuYzhipHz53SvxJuxX4Zs7OJ94LsZWCEw3I57HGBJpA==",
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/opds-web-client/-/opds-web-client-0.2.8.tgz",
+      "integrity": "sha512-QpqnkqygoXd3RYyeN0NBlYHmYFoiwGIjYHKOUmJWM1GfblALlOmal7eA11Tt1v6AWZC4TbntSCYf4/VZO5M4eA==",
       "requires": {
         "@nypl/dgx-svg-icons": "0.3.4",
         "dompurify": "0.8.9",
@@ -6764,7 +6764,7 @@
         "react": "16.8.6",
         "react-dom": "16.8.6",
         "react-redux": "7.1.0",
-        "react-router": "3.2.3",
+        "react-router": "3.2.0",
         "redux": "4.0.1",
         "redux-localstorage": "0.4.1",
         "redux-thunk": "2.3.0",
@@ -7698,24 +7698,23 @@
       }
     },
     "react-router": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-3.2.3.tgz",
-      "integrity": "sha512-dOBEo8985n6xyJmorgHtLxb/k30ua/JdfUhATGTTVQJsnlb/u/rx7X7p//qHyLWEfUcM0CLMTXWS+hp+THCsxA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-3.2.0.tgz",
+      "integrity": "sha512-sXlLOg0TRCqnjCVskqBHGjzNjcJKUqXEKnDSuxMYJSPJNq9hROE9VsiIW2kfIq7Ev+20Iz0nxayekXyv0XNmsg==",
       "requires": {
         "create-react-class": "15.6.3",
         "history": "3.3.0",
-        "hoist-non-react-statics": "2.5.5",
+        "hoist-non-react-statics": "1.2.0",
         "invariant": "2.2.4",
         "loose-envify": "1.4.0",
         "prop-types": "15.7.2",
-        "react-is": "16.8.6",
         "warning": "3.0.0"
       },
       "dependencies": {
         "hoist-non-react-statics": {
-          "version": "2.5.5",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-          "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz",
+          "integrity": "sha1-qkSM8JhtVcxAdzsXF0t90GbLfPs="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.3.16",
+  "version": "0.3.17",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "library-simplified-reusable-components": "1.3.16",
     "numeral": "^2.0.6",
     "opds-feed-parser": "0.0.17",
-    "opds-web-client": "0.2.6",
+    "opds-web-client": "0.2.8",
     "prop-types": "^15.7.2",
     "qs": "^6.2.0",
     "react": "^16.8.6",

--- a/src/components/CatalogPage.tsx
+++ b/src/components/CatalogPage.tsx
@@ -55,6 +55,8 @@ export default class CatalogPage extends React.Component<CatalogPageProps, {}> {
       return "Circulation Manager" + (details ? " - " + details : "");
     };
 
+    console.log(collectionUrl);
+
     return (
       <OPDSCatalog
         collectionUrl={collectionUrl}

--- a/src/components/CatalogPage.tsx
+++ b/src/components/CatalogPage.tsx
@@ -55,8 +55,6 @@ export default class CatalogPage extends React.Component<CatalogPageProps, {}> {
       return "Circulation Manager" + (details ? " - " + details : "");
     };
 
-    console.log(collectionUrl);
-
     return (
       <OPDSCatalog
         collectionUrl={collectionUrl}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -75,17 +75,20 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
     let currentLibrary = this.context.library && this.context.library();
     let isLibraryManager = this.context.admin.isLibraryManager(currentLibrary);
     let isSystemAdmin = this.context.admin.isSystemAdmin();
+    // Links that will be rendered in a NavItem Bootstrap component.
     const libraryNavItems = [
       { label: "Catalog", href: "%2Fgroups" },
       { label: "Complaints", href: "%2Fadmin%2Fcomplaints" },
       { label: "Hidden Books", href: "%2Fadmin%2Fsuppressed" },
     ];
+    // Links that will be rendered in a Link router component and are library specific.
     const libraryLinkItems = [
       { label: "Lists", href: "/admin/web/lists/" },
       { label: "Lanes", href: "/admin/web/lanes/", auth: isLibraryManager },
       { label: "Dashboard", href: "/admin/web/dashboard/"  },
       { label: "Patrons", href: "/admin/web/patrons/", auth: isLibraryManager },
     ];
+    // Links that will be rendered in a Link router component and are sitewide.
     const sitewideLinkItems = [
       { label: "Dashboard", href: "/admin/web/dashboard/",
         auth: (!this.context.library || !currentLibrary) },
@@ -185,7 +188,14 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
     this.setState({ showAccountDropdown });
   }
 
-  renderNavItem(item: HeaderNavItem, currentPathname: string, currentLibrary: string) {
+  /**
+   * renderNavItem
+   * Renders a NavItem Bootstrap component and is active based on the page's current path.
+   * @param {HeaderNavItem} item Object with the label and href for the navigation item.
+   * @param {string} currentPathname Page's current URL.
+   * @param {string} currentLibrary Active library.
+   */
+  renderNavItem(item: HeaderNavItem, currentPathname: string, currentLibrary: string = "") {
     const rootCatalogURL = "/admin/web/collection/";
     const href = item.href;
     const isActive = currentPathname.indexOf(href) !== -1;
@@ -202,6 +212,14 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
     );
   }
 
+  /**
+   * renderLinkItem
+   * Renders a Link Router component for library and sitewide navigation links
+   * and if the current admin has the correct authentication.
+   * @param {HeaderNavItem} item Object with the label and href for the navigation item.
+   * @param {string} currentPathname Page's current URL.
+   * @param {string} currentLibrary Active library.
+   */
   renderLinkItem(item: HeaderNavItem, currentPathname: string, currentLibrary: string = "") {
     const href = item.href;
     let isActive = currentPathname.indexOf(href) !== -1;
@@ -219,6 +237,8 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
       </li>
     );
 
+    // Sometimes, some links should only be shown to admins who have
+    // specific privileges. If there is no restriction, always render the link.
     if (item.auth !== undefined) {
       if (item.auth) {
         return liElem;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -38,7 +38,6 @@ export interface HeaderRouter extends Router {
 export interface HeaderNavItem {
   label: string;
   href: string;
-  catalog?: boolean;
   auth?: boolean;
 }
 
@@ -197,7 +196,7 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
    */
   renderNavItem(item: HeaderNavItem, currentPathname: string, currentLibrary: string = "") {
     const rootCatalogURL = "/admin/web/collection/";
-    const href = item.href;
+    const { label, href } = item;
     const isActive = currentPathname.indexOf(href) !== -1;
 
     return (
@@ -207,7 +206,7 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
         href={`${rootCatalogURL}${currentLibrary}${href}`}
         active={isActive}
       >
-        {item.label}
+        {label}
       </NavItem>
     );
   }
@@ -221,7 +220,7 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
    * @param {string} currentLibrary Active library.
    */
   renderLinkItem(item: HeaderNavItem, currentPathname: string, currentLibrary: string = "") {
-    const href = item.href;
+    const { label, href, auth } = item;
     let isActive = currentPathname.indexOf(href) !== -1;
     if (currentLibrary) {
       isActive = !!(isActive && currentLibrary);
@@ -232,15 +231,15 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
           to={`${href}${currentLibrary}`}
           className={isActive ? "active-link" : ""}
         >
-          {item.label}
+          {label}
         </Link>
       </li>
     );
 
     // Sometimes, some links should only be shown to admins who have
     // specific privileges. If there is no restriction, always render the link.
-    if (item.auth !== undefined) {
-      if (item.auth) {
+    if (auth !== undefined) {
+      if (auth) {
         return liElem;
       } else {
         return;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -34,6 +34,7 @@ export interface HeaderState {
 
 export interface HeaderRouter extends Router {
   getCurrentLocation?: Function;
+  location?: any;
 }
 
 /** Header of all admin interface pages, with a dropdown for selecting a library,
@@ -62,9 +63,10 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
   }
 
   render(): JSX.Element {
-    const currentPathname = (this.context.router &&
+    const currentPathname = decodeURIComponent(this.context.router &&
       this.context.router.getCurrentLocation() &&
       this.context.router.getCurrentLocation().pathname) || "";
+    console.log(this.context);
     let currentLibrary = this.context.library && this.context.library();
     let isLibraryManager = this.context.admin.isLibraryManager(currentLibrary);
     let isSystemAdmin = this.context.admin.isSystemAdmin();
@@ -106,7 +108,7 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
                 <CatalogLink
                   collectionUrl={"/" + currentLibrary + "/groups"}
                   bookUrl={null}
-                  className={currentPathname.indexOf("/admin/web/collection") !== -1 ? "active-link" : ""}
+                  className={currentPathname.indexOf("/groups") !== -1 ? "active-link" : ""}
                 >
                   Catalog
                 </CatalogLink>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -74,6 +74,9 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
     let currentLibrary = this.context.library && this.context.library();
     let isLibraryManager = this.context.admin.isLibraryManager(currentLibrary);
     let isSystemAdmin = this.context.admin.isSystemAdmin();
+    let isSiteWide = (!this.context.library || !currentLibrary);
+    let isSomeLibraryManager = this.context.admin.isLibraryManagerOfSomeLibrary();
+
     // Links that will be rendered in a NavItem Bootstrap component.
     const libraryNavItems = [
       { label: "Catalog", href: "%2Fgroups" },
@@ -89,12 +92,9 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
     ];
     // Links that will be rendered in a Link router component and are sitewide.
     const sitewideLinkItems = [
-      { label: "Dashboard", href: "dashboard/",
-        auth: (!this.context.library || !currentLibrary) },
-      { label: "System Configuration", href: "config/",
-        auth: this.context.admin.isLibraryManagerOfSomeLibrary() },
-      { label: "Troubleshooting", href: "troubleshooting/",
-        auth: isSystemAdmin },
+      { label: "Dashboard", href: "dashboard/", auth: isSiteWide },
+      { label: "System Configuration", href: "config/", auth: isSomeLibraryManager },
+      { label: "Troubleshooting", href: "troubleshooting/", auth: isSystemAdmin },
     ];
     const accountLink = { label: "Change password", href: "account/" };
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -82,21 +82,21 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
     ];
     // Links that will be rendered in a Link router component and are library specific.
     const libraryLinkItems = [
-      { label: "Lists", href: "/admin/web/lists/" },
-      { label: "Lanes", href: "/admin/web/lanes/", auth: isLibraryManager },
-      { label: "Dashboard", href: "/admin/web/dashboard/"  },
-      { label: "Patrons", href: "/admin/web/patrons/", auth: isLibraryManager },
+      { label: "Lists", href: "lists/" },
+      { label: "Lanes", href: "lanes/", auth: isLibraryManager },
+      { label: "Dashboard", href: "dashboard/"  },
+      { label: "Patrons", href: "patrons/", auth: isLibraryManager },
     ];
     // Links that will be rendered in a Link router component and are sitewide.
     const sitewideLinkItems = [
-      { label: "Dashboard", href: "/admin/web/dashboard/",
+      { label: "Dashboard", href: "dashboard/",
         auth: (!this.context.library || !currentLibrary) },
-      { label: "System Configuration", href: "/admin/web/config/",
+      { label: "System Configuration", href: "config/",
         auth: this.context.admin.isLibraryManagerOfSomeLibrary() },
-      { label: "Troubleshooting", href: "/admin/web/troubleshooting/",
+      { label: "Troubleshooting", href: "troubleshooting/",
         auth: isSystemAdmin },
     ];
-    const accountLink = { label: "Change password", href: "/admin/web/account/" };
+    const accountLink = { label: "Change password", href: "account/" };
 
     return (
       <Navbar fluid={true}>
@@ -220,6 +220,7 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
    * @param {string} currentLibrary Active library.
    */
   renderLinkItem(item: HeaderNavItem, currentPathname: string, currentLibrary: string = "") {
+    const rootUrl = "/admin/web/";
     const { label, href, auth } = item;
     let isActive = currentPathname.indexOf(href) !== -1;
     if (currentLibrary) {
@@ -228,7 +229,7 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
     const liElem = (
       <li className="header-link" key={href}>
         <Link
-          to={`${href}${currentLibrary}`}
+          to={`${rootUrl}${href}${currentLibrary}`}
           className={isActive ? "active-link" : ""}
         >
           {label}

--- a/src/components/__tests__/Header-test.tsx
+++ b/src/components/__tests__/Header-test.tsx
@@ -6,13 +6,13 @@ import { shallow, mount } from "enzyme";
 
 import { Header } from "../Header";
 import EditableInput from "../EditableInput";
-import CatalogLink from "opds-web-client/lib/components/CatalogLink";
+import { NavItem } from "react-bootstrap";
 import { Link } from "react-router";
 import Admin from "../../models/Admin";
 
 describe("Header", () => {
   let wrapper;
-  let push, context;
+  let context;
 
   const libraryManager = new Admin([{ "role": "manager", "library": "nypl" }]);
   const librarian = new Admin([{ "role": "librarian", "library": "nypl" }]);
@@ -35,7 +35,6 @@ describe("Header", () => {
   };
 
   beforeEach(() => {
-    push = stub();
     context = { library: () => "nypl", admin: libraryManager, router };
 
     wrapper = shallow(
@@ -85,28 +84,25 @@ describe("Header", () => {
     });
 
     it("shows catalog links when there's a library", () => {
-      let catalogLinks = wrapper.find(CatalogLink);
+      let navItems = wrapper.find(NavItem);
 
-      expect(catalogLinks.length).to.equal(3);
+      expect(navItems.length).to.equal(3);
 
-      let mainCatalogLink = catalogLinks.at(0);
-      expect(mainCatalogLink.prop("collectionUrl")).to.equal("/nypl/groups");
-      expect(mainCatalogLink.prop("bookUrl")).to.equal(null);
-      expect(mainCatalogLink.children().text()).to.equal("Catalog");
+      let mainNavItem = navItems.at(0);
+      expect(mainNavItem.prop("href")).to.contain("/nypl%2Fgroups");
+      expect(mainNavItem.children().text()).to.equal("Catalog");
 
-      let complaintsLink = catalogLinks.at(1);
-      expect(complaintsLink.prop("collectionUrl")).to.equal("/nypl/admin/complaints");
-      expect(complaintsLink.prop("bookUrl")).to.equal(null);
+      let complaintsLink = navItems.at(1);
+      expect(complaintsLink.prop("href")).to.contain("/nypl%2Fadmin%2Fcomplaints");
       expect(complaintsLink.children().text()).to.equal("Complaints");
 
-      let hiddenLink = catalogLinks.at(2);
-      expect(hiddenLink.prop("collectionUrl")).to.equal("/nypl/admin/suppressed");
-      expect(hiddenLink.prop("bookUrl")).to.equal(null);
+      let hiddenLink = navItems.at(2);
+      expect(hiddenLink.prop("href")).to.contain("/nypl%2Fadmin%2Fsuppressed");
       expect(hiddenLink.children().text()).to.equal("Hidden Books");
 
       wrapper.setContext({ admin: libraryManager });
-      catalogLinks = wrapper.find(CatalogLink);
-      expect(catalogLinks.length).to.equal(0);
+      navItems = wrapper.find(NavItem);
+      expect(navItems.length).to.equal(0);
     });
 
     it("shows sitewide links, non-catalog library links, and patron manager link for library manager", () => {
@@ -130,7 +126,7 @@ describe("Header", () => {
       expect(patronManagerLink.children().text()).to.equal("Patrons");
 
       let settingsLink = links.at(4);
-      expect(settingsLink.prop("to")).to.equal("/admin/web/config");
+      expect(settingsLink.prop("to")).to.equal("/admin/web/config/");
       expect(settingsLink.children().text()).to.equal("System Configuration");
 
 
@@ -138,10 +134,10 @@ describe("Header", () => {
       wrapper.setContext({ admin: libraryManager });
       links = wrapper.find(Link);
       dashboardLink = links.at(0);
-      expect(dashboardLink.prop("to")).to.equal("/admin/web/dashboard");
+      expect(dashboardLink.prop("to")).to.equal("/admin/web/dashboard/");
 
       settingsLink = links.at(1);
-      expect(settingsLink.prop("to")).to.equal("/admin/web/config");
+      expect(settingsLink.prop("to")).to.equal("/admin/web/config/");
     });
 
     it("shows sitewide and non-catalog library links for librarian", () => {
@@ -275,7 +271,7 @@ describe("Header", () => {
       dropdownLinks = wrapper.find("ul.dropdown-menu li");
       expect(dropdownLinks.length).to.equal(2);
       let changePassword = dropdownLinks.find(Link);
-      expect(changePassword.prop("to")).to.equal("/admin/web/account");
+      expect(changePassword.prop("to")).to.equal("/admin/web/account/");
       // The first anchor element is from the Link component.
       let signOut = dropdownLinks.find("a").at(1);
       expect(signOut.prop("href")).to.equal("/admin/sign_out");

--- a/src/stylesheets/header.scss
+++ b/src/stylesheets/header.scss
@@ -61,10 +61,7 @@
         }
 
         &:hover, &:active, &:focus {
-          color: $dark-gray;
-          background-color: $light-gray;
-          border-radius: 2px;
-          transition: background-color 0.3s ease-in;
+          @include headerNavLink;
         }
       }
     }
@@ -102,11 +99,11 @@
         &.active-link,
         &:hover,
         &:focus {
-          color: $dark-gray;
-          background-color: $light-gray;
-          border-radius: 2px;
-          transition: background-color 0.3s ease-in;
+          @include headerNavLink;
         }
+      }
+      &.active a {
+        @include headerNavLink;
       }
     }
   }

--- a/src/stylesheets/mixins.scss
+++ b/src/stylesheets/mixins.scss
@@ -9,3 +9,10 @@ $white: #FFF !default;
 @function tint($color, $percentage) {
   @return mix($white, $color, $percentage);
 }
+
+@mixin headerNavLink {
+  color: $dark-gray;
+  background-color: $light-gray;
+  border-radius: 2px;
+  transition: background-color 0.3s ease-in;
+}

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -52,6 +52,9 @@ module.exports = {
     ]
   },
   resolve: {
-    extensions: [".ts", ".tsx", ".js", ".scss"]
+    extensions: [".ts", ".tsx", ".js", ".scss"],
+    alias: {
+      react: path.resolve('./node_modules/react')
+    },
   }
 };


### PR DESCRIPTION
Resolves [SIMPLY-2281](https://jira.nypl.org/browse/SIMPLY-2281).

I'm slightly concerned that it may be over-engineered but there was no straight forward way to refactor the list of links. I'm not sure what, how, or when but the three catalog links - "Catalog", "Complaints", "Hidden Books" - stopped correctly displaying as active when you were on that page. These links are part of an app inside the main app so maybe there's something involved there... but  I couldn't figure out why the Header which was inside the `opds-web-client` would not re-render when it received a new router context. So if you were on "Hidden Books" that link would initially be correctly active, but if you then went to "Complaints" it would not be active and "Hidden Books" would remain active. I updated them to be Bootstrap's `NavItem` components. This causes a page refresh which is unfortunate but correctly shows which page you are on.

Why not make them `Link` components like the rest of the navigation items? Doing so leads to the same issue. It does work better since it stays "within" the app and the loading time is faster, but the internal router doesn't update and so the Header doesn't actually know that it has been updated, and the links don't show up as active.