### PR TITLE
Lists tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 ## Changelog
 
-### v0.3.21
+### v0.3.22
 #### Updated
 - Streamlined the book editor Lists tab by implementing a dropdown menu option on the InputList component.
+
+### v0.3.21
+#### Updated
+- Updated the StorageServices component to allow multiple storage services and also displaying each storage's name in the list of services.
+#### Fixed
+- Fixed an alignment issue in the WithRemoveButton component.
 
 ### v0.3.20
 #### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v0.3.21
+#### Updated
+- Streamlined the book editor Lists tab by implementing a dropdown menu option on the InputList component.
+
 ### v0.3.20
 #### Fixed
 - Fixed a bug where Firefox doesn't programmatically click on an anchor element created to download circulation events.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.3.20",
+  "version": "0.3.21",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.3.21",
+  "version": "0.3.22",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/__tests__/sharedFunctions-test.ts
+++ b/src/__tests__/sharedFunctions-test.ts
@@ -111,5 +111,8 @@ describe("isEqual", () => {
     let arr2 = ["b", "c", "a"];
     expect(isEqual(arr1, arr2)).to.be.true;
   });
+  it("returns true if the arrays have the same duplicates", () => {
+    expect(isEqual(["a", "a", "b"], ["b", "a", "a"])).to.be.true;
+  });
 
 });

--- a/src/__tests__/sharedFunctions-test.ts
+++ b/src/__tests__/sharedFunctions-test.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { findDefault, clearForm, formatString } from "../utils/sharedFunctions";
+import { findDefault, clearForm, formatString, isEqual } from "../utils/sharedFunctions";
 
 
 describe("findDefault", () => {
@@ -86,4 +86,30 @@ describe("formatString", () => {
     let result = formatString(stringToFormat, ["-"]);
     expect(result).to.equal("This is a sentence.");
   });
+});
+
+describe("isEqual", () => {
+  const arr1 = ["a", "b", "c"];
+
+  it("returns false if the arrays are not the same length", () => {
+    let arr2 = ["a", "b", "c", "d"];
+    expect(isEqual(arr1, arr2)).to.be.false;
+  });
+  it("returns false if the lengths are the same but not all of the elements match", () => {
+    let arr2 = ["a", "b", "d"];
+    expect(isEqual(arr1, arr2)).to.be.false;
+  });
+  it("returns false if there are duplicates", () => {
+    let arr2 = ["a", "a", "b"];
+    expect(isEqual(arr1, arr2)).to.be.false;
+  });
+  it("returns true if the arrays are the same", () => {
+    let arr2 = ["a", "b", "c"];
+    expect(isEqual(arr1, arr2)).to.be.true;
+  });
+  it("returns true even if the arrays do not list the elements in the same order", () => {
+    let arr2 = ["b", "c", "a"];
+    expect(isEqual(arr1, arr2)).to.be.true;
+  });
+
 });

--- a/src/components/CustomListsForBook.tsx
+++ b/src/components/CustomListsForBook.tsx
@@ -59,13 +59,13 @@ export class CustomListsForBook extends React.Component<CustomListsForBookProps,
         { this.props.book &&
           <h2>{this.props.book.title}</h2>
         }
-        <h3>Lists</h3>
+          <h3>Lists:</h3>
         { this.props.fetchError &&
           <ErrorMessage error={this.props.fetchError} tryAgain={this.refresh} />
         }
         <Form className="edit-form" content={[
           this.renderInputList(),
-          <a href={`/admin/web/lists/${this.props.library}/create`}>Create a new list</a>
+          this.renderLink()
         ]} onSubmit={this.save} />
       </div>
     );
@@ -75,26 +75,42 @@ export class CustomListsForBook extends React.Component<CustomListsForBookProps,
     return <option value={list.name} key={list.id} aria-selected={false}>{list.name}</option>;
   }
 
+  renderLink() {
+    if (this.props.allCustomLists && this.props.allCustomLists.length) {
+      return ([
+        <hr key="hr1"/>,
+        <span key="or">or</span>,
+        <hr key="hr2"/>,
+        <div key="list-creator-link" onClick={() => {(navigator as any).clipboard.writeText(this.props.book.title)}}>
+          <a href={`/admin/web/lists/${this.props.library}/create`}>Create a new list</a>
+          <p>(The book title will be copied to the clipboard so that you can easily search for it on the list creator page.)</p>
+        </div>
+      ]);
+    }
+  }
+
   renderInputList() {
     let allLists = this.props.allCustomLists || [];
-    return (
+    if (allLists.length) {
+      return (
         <ProtocolFormField
-          key={"lists"}
-          ref={"addList"}
-          setting={{
-            type: "menu",
-            format: "narrow",
-            key: "lists?",
-            label: null,
-            custom_lists: this.state.customLists,
-            required: true,
-            menuOptions: allLists.filter(l => l.name).map(l => this.makeSelect(l)),
-            urlBase: this.makeURL
-          }}
-          disabled={this.props.isFetching}
-          value={this.state.customLists && this.state.customLists.map(l => l.name)}
+        key={"lists"}
+        ref={"addList"}
+        setting={{
+          type: "menu",
+          format: "narrow",
+          key: "lists-input",
+          label: null,
+          custom_lists: this.state.customLists,
+          required: true,
+          menuOptions: allLists.filter(l => l.name).map(l => this.makeSelect(l)),
+          urlBase: this.makeURL
+        }}
+        disabled={this.props.isFetching}
+        value={this.state.customLists && this.state.customLists.map(l => l.name)}
         />
-    );
+      );
+    }
   }
 
   makeURL(listName): string {

--- a/src/components/CustomListsForBook.tsx
+++ b/src/components/CustomListsForBook.tsx
@@ -13,7 +13,7 @@ import { State } from "../reducers/index";
 
 export interface CustomListsForBookStateProps {
   allCustomLists?: CustomListData[];
-  customListsForBook?: CustomListsData;
+  customListsForBook?: CustomListData[];
   fetchError?: FetchErrorData;
   isFetching?: boolean;
 }
@@ -36,7 +36,7 @@ export interface CustomListsForBookOwnProps {
 export interface CustomListsForBookProps extends CustomListsForBookStateProps, CustomListsForBookDispatchProps, CustomListsForBookOwnProps {};
 
 export interface CustomListsForBookState {
-  customLists?: CustomListsData;
+  customLists?: CustomListData[];
 }
 
 /** Tab on the book details page that shows custom lists a book is on and lets
@@ -111,7 +111,7 @@ export class CustomListsForBook extends React.Component<CustomListsForBookProps,
             urlBase: this.makeURL
           }}
           disabled={this.props.isFetching}
-          value={this.props.customListsForBook && this.props.customListsForBook.custom_lists.map(l => l.name)}
+          value={this.props.customListsForBook && this.props.customListsForBook.map(l => l.name)}
           altValue="This book is not currently on any lists."
           onSubmit={this.save}
         />

--- a/src/components/CustomListsForBook.tsx
+++ b/src/components/CustomListsForBook.tsx
@@ -122,6 +122,7 @@ export class CustomListsForBook extends React.Component<CustomListsForBookProps,
           }}
           disabled={this.props.isFetching}
           value={this.state.customLists && this.state.customLists.map(l => l.name)}
+          altValue="This book is not currently on any lists."
         />
       );
     } else {

--- a/src/components/CustomListsForBook.tsx
+++ b/src/components/CustomListsForBook.tsx
@@ -63,7 +63,10 @@ export class CustomListsForBook extends React.Component<CustomListsForBookProps,
         { this.props.fetchError &&
           <ErrorMessage error={this.props.fetchError} tryAgain={this.refresh} />
         }
-        <Form className="edit-form" content={this.renderInputList()} onSubmit={this.save} />
+        <Form className="edit-form" content={[
+          this.renderInputList(),
+          <a href={`/admin/web/lists/${this.props.library}/create`}>Create a new list</a>
+        ]} onSubmit={this.save} />
       </div>
     );
   }

--- a/src/components/CustomListsForBook.tsx
+++ b/src/components/CustomListsForBook.tsx
@@ -87,7 +87,7 @@ export class CustomListsForBook extends React.Component<CustomListsForBookProps,
             menuOptions: allLists.filter(l => l.name).map(l => this.makeSelect(l))
           }}
           disabled={this.props.isFetching}
-          value={this.state.customLists.map(l => l.name)}
+          value={this.state.customLists && this.state.customLists.map(l => l.name)}
         />
     );
   }

--- a/src/components/CustomListsForBook.tsx
+++ b/src/components/CustomListsForBook.tsx
@@ -110,12 +110,13 @@ export class CustomListsForBook extends React.Component<CustomListsForBookProps,
           key={"lists"}
           ref={"addList"}
           setting={{
+            menuTitle: "Select an existing list",
             type: "menu",
             format: "narrow",
             key: "lists-input",
             label: null,
             custom_lists: this.state.customLists,
-            required: true,
+            required: false,
             menuOptions: allLists.filter(l => l.name).map(l => this.makeSelect(l)),
             urlBase: this.makeURL
           }}

--- a/src/components/CustomListsForBook.tsx
+++ b/src/components/CustomListsForBook.tsx
@@ -50,6 +50,7 @@ export class CustomListsForBook extends React.Component<CustomListsForBookProps,
     };
     this.refresh = this.refresh.bind(this);
     this.save = this.save.bind(this);
+    this.makeURL = this.makeURL.bind(this);
   }
 
   render(): JSX.Element {
@@ -85,12 +86,19 @@ export class CustomListsForBook extends React.Component<CustomListsForBookProps,
             custom_lists: this.state.customLists,
             required: true,
             menuOptions: allLists.filter(l => l.name).map(l => this.makeSelect(l)),
-            urlBase: `/admin/web/lists/${this.props.library}/edit/`
+            urlBase: this.makeURL
           }}
           disabled={this.props.isFetching}
           value={this.state.customLists && this.state.customLists.map(l => l.name)}
         />
     );
+  }
+
+  makeURL(listName): string {
+    let list = (this.props.allCustomLists || []).find(l => l.name === listName);
+    if (list) {
+      return `/admin/web/lists/${this.props.library}/edit/${list.id}`;
+    }
   }
 
   availableLists(): CustomListData[] {

--- a/src/components/CustomListsForBook.tsx
+++ b/src/components/CustomListsForBook.tsx
@@ -13,14 +13,14 @@ import { State } from "../reducers/index";
 
 export interface CustomListsForBookStateProps {
   allCustomLists?: CustomListData[];
-  customListsForBook?: CustomListData[];
+  customListsForBook?: CustomListsData;
   fetchError?: FetchErrorData;
   isFetching?: boolean;
 }
 
 export interface CustomListsForBookDispatchProps {
-  fetchAllCustomLists?: () => Promise<CustomListData[]>;
-  fetchCustomListsForBook?: (url: string) => Promise<CustomListData[]>;
+  fetchAllCustomLists?: () => Promise<CustomListsData>;
+  fetchCustomListsForBook?: (url: string) => Promise<CustomListsData>;
   editCustomListsForBook?: (url: string, data: FormData) => Promise<void>;
 }
 
@@ -36,7 +36,7 @@ export interface CustomListsForBookOwnProps {
 export interface CustomListsForBookProps extends CustomListsForBookStateProps, CustomListsForBookDispatchProps, CustomListsForBookOwnProps {};
 
 export interface CustomListsForBookState {
-  customLists: CustomListData[];
+  customLists?: CustomListsData;
 }
 
 /** Tab on the book details page that shows custom lists a book is on and lets
@@ -45,7 +45,7 @@ export class CustomListsForBook extends React.Component<CustomListsForBookProps,
   constructor(props: CustomListsForBookProps) {
     super(props);
     this.state = {
-      customLists: this.props.customListsForBook || []
+      customLists: this.props.customListsForBook
     };
     this.refresh = this.refresh.bind(this);
     this.save = this.save.bind(this);
@@ -111,7 +111,7 @@ export class CustomListsForBook extends React.Component<CustomListsForBookProps,
             urlBase: this.makeURL
           }}
           disabled={this.props.isFetching}
-          value={this.props.customListsForBook && this.props.customListsForBook.map(l => l.name)}
+          value={this.props.customListsForBook && this.props.customListsForBook.custom_lists.map(l => l.name)}
           altValue="This book is not currently on any lists."
           onSubmit={this.save}
         />

--- a/src/components/CustomListsForBook.tsx
+++ b/src/components/CustomListsForBook.tsx
@@ -19,8 +19,8 @@ export interface CustomListsForBookStateProps {
 }
 
 export interface CustomListsForBookDispatchProps {
-  fetchAllCustomLists?: () => Promise<CustomListsData>;
-  fetchCustomListsForBook?: (url: string) => Promise<CustomListsData>;
+  fetchAllCustomLists?: () => Promise<CustomListData[]>;
+  fetchCustomListsForBook?: (url: string) => Promise<CustomListData[]>;
   editCustomListsForBook?: (url: string, data: FormData) => Promise<void>;
 }
 

--- a/src/components/CustomListsForBook.tsx
+++ b/src/components/CustomListsForBook.tsx
@@ -42,6 +42,8 @@ export interface CustomListsForBookState {
 /** Tab on the book details page that shows custom lists a book is on and lets
     an admin add the book to lists or remove the book from lists. */
 export class CustomListsForBook extends React.Component<CustomListsForBookProps, CustomListsForBookState> {
+  private addListRef = React.createRef<ProtocolFormField>();
+
   constructor(props: CustomListsForBookProps) {
     super(props);
     this.state = {
@@ -79,8 +81,8 @@ export class CustomListsForBook extends React.Component<CustomListsForBookProps,
   renderLink(): JSX.Element {
     // Link to the form for creating a new list
     return(
-      <div role="button" key="list-creator-link" onClick={this.copyTitle}>
-        <a href={`/admin/web/lists/${this.props.library}/create`}>Create a new list</a>
+      <div key="list-creator-link">
+        <a onClick={this.copyTitle} href={`/admin/web/lists/${this.props.library}/create`}>Create a new list</a>
         <p>(The book title will be copied to the clipboard so that you can easily search for it on the list creator page.)</p>
       </div>
     );
@@ -97,8 +99,8 @@ export class CustomListsForBook extends React.Component<CustomListsForBookProps,
     if (allLists.length > 0) {
       return (
         <ProtocolFormField
-          key={"lists"}
-          ref={"addList"}
+          key="lists"
+          ref={this.addListRef}
           setting={{
             menuTitle: "Select an existing list",
             type: "menu",
@@ -110,10 +112,12 @@ export class CustomListsForBook extends React.Component<CustomListsForBookProps,
             menuOptions: allLists.filter(l => l.name).map(l => this.makeOption(l)),
             urlBase: this.makeURL
           }}
+          title="Current Lists"
           disabled={this.props.isFetching}
           value={this.props.customListsForBook && this.props.customListsForBook.map(l => l.name)}
           altValue="This book is not currently on any lists."
           onSubmit={this.save}
+          onEmpty="This book has been added to all the available lists."
         />
       );
     } else {
@@ -156,7 +160,7 @@ export class CustomListsForBook extends React.Component<CustomListsForBookProps,
   }
 
   save() {
-    const listNames = (this.refs.addList as ProtocolFormField).getValue();
+    const listNames = (this.addListRef.current as ProtocolFormField).getValue();
     const url = this.listsUrl();
     let data = new (window as any).FormData();
     let lists = [];

--- a/src/components/CustomListsForBook.tsx
+++ b/src/components/CustomListsForBook.tsx
@@ -84,7 +84,8 @@ export class CustomListsForBook extends React.Component<CustomListsForBookProps,
             label: null,
             custom_lists: this.state.customLists,
             required: true,
-            menuOptions: allLists.filter(l => l.name).map(l => this.makeSelect(l))
+            menuOptions: allLists.filter(l => l.name).map(l => this.makeSelect(l)),
+            urlBase: `/admin/web/lists/${this.props.library}/edit/`
           }}
           disabled={this.props.isFetching}
           value={this.state.customLists && this.state.customLists.map(l => l.name)}

--- a/src/components/InputList.tsx
+++ b/src/components/InputList.tsx
@@ -210,7 +210,7 @@ export default class InputList extends React.Component<InputListProps, InputList
     await this.setState({ listItems: this.state.listItems.concat(listItem), newItem: "" });
     // Actually save the changes instead of just manipulating the state
     if (this.props.onSubmit) { await this.props.onSubmit(); };
-    ref.clear();
+    if (this.props.setting.type !== "menu") { ref.clear(); };
   }
 
   getValue() {

--- a/src/components/InputList.tsx
+++ b/src/components/InputList.tsx
@@ -54,7 +54,7 @@ export default class InputList extends React.Component<InputListProps, InputList
     const setting = this.props.setting as any;
     let showButton = !this.state.options || this.state.options.length > 0;
     return (
-      <div>
+      <div className="input-list">
         { this.props.labelAndDescription(setting) }
         { this.state.listItems && this.state.listItems.map((listItem) => {
           let value = typeof(listItem) === "string" ? listItem : Object.keys(listItem)[0];
@@ -64,26 +64,7 @@ export default class InputList extends React.Component<InputListProps, InputList
               disabled={this.props.disabled}
               onRemove={() => this.removeListItem(listItem)}
             >
-              {
-                setting.format === "language-code" ?
-                  <LanguageField
-                    disabled={this.props.disabled}
-                    value={value}
-                    name={setting.key}
-                    languages={this.props.additionalData}
-                  /> :
-                  this.props.createEditableInput(setting, {
-                    type: "text",
-                    description: null,
-                    disabled: this.props.disabled,
-                    value: value,
-                    name: setting.key,
-                    label: null,
-                    extraContent: this.renderToolTip(listItem, setting.format),
-                    optionalText: !setting.required
-                  })
-                }
-
+              { this.renderListItem(setting, value, listItem) }
             </WithRemoveButton>
           );
         })}
@@ -121,6 +102,36 @@ export default class InputList extends React.Component<InputListProps, InputList
         </div>
       </div>
     );
+  }
+
+  renderListItem(setting, value, listItem) {
+    if (setting.format === "language-code") {
+      return (
+        <LanguageField
+          disabled={this.props.disabled}
+          value={value}
+          name={setting.key}
+          languages={this.props.additionalData}
+        />
+      );
+    } else if (setting.urlBase) {
+      return (
+        <a href={`${setting.urlBase}${listItem}`}>{listItem}</a>
+      );
+    } else {
+      return (
+        this.props.createEditableInput(setting, {
+          type: "text",
+          description: null,
+          disabled: this.props.disabled,
+          value: value,
+          name: setting.key,
+          label: null,
+          extraContent: this.renderToolTip(listItem, setting.format),
+          optionalText: !setting.required
+        })
+      );
+    }
   }
 
   renderMenu(setting) {

--- a/src/components/InputList.tsx
+++ b/src/components/InputList.tsx
@@ -143,7 +143,8 @@ export default class InputList extends React.Component<InputListProps, InputList
           elementType: "select",
           name: setting.key,
           value: setting.key,
-          label: null,
+          label: setting.menuTitle,
+          required: setting.required,
           ref: "addListItem",
           optionalText: !setting.required
         }, choices

--- a/src/components/InputList.tsx
+++ b/src/components/InputList.tsx
@@ -37,6 +37,7 @@ export default class InputList extends React.Component<InputListProps, InputList
     this.addListItem = this.addListItem.bind(this);
     this.removeListItem = this.removeListItem.bind(this);
     this.clear = this.clear.bind(this);
+    this.filterMenu = this.filterMenu.bind(this);
   }
 
   componentWillReceiveProps(newProps) {
@@ -159,7 +160,8 @@ export default class InputList extends React.Component<InputListProps, InputList
     if (!allOptions) {
       return;
     }
-    let remainingOptions = allOptions.filter(o => this.state.listItems.indexOf(o.props.value) < 0);
+    let listItems = this.state ? this.state.listItems : this.props.value;
+    let remainingOptions = allOptions.filter(o => listItems.indexOf(o.props.value) < 0);
     return remainingOptions;
   }
 

--- a/src/components/InputList.tsx
+++ b/src/components/InputList.tsx
@@ -116,7 +116,7 @@ export default class InputList extends React.Component<InputListProps, InputList
       );
     } else if (setting.urlBase) {
       return (
-        <a href={`${setting.urlBase}${listItem}`}>{listItem}</a>
+        <a href={setting.urlBase(listItem)}>{listItem}</a>
       );
     } else {
       return (

--- a/src/components/InputList.tsx
+++ b/src/components/InputList.tsx
@@ -14,6 +14,7 @@ export interface InputListProps {
   setting: SettingData | CustomListsSetting;
   disabled: boolean;
   value: Array<string | {} | JSX.Element>;
+  altValue?: string;
   additionalData?: any;
 }
 
@@ -56,6 +57,7 @@ export default class InputList extends React.Component<InputListProps, InputList
     return (
       <div className="input-list">
         { this.props.labelAndDescription(setting) }
+        { !(this.state.listItems.length > 0) && <span>{this.props.altValue}</span> }
         { this.state.listItems && this.state.listItems.map((listItem) => {
           let value = typeof(listItem) === "string" ? listItem : Object.keys(listItem)[0];
           return (

--- a/src/components/InputList.tsx
+++ b/src/components/InputList.tsx
@@ -167,11 +167,14 @@ export default class InputList extends React.Component<InputListProps, InputList
   }
 
   filterMenu() {
+    // All the possibilities, regardless of whether they've already been selected.
     let allOptions = (this.props.setting as any).menuOptions;
     if (!allOptions) {
       return;
     }
+    // Items that have already been selected, and should be eliminated from the menu.
     let listItems = this.state ? this.state.listItems : this.props.value;
+    // Items that haven't been selected yet.
     let remainingOptions = allOptions.filter(o => listItems.indexOf(o.props.value) < 0);
     return remainingOptions;
   }

--- a/src/components/ProtocolFormField.tsx
+++ b/src/components/ProtocolFormField.tsx
@@ -15,6 +15,8 @@ export interface ProtocolFormFieldProps {
   error?: FetchErrorData;
   additionalData?: any;
   onSubmit?: any;
+  onEmpty?: string;
+  title?: string;
 }
 
 /** Shows a form field for editing a single setting, based on setting information
@@ -104,7 +106,7 @@ export default class ProtocolFormField extends React.Component<ProtocolFormField
   renderListSettingWithOptions(setting: SettingData): JSX.Element {
     return (
       <div>
-        { this.labelAndDescription(setting) }
+        { setting.label && this.labelAndDescription(setting) }
         { setting.options.map((option) => {
             return this.createEditableInput(option, {
                 type: "checkbox",
@@ -128,12 +130,14 @@ export default class ProtocolFormField extends React.Component<ProtocolFormField
         ref="element"
         setting={setting}
         createEditableInput={this.createEditableInput}
-        labelAndDescription={this.labelAndDescription}
+        labelAndDescription={setting.label && this.labelAndDescription}
         disabled={this.props.disabled}
         value={value}
         altValue={this.props.altValue}
         additionalData={this.props.additionalData}
         onSubmit={this.props.onSubmit}
+        onEmpty={this.props.onEmpty}
+        title={this.props.title}
       />
     );
   }

--- a/src/components/ProtocolFormField.tsx
+++ b/src/components/ProtocolFormField.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import EditableInput from "./EditableInput";
-import WithRemoveButton from "./WithRemoveButton";
 import ColorPicker from "./ColorPicker";
 import { Button } from "library-simplified-reusable-components";
 import InputList from "./InputList";

--- a/src/components/ProtocolFormField.tsx
+++ b/src/components/ProtocolFormField.tsx
@@ -10,6 +10,7 @@ export interface ProtocolFormFieldProps {
   setting: SettingData | CustomListsSetting;
   disabled: boolean;
   value?: string | string[] | {}[] | Array<string | {} | JSX.Element> | JSX.Element;
+  altValue?: string;
   default?: any;
   error?: FetchErrorData;
   additionalData?: any;
@@ -129,6 +130,7 @@ export default class ProtocolFormField extends React.Component<ProtocolFormField
         labelAndDescription={this.labelAndDescription}
         disabled={this.props.disabled}
         value={value}
+        altValue={this.props.altValue}
         additionalData={this.props.additionalData}
       />
     );

--- a/src/components/ProtocolFormField.tsx
+++ b/src/components/ProtocolFormField.tsx
@@ -14,6 +14,7 @@ export interface ProtocolFormFieldProps {
   default?: any;
   error?: FetchErrorData;
   additionalData?: any;
+  onSubmit?: any;
 }
 
 /** Shows a form field for editing a single setting, based on setting information
@@ -132,6 +133,7 @@ export default class ProtocolFormField extends React.Component<ProtocolFormField
         value={value}
         altValue={this.props.altValue}
         additionalData={this.props.additionalData}
+        onSubmit={this.props.onSubmit}
       />
     );
   }

--- a/src/components/ProtocolFormField.tsx
+++ b/src/components/ProtocolFormField.tsx
@@ -30,7 +30,7 @@ export default class ProtocolFormField extends React.Component<ProtocolFormField
   }
 
   render(): JSX.Element {
-    const setting = this.props.setting as any;
+    const setting = this.props.setting as SettingData | CustomListsSetting;
     if (setting.type === "select") {
       return this.renderSelectSetting(setting);
     } else if (setting.type === "list" && setting.options) {

--- a/src/components/ProtocolFormField.tsx
+++ b/src/components/ProtocolFormField.tsx
@@ -4,13 +4,13 @@ import WithRemoveButton from "./WithRemoveButton";
 import ColorPicker from "./ColorPicker";
 import { Button } from "library-simplified-reusable-components";
 import InputList from "./InputList";
-import { SettingData } from "../interfaces";
+import { SettingData, CustomListsSetting } from "../interfaces";
 import { FetchErrorData } from "opds-web-client/lib/interfaces";
 
 export interface ProtocolFormFieldProps {
-  setting: SettingData;
+  setting: SettingData | CustomListsSetting;
   disabled: boolean;
-  value?: string | string[] | {}[] | Array<string | {}>;
+  value?: string | string[] | {}[] | Array<string | {} | JSX.Element> | JSX.Element;
   default?: any;
   error?: FetchErrorData;
   additionalData?: any;
@@ -27,12 +27,12 @@ export default class ProtocolFormField extends React.Component<ProtocolFormField
   }
 
   render(): JSX.Element {
-    const setting = this.props.setting;
+    const setting = this.props.setting as any;
     if (setting.type === "select") {
       return this.renderSelectSetting(setting);
     } else if (setting.type === "list" && setting.options) {
         return this.renderListSettingWithOptions(setting);
-    } else if (setting.type === "list") {
+    } else if (setting.type === "list" || setting.type === "menu") {
         return this.renderListSetting(setting);
     } else if (setting.type === "color-picker") {
         return this.renderColorPickerSetting(setting);
@@ -117,7 +117,7 @@ export default class ProtocolFormField extends React.Component<ProtocolFormField
     );
   }
 
-  renderListSetting(setting: SettingData): JSX.Element {
+  renderListSetting(setting: SettingData | CustomListsSetting): JSX.Element {
     // Flatten an object in which the values are arrays
     let value = Array.isArray(this.props.value) ?
       this.props.value :

--- a/src/components/__tests__/CustomListsForBook-test.tsx
+++ b/src/components/__tests__/CustomListsForBook-test.tsx
@@ -65,6 +65,9 @@ describe("CustomListsForBook", () => {
     });
 
     it("shows current lists", () => {
+      let h4 = wrapper.find("h4");
+      expect(h4.length).to.equal(1);
+      expect(h4.text()).to.equal("Current Lists");
       let removable = wrapper.find(WithRemoveButton);
       expect(removable.length).to.equal(1);
       let link = removable.find("a");
@@ -80,6 +83,8 @@ describe("CustomListsForBook", () => {
       placeholder = (wrapper.find(".input-list > span"));
       expect(placeholder.length).to.equal(1);
       expect(placeholder.text()).to.equal("This book is not currently on any lists.");
+      let h4 = wrapper.find("h4");
+      expect(h4.length).to.equal(0);
     });
 
     it("creates a URL based on list ID", () => {
@@ -106,12 +111,19 @@ describe("CustomListsForBook", () => {
       expect(button.prop("content")).to.equal("Add");
     });
 
+    it("does not show the menu if the book is already on all the lists", () => {
+      wrapper.setProps({ customListsForBook: allCustomLists });
+      wrapper.update();
+      let menu = wrapper.find("select");
+      expect(menu.length).to.equal(0);
+      let message = wrapper.find("span.add-list-item");
+      expect(message.text()).to.equal("This book has been added to all the available lists.");
+    });
+
     it("does not show the InputList if no lists exist", async () => {
       let inputList = wrapper.find(InputList);
       expect(inputList.length).to.equal(1);
       wrapper.setProps({ allCustomLists: [] });
-      await new Promise((resolve) => setTimeout(resolve, 0));
-      wrapper.update();
       inputList = wrapper.find(InputList);
       expect(inputList.length).to.equal(0);
       expect(wrapper.find("p").at(0).text()).to.equal("There are no available lists.");
@@ -136,7 +148,7 @@ describe("CustomListsForBook", () => {
       let copyTitle = stub(wrapper.instance(), "copyTitle").returns(wrapper.prop("book").title);
       wrapper.setProps({ copyTitle });
       expect(copyTitle.callCount).to.equal(0);
-      linkDiv.simulate("click");
+      link.simulate("click");
       expect(copyTitle.callCount).to.equal(1);
       expect(copyTitle()).to.equal("test title");
       copyTitle.restore();
@@ -178,8 +190,7 @@ describe("CustomListsForBook", () => {
       let menu = wrapper.find("select");
       menu.getDOMNode().value = "list 1";
       menu.simulate("change");
-      wrapper.find("button.add-list-item").simulate("click");
-      await new Promise((resolve) => setTimeout(resolve, 0));
+      await wrapper.find("button.add-list-item").simulate("click");
       expect(editCustomListsForBook.callCount).to.equal(1);
       let formData = editCustomListsForBook.args[0][1];
       expect(JSON.parse(formData.get("lists"))).to.deep.equal([
@@ -197,8 +208,7 @@ describe("CustomListsForBook", () => {
       let removables = wrapper.find(WithRemoveButton);
       expect(removables.length).to.equal(1);
       let removeButton = removables.find(Button);
-      removeButton.simulate("click");
-      await new Promise((resolve) => setTimeout(resolve, 0));
+      await removeButton.simulate("click");
 
       removables = wrapper.find(WithRemoveButton);
       expect(removables.length).to.equal(0);

--- a/src/components/__tests__/CustomListsForBook-test.tsx
+++ b/src/components/__tests__/CustomListsForBook-test.tsx
@@ -71,9 +71,9 @@ describe("CustomListsForBook", () => {
       expect(removable.length).to.equal(1);
 
       let link = wrapper.find("a");
-      // expect(link.length).to.equal(1);
-      // expect(link.props().href).to.equal("/admin/web/lists/library/edit/2");
-      // expect(link.text()).to.equal("list 2");
+      expect(link.length).to.equal(1);
+      expect(link.props().href).to.equal("/admin/web/lists/library/edit/2");
+      expect(link.text()).to.equal("list 2");
     });
 
     it("shows available lists", () => {
@@ -124,7 +124,7 @@ describe("CustomListsForBook", () => {
       expect(editCustomListsForBook.callCount).to.equal(0);
       let removables = wrapper.find(WithRemoveButton);
       expect(removables.length).to.equal(1);
-      expect(removables.find("input").prop("value")).to.equal("list 2");
+      expect(removables.find("a").text()).to.equal("list 2");
 
       let menu = wrapper.find("select");
       menu.getDOMNode().value = "list 1";
@@ -133,8 +133,8 @@ describe("CustomListsForBook", () => {
 
       removables = wrapper.find(WithRemoveButton);
       expect(removables.length).to.equal(2);
-      expect(removables.at(0).find("input").prop("value")).to.equal("list 2");
-      expect(removables.at(1).find("input").prop("value")).to.equal("list 1");
+      expect(removables.at(0).find("a").text()).to.equal("list 2");
+      expect(removables.at(1).find("a").text()).to.equal("list 1");
 
       // Click the submit button to trigger the callback
       wrapper.find(Button).last().simulate("click");

--- a/src/components/__tests__/CustomListsForBook-test.tsx
+++ b/src/components/__tests__/CustomListsForBook-test.tsx
@@ -24,9 +24,9 @@ describe("CustomListsForBook", () => {
     { id: "2", name: "list 2"},
     { id: "3", name: "list 3"}
   ];
-  let customListsForBook = [
-    { id: "2", name: "list 2"}
-  ];
+  let customListsForBook = {
+    custom_lists: [{ id: "2", name: "list 2"}]
+  };
 
   beforeEach(() => {
     fetchAllCustomLists = stub();
@@ -76,7 +76,7 @@ describe("CustomListsForBook", () => {
     it("shows placeholder text if there are no current lists", async () => {
       let placeholder = (wrapper.find(".input-list > span"));
       expect(placeholder.length).to.equal(0);
-      wrapper.setProps({ customListsForBook: [] });
+      wrapper.setProps({ customListsForBook: { custom_lists: [] }});
       placeholder = (wrapper.find(".input-list > span"));
       expect(placeholder.length).to.equal(1);
       expect(placeholder.text()).to.equal("This book is not currently on any lists.");

--- a/src/components/__tests__/CustomListsForBook-test.tsx
+++ b/src/components/__tests__/CustomListsForBook-test.tsx
@@ -2,13 +2,11 @@ import { expect } from "chai";
 import { stub } from "sinon";
 
 import * as React from "react";
-import { shallow, mount } from "enzyme";
+import { mount } from "enzyme";
 import { Button } from "library-simplified-reusable-components";
 import { CustomListsForBook } from "../CustomListsForBook";
 import ErrorMessage from "../ErrorMessage";
 import WithRemoveButton from "../WithRemoveButton";
-import ProtocolFormField from "../ProtocolFormField";
-import Autocomplete from "../Autocomplete";
 import InputList from "../InputList";
 
 describe("CustomListsForBook", () => {
@@ -47,7 +45,7 @@ describe("CustomListsForBook", () => {
         fetchCustomListsForBook={fetchCustomListsForBook}
         editCustomListsForBook={editCustomListsForBook}
         refreshCatalog={refreshCatalog}
-        />
+      />
     );
   });
 
@@ -75,10 +73,10 @@ describe("CustomListsForBook", () => {
       expect(link.text()).to.equal("list 2");
     });
 
-    it("shows placeholder text if there are no current lists", () => {
+    it("shows placeholder text if there are no current lists", async () => {
       let placeholder = (wrapper.find(".input-list > span"));
       expect(placeholder.length).to.equal(0);
-      wrapper.setState({ customLists: [] });
+      wrapper.setProps({ customListsForBook: [] });
       placeholder = (wrapper.find(".input-list > span"));
       expect(placeholder.length).to.equal(1);
       expect(placeholder.text()).to.equal("This book is not currently on any lists.");
@@ -108,24 +106,15 @@ describe("CustomListsForBook", () => {
       expect(button.prop("content")).to.equal("Add");
     });
 
-    it("does not show the InputList or the divider if no lists exist", () => {
+    it("does not show the InputList if no lists exist", async () => {
       let inputList = wrapper.find(InputList);
       expect(inputList.length).to.equal(1);
-      let dividers = wrapper.find("hr");
-      expect(dividers.length).to.equal(2);
       wrapper.setProps({ allCustomLists: [] });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      wrapper.update();
       inputList = wrapper.find(InputList);
       expect(inputList.length).to.equal(0);
-      dividers = wrapper.find("hr");
-      expect(dividers.length).to.equal(0);
-    });
-
-    it("does not show the divider if all the lists have already been selected", () => {
-      let dividers = wrapper.find("hr");
-      expect(dividers.length).to.equal(2);
-      wrapper.setState({ customLists: wrapper.prop("allCustomLists") });
-      dividers = wrapper.find("hr");
-      expect(dividers.length).to.equal(0);
+      expect(wrapper.find("p").at(0).text()).to.equal("There are no available lists.");
     });
 
     it("disables while fetching", () => {
@@ -180,7 +169,7 @@ describe("CustomListsForBook", () => {
       expect(fetchAllCustomLists.callCount).to.equal(1);
     });
 
-    it("adds a list", () => {
+    it("adds a list", async () => {
       expect(editCustomListsForBook.callCount).to.equal(0);
       let removables = wrapper.find(WithRemoveButton);
       expect(removables.length).to.equal(1);
@@ -190,33 +179,29 @@ describe("CustomListsForBook", () => {
       menu.getDOMNode().value = "list 1";
       menu.simulate("change");
       wrapper.find("button.add-list-item").simulate("click");
-
-      removables = wrapper.find(WithRemoveButton);
-      expect(removables.length).to.equal(2);
-      expect(removables.at(0).find("a").text()).to.equal("list 2");
-      expect(removables.at(1).find("a").text()).to.equal("list 1");
-
-      // Click the submit button to trigger the callback
-      wrapper.find(Button).last().simulate("click");
+      await new Promise((resolve) => setTimeout(resolve, 0));
       expect(editCustomListsForBook.callCount).to.equal(1);
       let formData = editCustomListsForBook.args[0][1];
       expect(JSON.parse(formData.get("lists"))).to.deep.equal([
         {id: "2", name: "list 2"},
         {id: "1", name: "list 1"}
       ]);
+      removables = wrapper.find(WithRemoveButton);
+      expect(removables.length).to.equal(2);
+      expect(removables.at(0).find("a").text()).to.equal("list 2");
+      expect(removables.at(1).find("a").text()).to.equal("list 1");
     });
 
-    it("removes a list", () => {
+    it("removes a list", async () => {
       expect(editCustomListsForBook.callCount).to.equal(0);
       let removables = wrapper.find(WithRemoveButton);
       expect(removables.length).to.equal(1);
       let removeButton = removables.find(Button);
       removeButton.simulate("click");
+      await new Promise((resolve) => setTimeout(resolve, 0));
 
       removables = wrapper.find(WithRemoveButton);
       expect(removables.length).to.equal(0);
-      // Click the submit button to trigger the callback
-      wrapper.find(Button).last().simulate("click");
       let links = wrapper.find(WithRemoveButton).find("a");
       expect(links.length).to.equal(0);
 

--- a/src/components/__tests__/CustomListsForBook-test.tsx
+++ b/src/components/__tests__/CustomListsForBook-test.tsx
@@ -24,9 +24,9 @@ describe("CustomListsForBook", () => {
     { id: "2", name: "list 2"},
     { id: "3", name: "list 3"}
   ];
-  let customListsForBook = {
-    custom_lists: [{ id: "2", name: "list 2"}]
-  };
+  let customListsForBook = [
+    { id: "2", name: "list 2"}
+  ];
 
   beforeEach(() => {
     fetchAllCustomLists = stub();
@@ -76,7 +76,7 @@ describe("CustomListsForBook", () => {
     it("shows placeholder text if there are no current lists", async () => {
       let placeholder = (wrapper.find(".input-list > span"));
       expect(placeholder.length).to.equal(0);
-      wrapper.setProps({ customListsForBook: { custom_lists: [] }});
+      wrapper.setProps({ customListsForBook: [] });
       placeholder = (wrapper.find(".input-list > span"));
       expect(placeholder.length).to.equal(1);
       expect(placeholder.text()).to.equal("This book is not currently on any lists.");

--- a/src/components/__tests__/CustomListsForBook-test.tsx
+++ b/src/components/__tests__/CustomListsForBook-test.tsx
@@ -87,10 +87,13 @@ describe("CustomListsForBook", () => {
       expect(newUrl).to.equal("/admin/web/lists/library/edit/42");
     });
 
-    it("shows available lists", () => {
+    it("shows a menu of available lists", () => {
       let availableLists = wrapper.find("select");
       expect(availableLists.length).to.equal(1);
       expect(availableLists.find("option").map(o => o.prop("value"))).to.deep.equal(["list 1", "list 3"]);
+      let label = availableLists.closest("label");
+      expect(label.length).to.equal(1);
+      expect(label.text()).to.contain("Select an existing list");
       let button = wrapper.find(".add-list-item-container").find(Button);
       expect(button.length).to.equal(1);
       expect(button.prop("content")).to.equal("Add");

--- a/src/components/__tests__/CustomListsForBook-test.tsx
+++ b/src/components/__tests__/CustomListsForBook-test.tsx
@@ -76,6 +76,18 @@ describe("CustomListsForBook", () => {
       expect(link.text()).to.equal("list 2");
     });
 
+    it("creates a URL based on list ID", () => {
+      let url1 = wrapper.instance().makeURL("list 1");
+      expect(url1).to.equal("/admin/web/lists/library/edit/1");
+      let url2 = wrapper.instance().makeURL("list 2");
+      expect(url2).to.equal("/admin/web/lists/library/edit/2");
+      // Making sure that it's actually using the ID, not just the number in the name...
+      let newList = { name: "new", id: "42" };
+      wrapper.setProps({ allCustomLists: allCustomLists.concat([newList] )});
+      let newUrl = wrapper.instance().makeURL("new");
+      expect(newUrl).to.equal("/admin/web/lists/library/edit/42");
+    });
+
     it("shows available lists", () => {
       let availableLists = wrapper.find("select");
       expect(availableLists.length).to.equal(1);

--- a/src/components/__tests__/CustomListsForBook-test.tsx
+++ b/src/components/__tests__/CustomListsForBook-test.tsx
@@ -75,6 +75,15 @@ describe("CustomListsForBook", () => {
       expect(link.text()).to.equal("list 2");
     });
 
+    it("shows placeholder text if there are no current lists", () => {
+      let placeholder = (wrapper.find(".input-list > span"));
+      expect(placeholder.length).to.equal(0);
+      wrapper.setState({ customLists: [] });
+      placeholder = (wrapper.find(".input-list > span"));
+      expect(placeholder.length).to.equal(1);
+      expect(placeholder.text()).to.equal("This book is not currently on any lists.");
+    });
+
     it("creates a URL based on list ID", () => {
       let url1 = wrapper.instance().makeURL("list 1");
       expect(url1).to.equal("/admin/web/lists/library/edit/1");

--- a/src/components/__tests__/CustomListsForBook-test.tsx
+++ b/src/components/__tests__/CustomListsForBook-test.tsx
@@ -69,8 +69,7 @@ describe("CustomListsForBook", () => {
     it("shows current lists", () => {
       let removable = wrapper.find(WithRemoveButton);
       expect(removable.length).to.equal(1);
-
-      let link = wrapper.find("a");
+      let link = removable.find("a");
       expect(link.length).to.equal(1);
       expect(link.props().href).to.equal("/admin/web/lists/library/edit/2");
       expect(link.text()).to.equal("list 2");
@@ -97,12 +96,49 @@ describe("CustomListsForBook", () => {
       expect(button.prop("content")).to.equal("Add");
     });
 
+    it("does not show the InputList or the divider if no lists exist", () => {
+      let inputList = wrapper.find(InputList);
+      expect(inputList.length).to.equal(1);
+      let dividers = wrapper.find("hr");
+      expect(dividers.length).to.equal(2);
+      wrapper.setProps({ allCustomLists: [] });
+      inputList = wrapper.find(InputList);
+      expect(inputList.length).to.equal(0);
+      dividers = wrapper.find("hr");
+      expect(dividers.length).to.equal(0);
+    });
+
+    it("does not show the divider if all the lists have already been selected", () => {
+      let dividers = wrapper.find("hr");
+      expect(dividers.length).to.equal(2);
+      wrapper.setState({ customLists: wrapper.prop("allCustomLists") });
+      dividers = wrapper.find("hr");
+      expect(dividers.length).to.equal(0);
+    });
+
     it("disables while fetching", () => {
       wrapper.setProps({ isFetching: true });
       let removable = wrapper.find(WithRemoveButton);
       expect(removable.props().disabled).to.equal(true);
       let inputList = wrapper.find(InputList);
       expect(inputList.props().disabled).to.equal(true);
+    });
+
+    it("displays a link to the list creator", () => {
+      let linkDiv = wrapper.find("div").last();
+      let link = linkDiv.find("a");
+      expect(link.prop("href")).to.equal("/admin/web/lists/library/create");
+      expect(link.text()).to.equal("Create a new list");
+      expect(linkDiv.find("p").text()).to.equal(
+        "(The book title will be copied to the clipboard so that you can easily search for it on the list creator page.)"
+      );
+      let copyTitle = stub(wrapper.instance(), "copyTitle").returns(wrapper.prop("book").title);
+      wrapper.setProps({ copyTitle });
+      expect(copyTitle.callCount).to.equal(0);
+      linkDiv.simulate("click");
+      expect(copyTitle.callCount).to.equal(1);
+      expect(copyTitle()).to.equal("test title");
+      copyTitle.restore();
     });
   });
 
@@ -169,11 +205,11 @@ describe("CustomListsForBook", () => {
       expect(removables.length).to.equal(0);
       // Click the submit button to trigger the callback
       wrapper.find(Button).last().simulate("click");
-      // let links = wrapper.find("a");
-      // expect(links.length).to.equal(0);
-      //
+      let links = wrapper.find(WithRemoveButton).find("a");
+      expect(links.length).to.equal(0);
+
       expect(editCustomListsForBook.callCount).to.equal(1);
-      // expect(editCustomListsForBook.args[0][0]).to.equal("admin/works/book url/lists");
+      expect(editCustomListsForBook.args[0][0]).to.equal("admin/works/book url/lists");
       let formData = editCustomListsForBook.args[0][1];
       expect(JSON.parse(formData.get("lists"))).to.deep.equal([]);
     });

--- a/src/components/__tests__/InputList-test.tsx
+++ b/src/components/__tests__/InputList-test.tsx
@@ -238,7 +238,7 @@ describe("InputList", () => {
           <option value={optionName} aria-selected={false}>{optionName}</option>
         );
       };
-      let menuSetting = {...setting, ...{type: "menu", menuOptions: options}};
+      let menuSetting = {...setting, ...{type: "menu", menuOptions: options, description: null }};
       wrapper = mount(
         <InputList
           createEditableInput={createEditableInput}
@@ -302,6 +302,18 @@ describe("InputList", () => {
       requiredText = wrapper.find(".required-field");
       expect(requiredText.length).to.equal(1);
       expect(requiredText.text()).to.equal("Required");
+    });
+    it("optionally renders an alternate value if there are no list items", () => {
+      let placeholder = (wrapper.find(".input-list > span"));
+      expect(placeholder.length).to.equal(0);
+      wrapper.setProps({ altValue: "No list items!" });
+      placeholder = (wrapper.find(".input-list > span"));
+      // There are still list items, so the placeholder isn't rendered yet.
+      expect(placeholder.length).to.equal(0);
+      wrapper.setProps({ value: [] });
+      placeholder = (wrapper.find(".input-list > span"));
+      expect(placeholder.length).to.equal(1);
+      expect(placeholder.text()).to.equal("No list items!");
     });
   });
 });

--- a/src/components/__tests__/InputList-test.tsx
+++ b/src/components/__tests__/InputList-test.tsx
@@ -234,8 +234,9 @@ describe("InputList", () => {
     expect(removables.length).to.equal(0);
   });
   describe("dropdown menu", () => {
+    let options;
     beforeEach(() => {
-      let options = [];
+      options = [];
       while (options.length < 3) {
         let optionName = `Option ${options.length + 1}`;
         options.push(
@@ -318,6 +319,18 @@ describe("InputList", () => {
       placeholder = (wrapper.find(".input-list > span"));
       expect(placeholder.length).to.equal(1);
       expect(placeholder.text()).to.equal("No list items!");
+    });
+    it("optionally renders an alternate value if all the available list items have already been added", () => {
+      wrapper.setProps({
+        value: ["Option 1", "Option 2", "Option 3"],
+        onEmpty: "You've run out of options!",
+        setting: {...wrapper.prop("setting"), ...{ format: "narrow" } }
+      });
+      wrapper.update();
+      let menu = wrapper.find("select");
+      expect(menu.length).to.equal(0);
+      let message = wrapper.find(".add-list-item-container span");
+      expect(message.text()).to.equal("You've run out of options!");
     });
   });
 });

--- a/src/components/__tests__/InputList-test.tsx
+++ b/src/components/__tests__/InputList-test.tsx
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 import * as React from "react";
 import { mount } from "enzyme";
-import { spy, stub } from "sinon";
+import { spy } from "sinon";
 import { Button } from "library-simplified-reusable-components";
 import buildStore from "../../store";
 
@@ -156,7 +156,7 @@ describe("InputList", () => {
     expect(removables.length).to.equal(1);
   });
 
-  it("adds a regular item", () => {
+  it("adds a regular item", async () => {
     let removables = wrapper.find(WithRemoveButton);
     expect(removables.length).to.equal(2);
 
@@ -165,7 +165,9 @@ describe("InputList", () => {
     blankInput.simulate("change");
     let addButton = wrapper.find("button.add-list-item");
     addButton.simulate("click");
+    await new Promise((resolve) => setTimeout(resolve, 0));
 
+    wrapper.update();
     removables = wrapper.find(WithRemoveButton);
     expect(removables.length).to.equal(3);
 
@@ -173,7 +175,7 @@ describe("InputList", () => {
     expect(blankInput.prop("value")).to.equal("");
   });
 
-  it("adds an autocompleted item", () => {
+  it("adds an autocompleted item", async () => {
     let languageSetting = { ...setting, format: "language-code" };
     wrapper.setProps({ setting: languageSetting, value: ["abc"] });
 
@@ -184,6 +186,8 @@ describe("InputList", () => {
     autocomplete.simulate("change");
     let addButton = wrapper.find("button.add-list-item");
     addButton.simulate("click");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    wrapper.update();
 
     removables = wrapper.find(WithRemoveButton);
     expect(removables.length).to.equal(2);

--- a/src/components/__tests__/InputList-test.tsx
+++ b/src/components/__tests__/InputList-test.tsx
@@ -288,5 +288,20 @@ describe("InputList", () => {
       expect(options.length).to.equal(2);
       expect(options.map(o => o.text()).includes("Option 1")).to.be.false;
     });
+    it("optionally renders a label", () => {
+      let settingWithLabel = {...wrapper.prop("setting"), ...{ menuTitle: "Custom Menu Title" }};
+      wrapper.setProps({ setting: settingWithLabel });
+      let label = wrapper.find("select").closest("label");
+      expect(label.text()).to.contain("Custom Menu Title");
+    });
+    it("optionally marks the menu as required", () => {
+      let requiredText = wrapper.find(".required-field");
+      expect(requiredText.length).to.equal(0);
+      let requiredSetting = {...wrapper.prop("setting"), ...{ menuTitle: "title", required: true }};
+      wrapper.setProps({ setting: requiredSetting });
+      requiredText = wrapper.find(".required-field");
+      expect(requiredText.length).to.equal(1);
+      expect(requiredText.text()).to.equal("Required");
+    });
   });
 });

--- a/src/components/__tests__/ProtocolFormField-test.tsx
+++ b/src/components/__tests__/ProtocolFormField-test.tsx
@@ -5,6 +5,7 @@ import { mount } from "enzyme";
 
 import ProtocolFormField from "../ProtocolFormField";
 import EditableInput from "../EditableInput";
+import InputList from "../InputList";
 import ColorPicker from "../ColorPicker";
 import { Button } from "library-simplified-reusable-components";
 
@@ -209,6 +210,21 @@ describe("ProtocolFormField", () => {
     expect(input.at(0).prop("checked")).to.be.ok;
     expect(input.at(1).prop("checked")).not.to.be.ok;
     expect(input.at(2).prop("checked")).to.be.ok;
+  });
+
+  it("renders menu setting", () => {
+    let inputList = wrapper.find(InputList);
+    expect(inputList.length).to.equal(0);
+    let menuSetting = {...setting, ...{
+      type: "menu",
+      menuOptions: ["A", "B", "C"].map(x => <option role="option" aria-selected={false}>{x}</option>)
+    }};
+    wrapper.setProps({ setting: menuSetting, value: [], altValue: "Alternate" });
+    inputList = wrapper.find(InputList);
+    expect(inputList.length).to.equal(1);
+    expect(inputList.prop("setting")).to.equal(menuSetting);
+    expect(inputList.prop("altValue")).to.equal("Alternate");
+    expect(inputList.find("select").length).to.equal(1);
   });
 
   it("renders image setting", () => {

--- a/src/components/__tests__/ProtocolFormField-test.tsx
+++ b/src/components/__tests__/ProtocolFormField-test.tsx
@@ -5,7 +5,6 @@ import { mount } from "enzyme";
 
 import ProtocolFormField from "../ProtocolFormField";
 import EditableInput from "../EditableInput";
-import WithRemoveButton from "../WithRemoveButton";
 import ColorPicker from "../ColorPicker";
 import { Button } from "library-simplified-reusable-components";
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -415,16 +415,10 @@ export interface CustomListsData {
   custom_lists: CustomListData[];
 }
 
-export interface CustomListsSetting {
-  type: string;
-  format?: string;
-  label?: string;
-  key: string | number;
+export interface CustomListsSetting extends SettingData {
   custom_lists: CustomListData[];
-  required?: boolean;
   menuOptions?: JSX.Element[];
   menuTitle?: string;
-  urlBase?: string;
 }
 
 export interface LaneData {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -207,6 +207,7 @@ export interface SettingData {
   options?: SettingData[];
   instructions?: string;
   format?: string;
+  urlBase?: any;
 }
 
 export interface ProtocolData {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -420,7 +420,7 @@ export interface CustomListsSetting {
   format?: string;
   label?: string;
   key: string | number;
-  custom_lists: CustomListsData;
+  custom_lists: CustomListData[];
   required?: boolean;
   menuOptions?: JSX.Element[];
   menuTitle?: string;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -423,6 +423,7 @@ export interface CustomListsSetting {
   custom_lists: CustomListsData;
   required?: boolean;
   menuOptions?: JSX.Element[];
+  menuTitle?: string;
   urlBase?: string;
 }
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -422,6 +422,7 @@ export interface CustomListsSetting {
   custom_lists: CustomListsData;
   required?: boolean;
   menuOptions?: JSX.Element[];
+  urlBase?: string;
 }
 
 export interface LaneData {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -404,6 +404,16 @@ export interface CustomListsData {
   custom_lists: CustomListData[];
 }
 
+export interface CustomListsSetting {
+  type: string;
+  format?: string;
+  label?: string;
+  key: string | number;
+  custom_lists: CustomListsData;
+  required?: boolean;
+  menuOptions?: JSX.Element[];
+}
+
 export interface LaneData {
   id: string | number;
   display_name: string;

--- a/src/stylesheets/app.scss
+++ b/src/stylesheets/app.scss
@@ -22,7 +22,6 @@
 @import "config_tab_container";
 @import "custom_list_editor";
 @import "custom_list_entries_editor";
-@import "custom_list_for_book";
 @import "custom_lists_page";
 @import "custom_lists_sidebar";
 @import "custom_lists";

--- a/src/stylesheets/book_details_container.scss
+++ b/src/stylesheets/book_details_container.scss
@@ -21,6 +21,14 @@
         border: 1px solid darken($gray-tint, 5);
         padding-left: 8px;
       }
+      .add-list-item-container {
+        margin-top: 48px;
+        padding-top: 16px;
+        border-top: 1px solid darken($gray-tint, 25);
+        select {
+          margin-top: 6px;
+        }
+      }
       .btn.add-list-item {
         width: 92px;
       }
@@ -37,6 +45,7 @@
           padding-bottom: 6px;
           margin-bottom: 8px;
           border-bottom: 1px solid $blue;
+          font-weight: bold;
         }
         p {
           font-size: .9em;

--- a/src/stylesheets/book_details_container.scss
+++ b/src/stylesheets/book_details_container.scss
@@ -11,4 +11,46 @@
       fill: $blue;
     }
   }
+  .custom-list-for-book {
+    h3 {
+      margin-bottom: 0;
+    }
+    form {
+      .input-list a {
+        border-radius: .25em;
+        border: 1px solid darken($gray-tint, 5);
+        padding-left: 8px;
+      }
+      .btn.add-list-item {
+        width: 92px;
+      }
+      > span {
+        display: inline-block;
+        margin: 0 10px;
+        color: $dark;
+      }
+      > div:not(.input-list) {
+        margin-top: 16px;
+        a {
+          display: block;
+          width: 100%;
+          padding-bottom: 6px;
+          margin-bottom: 8px;
+          border-bottom: 1px solid $blue;
+        }
+        p {
+          font-size: .9em;
+          margin-bottom: 0;
+        }
+      }
+      hr {
+        display: inline-block;
+        vertical-align: middle;
+        width: 9.7vw;
+        margin: 0;
+        border: none;
+        border-bottom: 1px solid $blue-dark;
+      }
+    }
+  }
 }

--- a/src/stylesheets/book_details_container.scss
+++ b/src/stylesheets/book_details_container.scss
@@ -15,7 +15,7 @@
     h3 {
       margin-bottom: 0;
     }
-    form {
+    .edit-form {
       .input-list a {
         border-radius: .25em;
         border: 1px solid darken($gray-tint, 5);
@@ -51,14 +51,6 @@
           font-size: .9em;
           margin-bottom: 0;
         }
-      }
-      hr {
-        display: inline-block;
-        vertical-align: middle;
-        width: 9.7vw;
-        margin: 0;
-        border: none;
-        border-bottom: 1px solid $blue-dark;
       }
     }
   }

--- a/src/stylesheets/custom_list_for_book.scss
+++ b/src/stylesheets/custom_list_for_book.scss
@@ -1,8 +1,0 @@
-.custom-list-for-book {
-  .with-remove-button {
-    button {
-      font-size: 12px;
-      padding: 5px;
-    }
-  }
-}

--- a/src/stylesheets/input_list.scss
+++ b/src/stylesheets/input_list.scss
@@ -17,7 +17,7 @@
       vertical-align: top;
     }
   }
-  a {
+  .with-remove-button a {
     display: block;
     background: darken($gray-tint, 5);
     padding: 6px 12px;

--- a/src/stylesheets/input_list.scss
+++ b/src/stylesheets/input_list.scss
@@ -1,19 +1,27 @@
-.add-list-item-container {
-  display: flex;
-  flex-direction: row;
-  justify-content: flex-start;
-  align-items: baseline;
+.input-list {
+  .add-list-item-container {
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-start;
+    align-items: baseline;
 
-  span.add-list-item {
-    display: inline-block;
-    margin-right: 10px;
-    width: 193px;
-    .form-group div {
-      width: 100%;
+    span.add-list-item {
+      display: inline-block;
+      margin-right: 10px;
+      width: 193px;
+      .form-group div {
+        width: 100%;
+      }
+    }
+    .btn.add-list-item {
+      vertical-align: top;
     }
   }
-
-  .btn.add-list-item {
-    vertical-align: top;
+  a {
+    display: block;
+    background: darken($gray-tint, 5);
+    padding: 6px 12px;
+    height: 34px;
+    width: 192px;
   }
 }

--- a/src/stylesheets/input_list.scss
+++ b/src/stylesheets/input_list.scss
@@ -9,6 +9,9 @@
       display: inline-block;
       margin-right: 10px;
       width: 193px;
+      &:only-child {
+        width: 100%;
+      }
       .form-group div {
         width: 100%;
       }
@@ -17,11 +20,15 @@
       vertical-align: top;
     }
   }
-  .with-remove-button a {
-    display: block;
-    background: darken($gray-tint, 5);
-    padding: 6px 12px;
-    height: 34px;
-    width: 192px;
+  .input-list-ul {
+    padding: 0;
+    list-style: none;
+    .with-remove-button a {
+      display: block;
+      background: darken($gray-tint, 5);
+      padding: 6px 12px;
+      height: 34px;
+      width: 192px;
+    }
   }
 }

--- a/src/stylesheets/input_list.scss
+++ b/src/stylesheets/input_list.scss
@@ -7,8 +7,12 @@
   span.add-list-item {
     display: inline-block;
     margin-right: 10px;
+    width: 193px;
+    .form-group div {
+      width: 100%;
+    }
   }
-  
+
   .btn.add-list-item {
     vertical-align: top;
   }

--- a/src/stylesheets/with_remove_button.scss
+++ b/src/stylesheets/with_remove_button.scss
@@ -1,4 +1,8 @@
 .with-remove-button {
+  margin: 15px 0;
+  .form-group, .form-control {
+    margin: 0;
+  }
   > span {
     display: inline-block;
     margin-right: 10px;

--- a/src/utils/sharedFunctions.ts
+++ b/src/utils/sharedFunctions.ts
@@ -43,6 +43,6 @@ export function formatString(word: string, replacement?: string[], capitalize = 
   return word;
 }
 
-export function isEqual(array1, array2): boolean {
+export function isEqual(array1: Array<any>, array2: Array<any>): boolean {
   return array1.length === array2.length && array1.every(x => array2.indexOf(x) >= 0);
 }

--- a/src/utils/sharedFunctions.ts
+++ b/src/utils/sharedFunctions.ts
@@ -42,3 +42,7 @@ export function formatString(word: string, replacement?: string[], capitalize = 
   }
   return word;
 }
+
+export function isEqual(array1, array2): boolean {
+  return array1.length === array2.length && array1.every(x => array2.indexOf(x) >= 0);
+}

--- a/src/utils/sharedFunctions.ts
+++ b/src/utils/sharedFunctions.ts
@@ -43,6 +43,7 @@ export function formatString(word: string, replacement?: string[], capitalize = 
   return word;
 }
 
+/** Compares two arrays to see whether they contain the same items.  (The order of the items doesn't matter.) */
 export function isEqual(array1: Array<any>, array2: Array<any>): boolean {
   return array1.length === array2.length && array1.every(x => array2.indexOf(x) >= 0);
 }


### PR DESCRIPTION
Resolves https://jira.nypl.org/browse/SIMPLY-2254

Previous behavior: users could type something other than the name of an actual list into the input field, or just leave the field blank, and submit it with no problems.  As demonstrated by the "before" screenshot, the book would get saved to a "list" whose name was a blank string, or to something that wasn't one of the existing lists.  Among other things, this meant that if users wanted to add the book to an existing list but typed the list's name wrong, they would never know that the book hadn't actually been added to the intended list.  (The previous input field was an autocomplete field, so it did present the names of all the lists, but it still accepted invalid values.)

New behavior: there is a drop-down menu so users can choose from among the existing lists.  The menu choices are automatically narrowed down to include only lists that the book isn't on yet.  (The menu is hidden if the book is on all of the available lists.)  If users want to add the book to a list that doesn't exist yet, there is a link for them to create a new list.  The book's title is automatically copied to the clipboard when they follow the link, so that if it's really long (see the example in the "after" screenshot!), they can just paste it into the list creator's search field rather than having to type it out.  Also, the lists tab is now more consistent with the rest of the interface.

Before:
<img width="600" alt="Screen Shot 2019-10-16 at 4 49 50 PM" src="https://user-images.githubusercontent.com/42178216/67415367-eeaf3180-f592-11e9-9b65-fe7f34498045.png">

After:
<img width="650" alt="Screen Shot 2019-10-23 at 11 09 02 AM" src="https://user-images.githubusercontent.com/42178216/67415403-fec71100-f592-11e9-8fe6-8c1bbfb54c90.png">

In terms of code changes: the lists tab now uses the InputList component (also used for geographic areas and languages in the library edit form).  The InputList now has additional options, which make it more reusable: it can render a dropdown menu, and it can optionally call a callback when individual items are added or deleted (rather than everything being submitted at once, from a Submit button).