### PR TITLE
Set default neighborhood analytics value to empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v0.4.5
+#### Fixed
+- Fixed a bug that blocked creation of a new local analytics service with disabled patron neighborhood analytics.
+
 ### v0.4.4
 #### Added
 - Added "All Ages" and "Research" to the list of audiences for an item's classification.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/components/NeighborhoodAnalyticsForm.tsx
+++ b/src/components/NeighborhoodAnalyticsForm.tsx
@@ -18,7 +18,7 @@ export interface NeighborhoodAnalyticsFormState {
 export default class NeighborhoodAnalyticsForm extends React.Component<NeighborhoodAnalyticsFormProps, NeighborhoodAnalyticsFormState> {
   constructor(props: NeighborhoodAnalyticsFormProps) {
     super(props);
-    this.state = { selected: props.currentValue || null };
+    this.state = { selected: props.currentValue || "" };
     this.handleNeighborhoodChange = this.handleNeighborhoodChange.bind(this);
     this.renderNeighborhoodForm = this.renderNeighborhoodForm.bind(this);
   }

--- a/src/components/__tests__/NeighborhoodAnalyticsForm-test.tsx
+++ b/src/components/__tests__/NeighborhoodAnalyticsForm-test.tsx
@@ -72,7 +72,7 @@ describe("NeighborhoodAnalyticsForm", () => {
   });
 
   it("updates the state when an option is chosen", () => {
-    expect(wrapper.state()["selected"]).to.be.null;
+    expect(wrapper.state()["selected"]).to.equal("");
     chooseOption("choice1");
     expect(wrapper.state()["selected"]).to.equal("choice1");
   });
@@ -112,7 +112,7 @@ describe("NeighborhoodAnalyticsForm", () => {
   });
 
   it("returns the value of the currently selected option", () => {
-    expect(wrapper.instance().getValue()).to.be.null;
+    expect(wrapper.instance().getValue()).to.equal("");
     chooseOption("choice1");
     expect(wrapper.instance().getValue()).to.equal("choice1");
     chooseOption("choice2");


### PR DESCRIPTION
Resolves https://jira.nypl.org/browse/SIMPLY-2456.  (To test: try making a new local analytics integration, without touching the Patron Neighborhood Analytics form.)