### PR TITLE
Fixing Firefox bug where circulation events excel file doesn't download.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v0.3.20
+#### Fixed
+- Fixed a bug where Firefox doesn't programmatically click on an anchor element created to download circulation events.
+
 ### v0.3.19
 #### Fixed
 - Fixed a bug where the catalog navigation links were not styled as "active" when they were on the correct page.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.3.19",
+  "version": "0.3.20",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/components/CirculationEventsDownloadForm.tsx
+++ b/src/components/CirculationEventsDownloadForm.tsx
@@ -119,7 +119,7 @@ export default class CirculationEventsDownloadForm extends React.Component<Circu
                 ref={this.locations}
                 className=""
                 label="Locations"
-                description="Comma-separated list of zip codes to gather events from."
+                description="Comma-separated list of locations (e.g. ZIP codes or library branch codes) to focus on."
                 name="locations"
                 id="locations"
                 optionalText={false}
@@ -183,6 +183,8 @@ export default class CirculationEventsDownloadForm extends React.Component<Circu
     let link = document.createElement("a");
     link.href = url;
     link.target = "_blank";
+    document.body.appendChild(link);
     link.click();
+    link.remove();
   }
 }


### PR DESCRIPTION
Resolves [SIMPLY-2307](https://jira.nypl.org/browse/SIMPLY-2307).

Minor description update for the location input text field.
Fixing a Firefox bug where it doesn't understand a virtually created anchor element and a click event unless it is part of the DOM.