### PR TITLE
Allowing multiple storage services and display each storage's name in…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v0.3.21
+#### Updated
+- Updated the StorageServices component to allow multiple storage services and also displaying each storage's name in the list of services.
+
 ### v0.3.20
 #### Fixed
 - Fixed a bug where Firefox doesn't programmatically click on an anchor element created to download circulation events.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.3.19",
+  "version": "0.3.21",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.3.20",
+  "version": "0.3.21",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/components/StorageServices.tsx
+++ b/src/components/StorageServices.tsx
@@ -12,7 +12,15 @@ export class StorageServices extends EditableConfigList<StorageServicesData, Sto
   urlBase = "/admin/web/config/storage/";
   identifierKey = "id";
   labelKey = "protocol";
-  limitOne = true;
+
+  label(item): string {
+    for (const protocol of this.props.data.protocols) {
+      if (protocol.name === item.protocol) {
+        return `${item.name}: ${protocol.label}`;
+      }
+    }
+    return item.protocol;
+  }
 }
 
 function mapStateToProps(state, ownProps) {


### PR DESCRIPTION
… the service list.

Resolves [SIMPLY-2297](https://jira.nypl.org/browse/SIMPLY-2297).

Part of the [circulation 1333 PR](https://github.com/NYPL-Simplified/circulation/pull/1333) (@leonardr ).

Following the same pattern as the "External Catalogs" page:
![Screen Shot 2019-10-10 at 4 20 45 PM](https://user-images.githubusercontent.com/1280564/66603455-40f75800-eb7a-11e9-9a51-d5632704c164.png)
