### PR TITLE
Metadata self tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v0.4.3
+#### Added
+- Added a Metadata Services tab to the self-tests section of the Troubleshooting page.
+
 ### v0.4.2
 #### Updated
 - Updated the `opds-web-client` package to v0.3.2.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 #### Added
 - Added a Metadata Services tab to the self-tests section of the Troubleshooting page.
 
-### v0.4.2
+### v0.4.2`
 #### Updated
 - Updated the `opds-web-client` package to v0.3.2.
 - Updated the ContextProvider based on the `opds-web-client`'s updated context APIs.
@@ -22,7 +22,7 @@
 #### Updated
 - Updated npm packages including chai, mocha, and sinon.
 - Updated version of Node to run in Travis to Node v10.
-#### Fixed
+#### Fixed``
 - Fixed tests that were passing in Node v8 but failing in Node v10. Specifically, stubbing window.confirm did not work on components that were fully mounted. A shallow mount helped fix this issue, but the tests needed to be updated accordingly.
 
 ### v0.3.26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 #### Added
 - Added a Metadata Services tab to the self-tests section of the Troubleshooting page.
 
-### v0.4.2`
+### v0.4.2
 #### Updated
 - Updated the `opds-web-client` package to v0.3.2.
 - Updated the ContextProvider based on the `opds-web-client`'s updated context APIs.
@@ -22,7 +22,7 @@
 #### Updated
 - Updated npm packages including chai, mocha, and sinon.
 - Updated version of Node to run in Travis to Node v10.
-#### Fixed``
+#### Fixed
 - Fixed tests that were passing in Node v8 but failing in Node v10. Specifically, stubbing window.confirm did not work on components that were fully mounted. A shallow mount helped fix this issue, but the tests needed to be updated accordingly.
 
 ### v0.3.26

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/components/MetadataServices.tsx
+++ b/src/components/MetadataServices.tsx
@@ -1,3 +1,4 @@
+import * as React from "react";
 import EditableConfigList, { EditableConfigListStateProps, EditableConfigListDispatchProps, EditableConfigListOwnProps } from "./EditableConfigList";
 import { connect } from "react-redux";
 import ActionCreator from "../actions";
@@ -14,11 +15,22 @@ export class MetadataServices extends EditableConfigList<MetadataServicesData, M
   urlBase = "/admin/web/config/metadata/";
   identifierKey = "id";
   labelKey = "protocol";
+  links = this.renderLinks();
 
+  renderLinks(): {[key: string]: JSX.Element} {
+    let linkBase = "/admin/web/troubleshooting/self-tests/metadataServices";
+    let linkElement = <a href={linkBase}>the troubleshooting page</a>;
+    return {
+      "info": <>Self-tests for the metadata services have been moved to {linkElement}.</>,
+      "footer": <>Problems with your metadata services?  Please visit {linkElement}.</>
+    };
+  }
   label(item): string {
     let label = item.name ? `${item.name}: ${item.protocol}` : item.protocol;
     return label;
   }
+
+
 }
 
 function mapStateToProps(state, ownProps) {

--- a/src/components/MetadataServices.tsx
+++ b/src/components/MetadataServices.tsx
@@ -29,8 +29,6 @@ export class MetadataServices extends EditableConfigList<MetadataServicesData, M
     let label = item.name ? `${item.name}: ${item.protocol}` : item.protocol;
     return label;
   }
-
-
 }
 
 function mapStateToProps(state, ownProps) {

--- a/src/components/SelfTestResult.tsx
+++ b/src/components/SelfTestResult.tsx
@@ -15,7 +15,6 @@ export default class SelfTestResult extends React.Component<SelfTestResultProps,
   }
 
   render() {
-    console.log(this.props);
     const colorResultClass = this.props.result.success ? "success" : "failure";
     return (
       <li className={this.props.isFetching ? "loading-self-test" : colorResultClass} key={this.props.result.name}>

--- a/src/components/SelfTestResult.tsx
+++ b/src/components/SelfTestResult.tsx
@@ -15,6 +15,7 @@ export default class SelfTestResult extends React.Component<SelfTestResultProps,
   }
 
   render() {
+    console.log(this.props);
     const colorResultClass = this.props.result.success ? "success" : "failure";
     return (
       <li className={this.props.isFetching ? "loading-self-test" : colorResultClass} key={this.props.result.name}>
@@ -33,7 +34,7 @@ export default class SelfTestResult extends React.Component<SelfTestResultProps,
           success: {`${this.props.result.success}`}
         </p>
         {
-          !this.props.result.success && (
+          !this.props.result.success && this.props.result.exception && (
             <p className="exception-description">
               exception: {this.props.result.exception.message}
             </p>

--- a/src/components/SelfTestResult.tsx
+++ b/src/components/SelfTestResult.tsx
@@ -45,7 +45,6 @@ export default class SelfTestResult extends React.Component<SelfTestResultProps,
 
   renderResult(result, colorResultClass) {
     let isList = Array.isArray(result);
-
     let content = isList ?
       <ol>{result.map((item, idx) => <li key={idx}>{item}</li>)}</ol> :
       result;

--- a/src/components/SelfTests.tsx
+++ b/src/components/SelfTests.tsx
@@ -40,6 +40,9 @@ export interface SelfTestsState {
 }
 
 export class SelfTests extends React.Component<SelfTestsProps, SelfTestsState> {
+  static defaultProps = {
+    sortByCollection: false
+  };
   constructor(props: SelfTestsProps) {
     super(props);
 

--- a/src/components/SelfTests.tsx
+++ b/src/components/SelfTests.tsx
@@ -155,8 +155,8 @@ function mapStateToProps(state, ownProps) {
   let item = ownProps.item;
   if (selfTests && selfTests.responseBody && selfTests.responseBody.self_test_results) {
     if (ownProps.type.includes(selfTests.responseBody.self_test_results.goal)) {
-      let oldTime = ownProps.item.self_test_results.start;
-      let newTime = selfTests.responseBody.self_test_results.self_test_results.start;
+      let oldTime = item.self_test_results && item.self_test_results.start;
+      let newTime = selfTests.responseBody.self_test_results.self_test_results && selfTests.responseBody.self_test_results.self_test_results.start;
       if (!oldTime || (newTime > oldTime)) {
         item = selfTests.responseBody.self_test_results;
       }

--- a/src/components/SelfTests.tsx
+++ b/src/components/SelfTests.tsx
@@ -104,7 +104,7 @@ export class SelfTests extends React.Component<SelfTestsProps, SelfTestsState> {
     );
 
     let resultList: JSX.Element[] = results.length ? results.map((result, idx) => this.makeResult(result, idx, isFetching)) : null;
-    let shouldSortByCollection: boolean = results.length && integration.goal && integration.goal === "metadata";
+    let shouldSortByCollection: boolean = results.length && (integration.goal && integration.goal === "metadata") || (integration.protocol && integration.protocol === "Metadata Wrangler");
     let collectionList = shouldSortByCollection && this.displayMetadata(results, isFetching);
 
     return (
@@ -187,7 +187,7 @@ function mapStateToProps(state, ownProps) {
     if (ownProps.type.includes(selfTests.responseBody.self_test_results.goal)) {
       let oldTime = item.self_test_results && item.self_test_results.start;
       let newTime = selfTests.responseBody.self_test_results.self_test_results && selfTests.responseBody.self_test_results.self_test_results.start;
-      if (!oldTime || (newTime > oldTime)) {
+      if (!oldTime || (newTime > oldTime) && selfTests.responseBody.self_test_results.id === item.id) {
         item = selfTests.responseBody.self_test_results;
       }
     }

--- a/src/components/SelfTestsCategory.tsx
+++ b/src/components/SelfTestsCategory.tsx
@@ -17,12 +17,24 @@ export default class SelfTestsCategory extends React.Component<SelfTestsCategory
 
   render(): JSX.Element {
     let onlyChild = this.props.items && this.props.items.length === 1;
+    let results = (item: ServiceData) => item.self_test_results && item.self_test_results.results || [];
+    let sortByCollection = (item: ServiceData): boolean => results(item).some(r => r.collection);
     let getClassName = (item: ServiceData): string => {
-      let results = item.self_test_results && item.self_test_results.results;
-      return results ? (results.every(r => r.success) ? "success" : "danger") : "default";
+      return results(item).length ? (results(item).every(r => r.success) ? "success" : "danger") : "default";
     };
-    let link = (item: ServiceData): JSX.Element => <a key={item.id} href={`/admin/web/config/${this.props.linkName}/edit/${item.id}`}>{item.name} configuration settings</a>;
-    let selfTests = (item: ServiceData): JSX.Element => <SelfTests key={item.name} store={this.props.store} type={this.props.type} item={item} csrfToken={this.props.csrfToken} />;
+    let link = (item: ServiceData): JSX.Element =>
+      <a key={item.id} href={`/admin/web/config/${this.props.linkName}/edit/${item.id}`}>
+        {item.name} configuration settings
+      </a>;
+    let selfTests = (item: ServiceData): JSX.Element =>
+      <SelfTests
+        key={item.name}
+        store={this.props.store}
+        type={this.props.type}
+        item={item}
+        csrfToken={this.props.csrfToken}
+        sortByCollection={sortByCollection(item)}
+      />;
     return (
       <div className="self-tests-category has-additional-content">
         <ul>

--- a/src/components/SelfTestsCategory.tsx
+++ b/src/components/SelfTestsCategory.tsx
@@ -18,9 +18,11 @@ export default class SelfTestsCategory extends React.Component<SelfTestsCategory
   render(): JSX.Element {
     let onlyChild = this.props.items && this.props.items.length === 1;
     let results = (item: ServiceData) => item.self_test_results && item.self_test_results.results || [];
-    let sortByCollection = (item: ServiceData): boolean => results(item).some(r => r.collection);
+    let items = {};
+    this.props.items && this.props.items.map(i => items[i.name] ? items[i.name].concat(results(i)) : items[i.name] = results(i));
+    let sortByCollection = (item: ServiceData): boolean => items[item.name].some(r => r.collection);
     let getClassName = (item: ServiceData): string => {
-      return results(item).length ? (results(item).every(r => r.success) ? "success" : "danger") : "default";
+      return items[item.name].length ? (items[item.name].every(r => r.success) ? "success" : "danger") : "default";
     };
     let link = (item: ServiceData): JSX.Element =>
       <a key={item.id} href={`/admin/web/config/${this.props.linkName}/edit/${item.id}`}>

--- a/src/components/SelfTestsTabContainer.tsx
+++ b/src/components/SelfTestsTabContainer.tsx
@@ -39,7 +39,8 @@ export class SelfTestsTabContainer extends TabContainer<SelfTestsTabContainerPro
   DISPLAY_NAMES = {
     collections: "Collections",
     patronAuthServices: "Patron Authentication",
-    searchServices: "Search Service Configuration"
+    searchServices: "Search Service Configuration",
+    metadataServices: "Metadata Services"
   };
 
   componentWillMount() {
@@ -104,7 +105,7 @@ function mapStateToProps(state, ownProps: SelfTestsTabContainerOwnProps) {
 
 function mapDispatchToProps(dispatch: Function, ownProps: SelfTestsTabContainerOwnProps) {
   let actions = new ActionCreator();
-  const itemTypes = ["Collections", "PatronAuthServices", "SearchServices"];
+  const itemTypes = ["Collections", "PatronAuthServices", "SearchServices", "MetadataServices"];
   return {
     fetchItems: () => itemTypes.forEach(type => dispatch(actions["fetch" + type]()))
   };

--- a/src/components/TroubleshootingPage.tsx
+++ b/src/components/TroubleshootingPage.tsx
@@ -34,7 +34,7 @@ export default class TroubleshootingPage extends React.Component<Troubleshooting
 
   CATEGORIES = {
     "diagnostics": ["coverage_provider", "script", "monitor", "other"],
-    "self-tests": ["collections", "patronAuthServices", "searchServices"]
+    "self-tests": ["collections", "patronAuthServices", "searchServices", "metadataServices"]
   };
 
   constructor(props) {

--- a/src/components/__tests__/ContextProvider-test.tsx
+++ b/src/components/__tests__/ContextProvider-test.tsx
@@ -61,7 +61,7 @@ describe("ContextProvider", () => {
         pathFor: PropTypes.func.isRequired
       };
       render() {
-        const hasContext = this.context?.pathFor === pathForStub;
+        const hasContext = this.context && this.context.pathFor === pathForStub;
         return (
           <div>
             {hasContext ? hasAccess : "doesn't have access to context"}

--- a/src/components/__tests__/SelfTests-test.tsx
+++ b/src/components/__tests__/SelfTests-test.tsx
@@ -130,14 +130,13 @@ describe("SelfTests", () => {
         item={collections[0]}
         type="collection"
         getSelfTests={stub()}
-        sortByCollection={false}
       />
     );
   });
 
   it("should render the SelfTests component with empty self_test_results", () => {
     wrapper = shallow(
-      <SelfTests item={{} as any} type="collection" getSelfTests={stub()} sortByCollection={false} />
+      <SelfTests item={{} as any} type="collection" getSelfTests={stub()} />
     );
     expect(wrapper.render().hasClass("integration-selftests")).to.equal(true);
     expect(wrapper.find("ul").length).to.equal(0);
@@ -149,7 +148,7 @@ describe("SelfTests", () => {
     let self_test_results = {...collections[0].self_test_results, ...{exception}};
     let item = {...collections[0], ...{self_test_results}};
     wrapper = shallow(
-      <SelfTests item={item} type="collection" getSelfTests={stub()} sortByCollection={false} />
+      <SelfTests item={item} type="collection" getSelfTests={stub()} />
     );
     expect(wrapper.render().hasClass("integration-selftests")).to.equal(true);
     expect(wrapper.find("ul").length).to.equal(0);
@@ -202,7 +201,7 @@ describe("SelfTests", () => {
     beforeEach(() => {
       wrapper = mount(
         <SelfTests
-          item={collections[1]} type="collection" getSelfTests={stub()} sortByCollection={false}
+          item={collections[1]} type="collection" getSelfTests={stub()}
         />
       );
     });
@@ -210,7 +209,7 @@ describe("SelfTests", () => {
     it("should display the base error message when attempting to run self tests", () => {
       wrapper = shallow(
         <SelfTests
-          item={collections[2]} type="collection" getSelfTests={stub()} sortByCollection={false}
+          item={collections[2]} type="collection" getSelfTests={stub()}
         />
       );
 
@@ -261,7 +260,6 @@ describe("SelfTests", () => {
           type="collection"
           runSelfTests={runSelfTests}
           getSelfTests={getSelfTests}
-          sortByCollection={false}
         />
       );
     });
@@ -290,7 +288,6 @@ describe("SelfTests", () => {
           type="collection"
           runSelfTests={runSelfTests}
           getSelfTests={getSelfTests}
-          sortByCollection={false}
         />
       );
       let runSelfTestsBtn = wrapper.find("button").findWhere(el => el.text() === "Run tests").at(0);

--- a/src/components/__tests__/SelfTests-test.tsx
+++ b/src/components/__tests__/SelfTests-test.tsx
@@ -143,9 +143,25 @@ describe("SelfTests", () => {
     expect(wrapper.find("p").text()).to.equal("No self test results found.");
   });
 
+  it("should render the SelfTests component for new services", () => {
+    let exception = "This integration has no attribute 'prior_test_results'";
+    let self_test_results = {...collections[0].self_test_results, ...{exception}};
+    let item = {...collections[0], ...{self_test_results}};
+    wrapper = shallow(
+      <SelfTests item={item} type="collection" getSelfTests={stub()} />
+    );
+    expect(wrapper.render().hasClass("integration-selftests")).to.equal(true);
+    expect(wrapper.find("ul").length).to.equal(0);
+    expect(wrapper.find(".description").text()).to.equal("There are no self test results yet.");
+  });
+
   it("should render the SelfTests component with results", () => {
     expect(wrapper.render().hasClass("integration-selftests")).to.equal(true);
     expect(wrapper.find("ul").length).to.equal(1);
+  });
+
+  it("should format the date and duration of the most recent tests", () => {
+    expect(wrapper.instance().formatDate(collections[0])).to.equal("Tests last ran on Tue Aug 07 2018 15:34:54 and lasted 1.75s.");
   });
 
   it("should handle new props", () => {

--- a/src/components/__tests__/SelfTests-test.tsx
+++ b/src/components/__tests__/SelfTests-test.tsx
@@ -130,13 +130,14 @@ describe("SelfTests", () => {
         item={collections[0]}
         type="collection"
         getSelfTests={stub()}
+        sortByCollection={false}
       />
     );
   });
 
   it("should render the SelfTests component with empty self_test_results", () => {
     wrapper = shallow(
-      <SelfTests item={{} as any} type="collection" getSelfTests={stub()} />
+      <SelfTests item={{} as any} type="collection" getSelfTests={stub()} sortByCollection={false} />
     );
     expect(wrapper.render().hasClass("integration-selftests")).to.equal(true);
     expect(wrapper.find("ul").length).to.equal(0);
@@ -148,7 +149,7 @@ describe("SelfTests", () => {
     let self_test_results = {...collections[0].self_test_results, ...{exception}};
     let item = {...collections[0], ...{self_test_results}};
     wrapper = shallow(
-      <SelfTests item={item} type="collection" getSelfTests={stub()} />
+      <SelfTests item={item} type="collection" getSelfTests={stub()} sortByCollection={false} />
     );
     expect(wrapper.render().hasClass("integration-selftests")).to.equal(true);
     expect(wrapper.find("ul").length).to.equal(0);
@@ -201,7 +202,7 @@ describe("SelfTests", () => {
     beforeEach(() => {
       wrapper = mount(
         <SelfTests
-          item={collections[1]} type="collection" getSelfTests={stub()}
+          item={collections[1]} type="collection" getSelfTests={stub()} sortByCollection={false}
         />
       );
     });
@@ -209,7 +210,7 @@ describe("SelfTests", () => {
     it("should display the base error message when attempting to run self tests", () => {
       wrapper = shallow(
         <SelfTests
-          item={collections[2]} type="collection" getSelfTests={stub()}
+          item={collections[2]} type="collection" getSelfTests={stub()} sortByCollection={false}
         />
       );
 
@@ -260,6 +261,7 @@ describe("SelfTests", () => {
           type="collection"
           runSelfTests={runSelfTests}
           getSelfTests={getSelfTests}
+          sortByCollection={false}
         />
       );
     });
@@ -288,6 +290,7 @@ describe("SelfTests", () => {
           type="collection"
           runSelfTests={runSelfTests}
           getSelfTests={getSelfTests}
+          sortByCollection={false}
         />
       );
       let runSelfTestsBtn = wrapper.find("button").findWhere(el => el.text() === "Run tests").at(0);
@@ -322,21 +325,22 @@ describe("SelfTests", () => {
         success: success
       }};
     };
-    let f = (results) => wrapper.instance().displayMetadata(results, false);
+    let display = (results) => wrapper.instance().displayByCollection(results, false);
     it("should call displayMetadata", () => {
-      let spyDisplayMetadata = spy(wrapper.instance(), "displayMetadata");
-      expect(spyDisplayMetadata.callCount).to.equal(0);
+      let spyDisplayByCollection = spy(wrapper.instance(), "displayByCollection");
+      expect(spyDisplayByCollection.callCount).to.equal(0);
       let integration = {...collections[0], ...{goal: "metadata"}};
       wrapper.setState({ mostRecent: integration });
-      expect(spyDisplayMetadata.callCount).to.equal(1);
-      expect(spyDisplayMetadata.args[0][0][0]).to.equal(baseResult);
-      spyDisplayMetadata.restore();
+      wrapper.setProps({ sortByCollection: true });
+      expect(spyDisplayByCollection.callCount).to.equal(1);
+      expect(spyDisplayByCollection.args[0][0][0]).to.equal(baseResult);
+      spyDisplayByCollection.restore();
     });
     it("should sort metadata test results by their collection", () => {
       while (results.length < collectionNames.length * 2) {
         collectionNames.map(c => results.push(makeResult(c)));
       }
-      let collectionPanels = f(results);
+      let collectionPanels = display(results);
       expect(collectionPanels.length).to.equal(collectionNames.length);
       collectionPanels.map((panel: JSX.Element, idx: number) => {
         let collectionName = collectionNames[idx];
@@ -351,13 +355,13 @@ describe("SelfTests", () => {
     });
     it("should display the result of the initial setup test", () => {
       let initialResult = makeResult("undefined");
-      let panel = f([initialResult])[0];
+      let panel = display([initialResult])[0];
       expect(panel.props.headerText).to.equal("Initial Setup");
     });
     it("should add the 'danger' class if not all the tests for the collection succeeded", () => {
       let errorResult = makeResult("With Error", false);
       let successResult = makeResult("With Error");
-      let panel = f([errorResult, successResult])[0];
+      let panel = display([errorResult, successResult])[0];
       expect(panel.props.style).to.equal("danger");
     });
   });

--- a/src/components/__tests__/SelfTestsCategory-test.tsx
+++ b/src/components/__tests__/SelfTestsCategory-test.tsx
@@ -112,4 +112,16 @@ describe("SelfTestsCategory", () => {
     let singleItem = wrapper.find("ul").first().find(Panel);
     expect(singleItem.prop("openByDefault")).to.be.true;
   });
+
+  it("passes the sortByCollection prop to SelfTests", () => {
+    let selfTests = wrapper.find(SelfTests).at(0);
+    expect(selfTests.prop("sortByCollection")).to.be.false;
+    let inner = {...collections[0].self_test_results.results, ...{collection: "sort!"}};
+    let outer = {...collections[0].self_test_results, ...{results: [inner]}};
+    let withCollection = {...collections[0], ...({self_test_results: outer})};
+    (collections as any).unshift(withCollection);
+    wrapper.setProps({ items: collections });
+    selfTests = wrapper.find(SelfTests).at(0);
+    expect(selfTests.prop("sortByCollection")).to.be.true;
+  });
 });

--- a/src/components/__tests__/SelfTestsTabContainer-test.tsx
+++ b/src/components/__tests__/SelfTestsTabContainer-test.tsx
@@ -61,7 +61,7 @@ describe("SelfTestsTabContainer", () => {
     let nav = wrapper.find(".nav-tabs").at(0);
     expect(nav.length).to.equal(1);
     let tabs = nav.find("li");
-    expect(tabs.length).to.equal(3);
+    expect(tabs.length).to.equal(4);
 
     let collectionsTab = tabs.at(0);
     expect(collectionsTab.text()).to.equal("Collections");
@@ -74,12 +74,16 @@ describe("SelfTestsTabContainer", () => {
     let searchTab = tabs.at(2);
     expect(searchTab.text()).to.equal("Search Service Configuration");
     expect(searchTab.hasClass("active")).to.be.false;
+
+    let metadataTab = tabs.at(3);
+    expect(metadataTab.text()).to.equal("Metadata Services");
+    expect(metadataTab.hasClass("active")).to.be.false;
   });
 
   it("renders tab content", () => {
     let contentComponents = wrapper.find(".tab-content > div");
-    expect(contentComponents.length).to.equal(3);
-    let [collectionsContent, patronAuthContent, searchContent] = contentComponents.map(c => c.childAt(0));
+    expect(contentComponents.length).to.equal(4);
+    let [collectionsContent, patronAuthContent, searchContent, metadataContent] = contentComponents.map(c => c.childAt(0));
 
     expect(collectionsContent.prop("type")).to.equal("collection");
     expect(collectionsContent.prop("items")).to.equal(collections);
@@ -88,6 +92,7 @@ describe("SelfTestsTabContainer", () => {
 
     expect(patronAuthContent.find(LoadingIndicator).length).to.equal(1);
     expect(searchContent.find(LoadingIndicator).length).to.equal(1);
+    expect(metadataContent.find(LoadingIndicator).length).to.equal(1);
   });
 
   it("calls fetchItems on mount", () => {
@@ -102,7 +107,7 @@ describe("SelfTestsTabContainer", () => {
     wrapper.setProps({ fetchError });
 
     error = wrapper.find(ErrorMessage);
-    expect(error.length).to.equal(3);
+    expect(error.length).to.equal(4);
   });
 
   it("calls goToTab", () => {
@@ -142,5 +147,6 @@ describe("SelfTestsTabContainer", () => {
     expect(wrapper.instance().getNames("collections")).to.eql(["collections", "collection", "collections"]);
     expect(wrapper.instance().getNames("patronAuthServices")).to.eql(["patron_auth_services", "patron_auth_service", "patronAuth"]);
     expect(wrapper.instance().getNames("searchServices")).to.eql(["search_services", "search_service", "search"]);
+    expect(wrapper.instance().getNames("metadataServices")).to.eql(["metadata_services", "metadata_service", "metadata"]);
   });
 });

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -237,6 +237,7 @@ export interface SelfTestsResult {
   result?: string | string[];
   start: string;
   success: boolean;
+  collection?: string;
 }
 
 export interface SelfTestsData {
@@ -258,6 +259,7 @@ export interface ServiceData {
   };
   libraries?: LibraryWithSettingsData[];
   self_test_results?: SelfTestsData;
+  goal?: string;
 }
 
 export interface ServicesData {

--- a/src/stylesheets/self_tests.scss
+++ b/src/stylesheets/self_tests.scss
@@ -53,6 +53,10 @@
           margin-left: auto;
         }
 
+        .panel-success > .panel-heading {
+          background: #809F69;
+        }
+
         .results {
           display: flex;
           width: 100%;


### PR DESCRIPTION
Resolves [2420](https://jira.nypl.org/browse/SIMPLY-2420); adding a metadata tab to the self-tests section on the Troubleshooting page.

Goes with these [circulation](https://github.com/NYPL-Simplified/circulation/pull/1366) and [core](https://github.com/NYPL-Simplified/server_core/pull/1144) branches (also called `metadata-self-tests`).