### PR TITLE
Fix create and search buttons on Lists page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+###v0.3.24
+#### Fixed
+- Cosmetic fixes for buttons on the Lists page.
+
 ### v0.3.23
 #### Fixed
 - Implemented an automatic search for a title when the link from the book editor Lists tab to the Lists page is used.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.3.23",
+  "version": "0.3.24",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/stylesheets/custom_list_editor.scss
+++ b/src/stylesheets/custom_list_editor.scss
@@ -54,6 +54,7 @@
     }
     button {
       align-self: flex-end;
+      margin-bottom: 4px;
     }
   }
 

--- a/src/stylesheets/custom_lists_sidebar.scss
+++ b/src/stylesheets/custom_lists_sidebar.scss
@@ -4,6 +4,10 @@
   margin: 7px;
   overflow-y: scroll;
 
+  .create-button.centered {
+    font-size: 1.2em;
+  }
+
   .form-group {
     display: inline-block;
     margin-top: 15px;


### PR DESCRIPTION
Resolves https://jira.nypl.org/browse/SIMPLY-2379 (search button weirdly aligned) and https://jira.nypl.org/browse/SIMPLY-2323 (GIANT "create new list" button).

Before:

<img width="707" alt="Screen Shot 2019-11-06 at 4 55 29 PM" src="https://user-images.githubusercontent.com/42178216/68405720-9bbaaa00-014e-11ea-8d1c-8b2e43667d3f.png">
<img width="456" alt="Screen Shot 2019-09-26 at 3 30 46 PM" src="https://user-images.githubusercontent.com/42178216/68406064-24d1e100-014f-11ea-9a2b-83bc317e5ec5.png">

After:

<img width="853" alt="Screen Shot 2019-11-07 at 11 06 37 AM" src="https://user-images.githubusercontent.com/42178216/68405783-b1c86a80-014e-11ea-8451-c320b3375e0b.png">
<img width="446" alt="Screen Shot 2019-11-07 at 11 06 42 AM" src="https://user-images.githubusercontent.com/42178216/68405790-b4c35b00-014e-11ea-9210-8d6fb11d52ba.png">
