### PR TITLE
Updating the context so that pathFor is supported.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Changelog
 
+### v0.4.2
+#### Updated
+- Updated the `opds-web-client` package to v0.3.2.
+- Updated the ContextProvider based on the `opds-web-client`'s updated context APIs.
+
 ### v0.4.1
 #### Fixed
 - Fixed accessibility issues found by the `react-axe` package.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6715,9 +6715,9 @@
       }
     },
     "opds-web-client": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/opds-web-client/-/opds-web-client-0.3.0.tgz",
-      "integrity": "sha512-7+V25VINz8lZOelpeVhfPi9guBILGwIA8XuzsFdOjnIG7JaFbnkMevKA+26Ut/k0qkhao7yk/+pUJ0UJlDedgQ==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/opds-web-client/-/opds-web-client-0.3.2.tgz",
+      "integrity": "sha512-Lrx2wNcfcsEJd4HgstS/vs3LfgUA7cUrfPWPBA8KaldazAVaG6wr3EfZ3iUNP+stmVHNBQVJQVx6fD/hFeHmNg==",
       "requires": {
         "@nypl/dgx-svg-icons": "^0.3.4",
         "dompurify": "^0.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",
@@ -36,7 +36,7 @@
     "library-simplified-reusable-components": "1.3.16",
     "numeral": "^2.0.6",
     "opds-feed-parser": "0.0.17",
-    "opds-web-client": "0.3.0",
+    "opds-web-client": "0.3.2",
     "prop-types": "^15.7.2",
     "qs": "^6.2.0",
     "react": "^16.8.6",

--- a/src/components/CatalogPage.tsx
+++ b/src/components/CatalogPage.tsx
@@ -4,6 +4,7 @@ import { Router, Route, browserHistory } from "react-router";
 const OPDSCatalog = require("opds-web-client");
 import { NavigateContext } from "opds-web-client/lib/interfaces";
 import { ComputeBreadcrumbs } from "opds-web-client/lib/components/Breadcrumbs";
+import PathForProvider from "opds-web-client/lib/components/context/PathForContext";
 import * as PropTypes from "prop-types";
 import reducers from "../reducers/index";
 import BookDetailsContainer from "./BookDetailsContainer";
@@ -13,6 +14,7 @@ import { BookLink } from "../interfaces";
 import computeBreadcrumbs from "../computeBreadcrumbs";
 import EntryPointsContainer from "./EntryPointsContainer";
 import WelcomePage from "./WelcomePage";
+import { PathFor } from "../interfaces";
 
 export interface CatalogPageProps extends React.Props<CatalogPage> {
   params: {
@@ -22,12 +24,20 @@ export interface CatalogPageProps extends React.Props<CatalogPage> {
   };
 }
 
+export interface CatalogPageContext {
+  pathFor: PathFor;
+}
+
 /** Extracts URL parameters and renders the OPDS Web Client for the appropriate catalog
     and book, using the admin interface header and book details wrapper with extra tabs. */
 export default class CatalogPage extends React.Component<CatalogPageProps, {}> {
   static childContextTypes: React.ValidationMap<any> = {
     tab: PropTypes.string,
     library: PropTypes.func
+  };
+
+  static contextTypes: React.ValidationMap<CatalogPageContext> = {
+    pathFor: PropTypes.func.isRequired
   };
 
   getChildContext() {
@@ -58,16 +68,18 @@ export default class CatalogPage extends React.Component<CatalogPageProps, {}> {
 
     return (
       <>
-        <OPDSCatalog
-          collectionUrl={collectionUrl}
-          bookUrl={bookUrl}
-          BookDetailsContainer={BookDetailsContainer}
-          Header={Header}
-          pageTitleTemplate={pageTitleTemplate}
-          computeBreadcrumbs={computeBreadcrumbs}
-          CollectionContainer={EntryPointsContainer}
-          allLanguageSearch={true}
-        />
+        <PathForProvider pathFor={this.context.pathFor}>
+          <OPDSCatalog
+            collectionUrl={collectionUrl}
+            bookUrl={bookUrl}
+            BookDetailsContainer={BookDetailsContainer}
+            Header={Header}
+            pageTitleTemplate={pageTitleTemplate}
+            computeBreadcrumbs={computeBreadcrumbs}
+            CollectionContainer={EntryPointsContainer}
+            allLanguageSearch={true}
+          />
+        </PathForProvider>
         <Footer />
       </>
     );

--- a/src/components/CatalogPage.tsx
+++ b/src/components/CatalogPage.tsx
@@ -1,20 +1,13 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
-import { Router, Route, browserHistory } from "react-router";
 const OPDSCatalog = require("opds-web-client");
-import { NavigateContext } from "opds-web-client/lib/interfaces";
-import { ComputeBreadcrumbs } from "opds-web-client/lib/components/Breadcrumbs";
-import PathForProvider from "opds-web-client/lib/components/context/PathForContext";
 import * as PropTypes from "prop-types";
-import reducers from "../reducers/index";
 import BookDetailsContainer from "./BookDetailsContainer";
 import Header from "./Header";
 import Footer from "./Footer";
-import { BookLink } from "../interfaces";
 import computeBreadcrumbs from "../computeBreadcrumbs";
 import EntryPointsContainer from "./EntryPointsContainer";
 import WelcomePage from "./WelcomePage";
-import { PathFor } from "../interfaces";
 
 export interface CatalogPageProps extends React.Props<CatalogPage> {
   params: {
@@ -24,20 +17,12 @@ export interface CatalogPageProps extends React.Props<CatalogPage> {
   };
 }
 
-export interface CatalogPageContext {
-  pathFor: PathFor;
-}
-
 /** Extracts URL parameters and renders the OPDS Web Client for the appropriate catalog
     and book, using the admin interface header and book details wrapper with extra tabs. */
 export default class CatalogPage extends React.Component<CatalogPageProps, {}> {
   static childContextTypes: React.ValidationMap<any> = {
     tab: PropTypes.string,
     library: PropTypes.func
-  };
-
-  static contextTypes: React.ValidationMap<CatalogPageContext> = {
-    pathFor: PropTypes.func.isRequired
   };
 
   getChildContext() {
@@ -68,18 +53,16 @@ export default class CatalogPage extends React.Component<CatalogPageProps, {}> {
 
     return (
       <>
-        <PathForProvider pathFor={this.context.pathFor}>
-          <OPDSCatalog
-            collectionUrl={collectionUrl}
-            bookUrl={bookUrl}
-            BookDetailsContainer={BookDetailsContainer}
-            Header={Header}
-            pageTitleTemplate={pageTitleTemplate}
-            computeBreadcrumbs={computeBreadcrumbs}
-            CollectionContainer={EntryPointsContainer}
-            allLanguageSearch={true}
-          />
-        </PathForProvider>
+        <OPDSCatalog
+          collectionUrl={collectionUrl}
+          bookUrl={bookUrl}
+          BookDetailsContainer={BookDetailsContainer}
+          Header={Header}
+          pageTitleTemplate={pageTitleTemplate}
+          computeBreadcrumbs={computeBreadcrumbs}
+          CollectionContainer={EntryPointsContainer}
+          allLanguageSearch={true}
+        />
         <Footer />
       </>
     );

--- a/src/components/ContextProvider.tsx
+++ b/src/components/ContextProvider.tsx
@@ -5,8 +5,9 @@ import buildStore from "../store";
 import { PathFor } from "../interfaces";
 import { State } from "../reducers/index";
 import Admin from "../models/Admin";
+import PathForProvider from "opds-web-client/lib/components/context/PathForContext";
 
-export interface ContextProviderProps extends React.Props<any> {
+export interface ContextProviderProps extends React.Props<{}> {
   csrfToken: string;
   showCircEventsDownload?: boolean;
   settingUp?: boolean;
@@ -63,9 +64,8 @@ export default class ContextProvider extends React.Component<ContextProviderProp
     }
   }
 
-  static childContextTypes: React.ValidationMap<any> = {
+  static childContextTypes: React.ValidationMap<{}> = {
     editorStore: PropTypes.object.isRequired,
-    pathFor: PropTypes.func.isRequired,
     csrfToken: PropTypes.string.isRequired,
     showCircEventsDownload: PropTypes.bool.isRequired,
     settingUp: PropTypes.bool.isRequired,
@@ -75,7 +75,6 @@ export default class ContextProvider extends React.Component<ContextProviderProp
   getChildContext() {
     return {
       editorStore: this.store,
-      pathFor: this.pathFor,
       csrfToken: this.props.csrfToken,
       showCircEventsDownload: this.props.showCircEventsDownload || false,
       settingUp: this.props.settingUp || false,
@@ -84,6 +83,10 @@ export default class ContextProvider extends React.Component<ContextProviderProp
   }
 
   render() {
-    return React.Children.only(this.props.children) as JSX.Element;
+    return (
+      <PathForProvider pathFor={this.pathFor}>
+        {React.Children.only(this.props.children) as JSX.Element}
+      </PathForProvider>
+    );
   }
 }

--- a/src/components/__tests__/ContextProvider-test.tsx
+++ b/src/components/__tests__/ContextProvider-test.tsx
@@ -1,16 +1,20 @@
 import { expect } from "chai";
 
 import * as React from "react";
-import { shallow } from "enzyme";
+import { shallow, mount } from "enzyme";
 import * as jsdom from "jsdom";
 
 import ContextProvider from "../ContextProvider";
 import Admin from "../../models/Admin";
+import * as PropTypes from "prop-types";
+import { stub } from "sinon";
 
-class FakeChild extends React.Component<any, any> {}
+class FakeChild extends React.Component<{}, {}> {}
 
 describe("ContextProvider", () => {
   let wrapper;
+  let instance;
+  let pathFor;
 
   beforeEach(() => {
     wrapper = shallow(
@@ -18,17 +22,18 @@ describe("ContextProvider", () => {
         csrfToken="token"
         roles={ [{ "role": "system" }] }
         email="email"
-        >
+      >
         <FakeChild />
       </ContextProvider>
     );
+    instance = wrapper.instance();
+    pathFor = instance.pathFor;
   });
 
   it("provides child context", () => {
-    let context = wrapper.instance().getChildContext();
+    let context = instance.getChildContext();
     expect(context.editorStore.getState().editor).to.be.ok;
     expect(context.editorStore.getState().catalog).to.be.ok;
-    expect(context.pathFor).to.equal(wrapper.instance().pathFor);
     expect(context.csrfToken).to.equal("token");
     expect(context.settingUp).not.to.be.ok;
     expect(context.admin instanceof Admin).to.be.ok;
@@ -41,64 +46,98 @@ describe("ContextProvider", () => {
     expect(children.length).to.equal(1);
   });
 
-  describe("pathFor", () => {
+  it("should pass down the pathFor function down to the child as context", () => {
+    const hasAccess = "has access to pathFor context";
+    let pathForStub = stub();
+    class MockContextProvider extends ContextProvider {
+      constructor(props) {
+        super(props);
+        this.pathFor = pathForStub;
+      }
+    }
+
+    class Child extends React.Component<{}, {}> {
+      static contextTypes = {
+        pathFor: PropTypes.func.isRequired
+      };
+      render() {
+        const hasContext = this.context?.pathFor === pathForStub;
+        return (
+          <div>
+            {hasContext ? hasAccess : "doesn't have access to context"}
+          </div>
+        );
+      }
+    }
+
+    let mockProvider = mount(
+      <MockContextProvider csrfToken="token">
+        <Child />
+      </MockContextProvider>
+    );
+
+    expect(mockProvider.text()).to.equal(hasAccess);
+  });
+
+  describe("class methods", () => {
     let collectionUrl = "collection/url";
     let bookUrl = "book/url";
     let tab = "tab";
 
-    it("prepares collection url", () => {
-      let host = "http://example.com";
-      (jsdom as any).changeURL(window, host + "/test");
-      let url = host + "/groups/eng/Adult%20Fiction";
-      expect(wrapper.instance().prepareCollectionUrl(url)).to.equal("groups%2Feng%2FAdult%2520Fiction");
+    describe("prepareCollectionUrl", () => {
+      it("prepares collection url", () => {
+        let host = "http://example.com";
+        (jsdom as any).changeURL(window, host + "/test");
+        let url = host + "/groups/eng/Adult%20Fiction";
+        expect(instance.prepareCollectionUrl(url)).to.equal("groups%2Feng%2FAdult%2520Fiction");
+      });
     });
 
-    it("prepares book url", () => {
-      let host = "http://example.com";
-      (jsdom as any).changeURL(window, host + "/test");
-      let url = host + "/library/works/Axis%20360/Axis%20360%20ID/0016201449";
-      expect(wrapper.instance().prepareBookUrl(url)).to.equal("library%2FAxis%2520360%2FAxis%2520360%2520ID%2F0016201449");
+    describe("prepareBookUrl", () => {
+      it("prepares book url", () => {
+        let host = "http://example.com";
+        (jsdom as any).changeURL(window, host + "/test");
+        let url = host + "/library/works/Axis%20360/Axis%20360%20ID/0016201449";
+        expect(instance.prepareBookUrl(url)).to.equal("library%2FAxis%2520360%2FAxis%2520360%2520ID%2F0016201449");
+      });
     });
 
-    it("returns a path with collection, book, and tab", () => {
-      let instance = wrapper.instance();
-      let path = instance.pathFor(collectionUrl, bookUrl, tab);
-      expect(path).to.equal(
-        `/admin/web/collection/${instance.prepareCollectionUrl(collectionUrl)}` +
-        `/book/${instance.prepareBookUrl(bookUrl)}/tab/${tab}`
-      );
-    });
+    describe("pathFor", () => {
+      it("returns a path with collection, book, and tab", () => {
+        let path = pathFor(collectionUrl, bookUrl, tab);
+        expect(path).to.equal(
+          `/admin/web/collection/${instance.prepareCollectionUrl(collectionUrl)}` +
+          `/book/${instance.prepareBookUrl(bookUrl)}/tab/${tab}`
+        );
+      });
 
-    it("returns a path with collection and book", () => {
-      let instance = wrapper.instance();
-      let path = instance.pathFor(collectionUrl, bookUrl, null);
-      expect(path).to.equal(
-        `/admin/web/collection/${instance.prepareCollectionUrl(collectionUrl)}` +
-        `/book/${instance.prepareBookUrl(bookUrl)}`
-      );
-    });
+      it("returns a path with collection and book", () => {
+        let path = pathFor(collectionUrl, bookUrl, null);
+        expect(path).to.equal(
+          `/admin/web/collection/${instance.prepareCollectionUrl(collectionUrl)}` +
+          `/book/${instance.prepareBookUrl(bookUrl)}`
+        );
+      });
 
-    it("returns a path with only collection", () => {
-      let instance = wrapper.instance();
-      let path = instance.pathFor(collectionUrl, null, null);
-      expect(path).to.equal(`/admin/web/collection/${instance.prepareCollectionUrl(collectionUrl)}`);
-    });
+      it("returns a path with only collection", () => {
+        let path = pathFor(collectionUrl, null, null);
+        expect(path).to.equal(`/admin/web/collection/${instance.prepareCollectionUrl(collectionUrl)}`);
+      });
 
-    it("returns a path with only book", () => {
-      let instance = wrapper.instance();
-      let path = instance.pathFor(null, bookUrl, null);
-      expect(path).to.equal(`/admin/web/book/${instance.prepareBookUrl(bookUrl)}`);
-    });
+      it("returns a path with only book", () => {
+        let path = pathFor(null, bookUrl, null);
+        expect(path).to.equal(`/admin/web/book/${instance.prepareBookUrl(bookUrl)}`);
+      });
 
-    it("returns a path with book and tab", () => {
-      let instance = wrapper.instance();
-      let path = instance.pathFor(null, bookUrl, tab);
-      expect(path).to.equal(`/admin/web/book/${instance.prepareBookUrl(bookUrl)}/tab/${tab}`);
-    });
+      it("returns a path with book and tab", () => {
+        let path = pathFor(null, bookUrl, tab);
+        expect(path).to.equal(`/admin/web/book/${instance.prepareBookUrl(bookUrl)}/tab/${tab}`);
+      });
 
-    it("returns a path with no collection, book, or tab", () => {
-      let path = wrapper.instance().pathFor(null, null, null);
-      expect(path).to.equal(`/admin/web`);
+      it("returns a path with no collection, book, or tab", () => {
+        let path = pathFor(null, null, null);
+        expect(path).to.equal(`/admin/web`);
+      });
     });
   });
 });


### PR DESCRIPTION
This fixes the issue found when trying to import the `logic-components` branch from the `opds-web-client` into this app. This was an issue raised in PR [opds-web-client #248](https://github.com/NYPL-Simplified/opds-web-client/pull/248). I haven't updated the version or changelog, but will do so after some feedback. It seems this is the minimum required to make everything work.