### PR TITLE
Updating and adding a default string to the DraftJS editor when an empty value is passed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v0.4.3
+#### Fixed
+- Fixed a bug where an empty book summary caused creating a DraftJS instance to crash the app.
+
 ### v0.4.2
 #### Updated
 - Updated the `opds-web-client` package to v0.3.2.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/components/BookEditForm.tsx
+++ b/src/components/BookEditForm.tsx
@@ -144,6 +144,7 @@ export default class BookEditForm extends React.Component<BookEditFormProps, Boo
 
   save(data: FormData) {
     const summary = (this.summaryRef.current).getValue();
+    // Only update the summary if it was intentionally updated.
     if (summary !== this.defaultContent) {
       data.append("summary", summary);
     }

--- a/src/components/BookEditForm.tsx
+++ b/src/components/BookEditForm.tsx
@@ -23,6 +23,7 @@ export interface BookEditFormState {
 /** Edit a book's metadata in the edit tab on the book details page. */
 export default class BookEditForm extends React.Component<BookEditFormProps, BookEditFormState> {
   private summaryRef = React.createRef<EditorField>();
+  defaultContent = "<p>Update the summary for this book.</p>";
 
   constructor(props) {
     super(props);
@@ -124,6 +125,7 @@ export default class BookEditForm extends React.Component<BookEditFormProps, Boo
           <EditorField
             ref={this.summaryRef}
             content={this.props.summary}
+            defaultContent={this.defaultContent}
             disabled={this.props.disabled}
           />
         </div>
@@ -142,7 +144,9 @@ export default class BookEditForm extends React.Component<BookEditFormProps, Boo
 
   save(data: FormData) {
     const summary = (this.summaryRef.current).getValue();
-    data.append("summary", summary);
+    if (summary !== this.defaultContent) {
+      data.append("summary", summary);
+    }
     this.props.editBook(this.props.editLink.href, data).then(response => {
       this.props.refresh();
     });

--- a/src/components/EditorField.tsx
+++ b/src/components/EditorField.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
-import { Editor, EditorState, ContentState, RichUtils, convertFromHTML, compositeDecorator } from "draft-js";
+import { Editor, EditorState, ContentState, RichUtils, convertFromHTML, compositeDecorator,
+ContentBlock } from "draft-js";
 import { convertToHTML } from "draft-convert";
 import { Button } from "library-simplified-reusable-components";
 
@@ -8,18 +9,30 @@ interface EditorFieldState {
 }
 
 interface EditorFieldProps {
+  defaultContent?: string;
   content: string;
   disabled: boolean;
 }
 
 export default class EditorField extends React.Component<EditorFieldProps, EditorFieldState> {
+  static defaultProps = {
+    defaultContent: "<p>Update the content for this field.</p>"
+  };
+
   constructor(props) {
     super(props);
+    // "<p></p>" is the default that DraftJS outputs when the content
+    // summary is empty. This value, however, breaks when trying to create
+    // a contentState from `ContentState.createFromBlockArray` since
+    // `blocksFromHTML.contentBlocks` is an empty array.
+    let content = (props.content === "<p></p>" || props.content === "") ?
+      props.defaultContent : props.content;
     let blocksFromHTML;
+
     try {
-      blocksFromHTML = convertFromHTML(JSON.parse(props.content));
+      blocksFromHTML = convertFromHTML(JSON.parse(content));
     } catch {
-      blocksFromHTML = convertFromHTML(props.content);
+      blocksFromHTML = convertFromHTML(content);
     }
     const contentState = ContentState.createFromBlockArray(
       blocksFromHTML.contentBlocks,

--- a/src/components/EditorField.tsx
+++ b/src/components/EditorField.tsx
@@ -31,7 +31,7 @@ export default class EditorField extends React.Component<EditorFieldProps, Edito
     // summary is empty. This value, however, breaks when trying to create
     // a contentState from `ContentState.createFromBlockArray` since
     // `blocksFromHTML.contentBlocks` is an empty array.
-    let content = (props.content === "<p></p>" || props.content === "") ?
+    let content = (!props.content || props.content === "<p></p>" || props.content === "") ?
       props.defaultContent : props.content;
     let blocksFromHTML;
 

--- a/src/components/EditorField.tsx
+++ b/src/components/EditorField.tsx
@@ -1,6 +1,12 @@
 import * as React from "react";
-import { Editor, EditorState, ContentState, RichUtils, convertFromHTML, compositeDecorator,
-ContentBlock } from "draft-js";
+import {
+  Editor,
+  EditorState,
+  ContentState,
+  RichUtils,
+  convertFromHTML,
+  compositeDecorator
+} from "draft-js";
 import { convertToHTML } from "draft-convert";
 import { Button } from "library-simplified-reusable-components";
 

--- a/src/components/__tests__/BookEditForm-test.tsx
+++ b/src/components/__tests__/BookEditForm-test.tsx
@@ -2,7 +2,7 @@ import { expect } from "chai";
 import { stub } from "sinon";
 
 import * as React from "react";
-import { shallow, mount } from "enzyme";
+import { mount } from "enzyme";
 
 import BookEditForm from "../BookEditForm";
 import EditableInput from "../EditableInput";
@@ -307,8 +307,11 @@ describe("BookEditForm", () => {
     expect(editBook.args[0][1].get("summary")).to.contain(bookData.summary);
   });
 
-  it("refreshes book after editing", (done) => {
+  it("refreshes book after editing", async () => {
     let editBook = stub().returns(new Promise((resolve, reject) => {
+      resolve();
+    }));
+    let refreshStub = stub().returns(new Promise((resolve, reject) => {
       resolve();
     }));
     wrapper = mount(
@@ -318,13 +321,42 @@ describe("BookEditForm", () => {
         media={media}
         languages={languages}
         disabled={false}
-        refresh={done}
+        refresh={refreshStub}
         editBook={editBook}
       />
     );
 
     let form = wrapper.find(Form);
-    form.prop("onSubmit")(new (window as any).FormData(form.getDOMNode()));
+    await form.prop("onSubmit")(new (window as any).FormData(form.getDOMNode()));
+    expect(refreshStub.callCount).to.equal(1);
+  });
+
+  it("only adds updated summary content if it's not empty", async () => {
+    let editBook = stub().returns(new Promise((resolve, reject) => {
+      resolve();
+    }));
+    let refreshStub = stub().returns(new Promise((resolve, reject) => {
+      resolve();
+    }));
+
+    wrapper = mount(
+      <BookEditForm
+        {...{ ...bookData, summary: "<p></p>" }}
+        roles={roles}
+        media={media}
+        languages={languages}
+        disabled={false}
+        refresh={refreshStub}
+        editBook={editBook}
+        editLink={{ href: "test-url", rel: "something" }}
+      />
+    );
+
+    let form = wrapper.find(Form);
+    let data = new (window as any).FormData(form.getDOMNode());
+    await form.prop("onSubmit")(data);
+
+    expect(editBook.args[0][1].get("summary")).to.equal(null);
   });
 
   it("disables all inputs", () => {

--- a/src/components/__tests__/BookEditForm-test.tsx
+++ b/src/components/__tests__/BookEditForm-test.tsx
@@ -338,10 +338,13 @@ describe("BookEditForm", () => {
     let refreshStub = stub().returns(new Promise((resolve, reject) => {
       resolve();
     }));
+    // Since we are adding an empty string, there should be no `summary` value
+    // in the FormData object that gets passed to the `editBook` function.
+    const emptySummaryData = { ...bookData, summary: "<p></p>" };
 
     wrapper = mount(
       <BookEditForm
-        {...{ ...bookData, summary: "<p></p>" }}
+        {...emptySummaryData}
         roles={roles}
         media={media}
         languages={languages}

--- a/src/components/__tests__/EditorField-test.tsx
+++ b/src/components/__tests__/EditorField-test.tsx
@@ -61,6 +61,10 @@ describe("EditorField", () => {
     wrapper = mount(<EditorField content="" disabled={false} />);
     expect(wrapper.instance().getValue())
       .to.equal("<p>Update the content for this field.</p>");
+
+    wrapper = mount(<EditorField content={undefined} disabled={false} />);
+      expect(wrapper.instance().getValue())
+        .to.equal("<p>Update the content for this field.</p>");
   });
 
   it("can be disabled", () => {

--- a/src/components/__tests__/EditorField-test.tsx
+++ b/src/components/__tests__/EditorField-test.tsx
@@ -1,8 +1,8 @@
 import { expect } from "chai";
-import { spy, stub } from "sinon";
+import { stub } from "sinon";
 
 import * as React from "react";
-import { shallow, mount } from "enzyme";
+import { mount } from "enzyme";
 
 import EditorField from "../EditorField";
 import { Editor } from "draft-js";
@@ -46,6 +46,21 @@ describe("EditorField", () => {
 
   it("gets the current value", () => {
     expect(wrapper.instance().getValue()).to.equal("<p>This is a summary.</p>");
+  });
+
+  it("gets the default content if no content is an empty html string", () => {
+    // The empty paragraph element seems to be the default that is
+    // injected whenever the editor is saved with no content. We are checking
+    // against that in case the summary is empty or it was removed by
+    // the admin.
+    wrapper = mount(<EditorField content="<p></p>" disabled={false} />);
+    expect(wrapper.instance().getValue())
+      .to.equal("<p>Update the content for this field.</p>");
+
+    // The empty string case.
+    wrapper = mount(<EditorField content="" disabled={false} />);
+    expect(wrapper.instance().getValue())
+      .to.equal("<p>Update the content for this field.</p>");
   });
 
   it("can be disabled", () => {

--- a/src/testHelper.ts
+++ b/src/testHelper.ts
@@ -10,6 +10,7 @@ const win = doc.defaultView;
 
 global["document"] = doc;
 global["window"] = win;
+global["HTMLElement"] = win.HTMLElement;
 
 Object.keys(window).forEach((key) => {
   if (!(key in global)) {


### PR DESCRIPTION
Resolves [SIMPLY-2439](https://jira.nypl.org/browse/SIMPLY-2439).

On error in the console that appears is misleading in production. In local development, it was an error with the not being able to get the `key` for some value. Not sure exactly how DraftJs tries to create an editor element, but having an empty summary breaks when trying to parse the string to pass it to `ContentState.createFromBlockArray` from `blocksFromHTML.contentBlocks`.

There are two scenarios this seems to happen:
1) A book already has no summary and the page breaks
2) An admin removes the summary from a book and saves the editor 

The second one is the one I tested and found that DraftJS adds an automatic `"<p></p>"` string as a default so tested against that and the empty string too.

There is now a default string that gets rendered from `EditorField`, but in `BookEditForm`, it does not get saved. So the content that appears will only serve as a reminder to admins to update the content. Maybe that should be more explicit and say something like `"Update the summary for this book. This content will not be saved."`?