### PR TITLE
Small change to add two new audience values in the admin.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v0.4.4
+#### Added
+- Added "All Ages" and "Research" to the list of audiences for an item's classification.
+
 ### v0.4.3
 #### Added
 - Added a Metadata Services tab to the self-tests section of the Troubleshooting page.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.4.2",
+  "version": "0.4.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/components/ClassificationsForm.tsx
+++ b/src/components/ClassificationsForm.tsx
@@ -79,6 +79,8 @@ export default class ClassificationsForm extends React.Component<Classifications
                 <option value="Young Adult" aria-selected={audience === "Young Adult"}>Young Adult</option>
                 <option value="Adult" aria-selected={audience === "Adult"}>Adult</option>
                 <option value="Adults Only" aria-selected={audience === "Adults Only"}>Adults Only</option>
+                <option value="All Ages" aria-selected={audience === "All Ages"}>All Ages</option>
+                <option value="Research" aria-selected={audience === "Research"}>Research</option>
               </EditableInput>
 
               { this.shouldShowTargetAge() &&

--- a/src/components/__tests__/ClassificationsForm-test.tsx
+++ b/src/components/__tests__/ClassificationsForm-test.tsx
@@ -58,7 +58,7 @@ describe("ClassificationsForm", () => {
       expect(select.props().value).to.equal("None");
 
       let options = select.find("select").children();
-      expect(options.length).to.equal(5);
+      expect(options.length).to.equal(7);
 
       // This only gets rendered without an initial fiction classification:
       let noFictionSelectedRadio = wrapper
@@ -178,7 +178,7 @@ describe("ClassificationsForm", () => {
 
       let options = select.find("select").children();
       // The "None" select Audience value should not be rendered.
-      expect(options.length).to.equal(4);
+      expect(options.length).to.equal(6);
     });
 
     it("shows editable inputs with min and max target age", () => {


### PR DESCRIPTION
Helps resolves [SIMPLY-538](https://jira.nypl.org/browse/SIMPLY-538). There are server branches to this PR but this PR itself is very small and just adds two select options in the Audiences dropdown. I think ideally these values should come from the server but could be something worth doing at a later time.