### PR TITLE
Add automatic capitalization option for InputList

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v0.4.6
+#### Updated
+- Implemented an optional case-insensitive configuration for InputList.
+
 ### v0.4.5
 #### Fixed
 - Fixed a bug that blocked creation of a new local analytics service with disabled patron neighborhood analytics.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/components/InputList.tsx
+++ b/src/components/InputList.tsx
@@ -5,7 +5,7 @@ import { SettingData, CustomListsSetting } from "../interfaces";
 import ToolTip from "./ToolTip";
 import { LocatorIcon } from "@nypl/dgx-svg-icons";
 import { Button } from "library-simplified-reusable-components";
-import { isEqual } from "../utils/sharedFunctions";
+import { isEqual, formatString } from "../utils/sharedFunctions";
 
 export interface InputListProps {
   createEditableInput: (setting: SettingData, customProps?: any, children?: JSX.Element[]) => JSX.Element;
@@ -18,6 +18,7 @@ export interface InputListProps {
   onSubmit?: any;
   onEmpty?: string;
   title?: string;
+  capitalize?: boolean;
 }
 
 export interface InputListState {
@@ -41,6 +42,7 @@ export default class InputList extends React.Component<InputListProps, InputList
     this.removeListItem = this.removeListItem.bind(this);
     this.clear = this.clear.bind(this);
     this.filterMenu = this.filterMenu.bind(this);
+    this.capitalize = this.capitalize.bind(this);
   }
 
   componentWillReceiveProps(newProps) {
@@ -227,7 +229,7 @@ export default class InputList extends React.Component<InputListProps, InputList
     let ref = this.props.setting.format === "language-code" ?
       (this.refs["addListItem"] as any).refs["autocomplete"] :
       (this.refs["addListItem"] as any);
-    const listItem = ref.getValue();
+    const listItem = this.props.setting.capitalize ? this.capitalize(ref.getValue()) : ref.getValue();
     await this.setState({ listItems: this.state.listItems.concat(listItem), newItem: "" });
     // Actually save the changes instead of just manipulating the state
     if (this.props.onSubmit) {
@@ -236,6 +238,14 @@ export default class InputList extends React.Component<InputListProps, InputList
     if (this.props.setting.type !== "menu") {
       ref.clear();
     }
+  }
+
+  capitalize(value: string): string {
+    // If it's a state/province abbreviation, the whole thing should be uppercase.  Otherwise, just capitalize
+    // the first letter of each word.
+    return value.split(" ").map(x =>
+      x.length === 2 && this.props.setting.format === "geographic" ? x.toUpperCase() : formatString(x)
+    ).join(" ");
   }
 
   getValue() {

--- a/src/components/__tests__/InputList-test.tsx
+++ b/src/components/__tests__/InputList-test.tsx
@@ -175,6 +175,41 @@ describe("InputList", () => {
     expect(blankInput.prop("value")).to.equal("");
   });
 
+  it("adds and capitalizes an item", async() => {
+    wrapper.setProps({ setting: { ...wrapper.prop("setting"), ...{"capitalize": true} }});
+    let removables = wrapper.find(WithRemoveButton);
+    expect(removables.length).to.equal(2);
+
+    let blankInput = wrapper.find("span.add-list-item input");
+    blankInput.getDOMNode().value = "new york";
+    blankInput.simulate("change");
+    let addButton = wrapper.find("button.add-list-item");
+    addButton.simulate("click");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    wrapper.update();
+    removables = wrapper.find(WithRemoveButton);
+    expect(removables.length).to.equal(3);
+    expect(removables.at(2).find(EditableInput).prop("value")).to.equal("New York");
+    expect(wrapper.state()["listItems"][2]).to.equal("New York");
+
+    blankInput = wrapper.find("span.add-list-item input");
+    expect(blankInput.prop("value")).to.equal("");
+  });
+
+  it("capitalizes a string", () => {
+    wrapper.setProps({ setting: {...wrapper.prop("setting"), ...{"format": "geographic"}}});
+    let cap = wrapper.instance().capitalize;
+    // Capitalizes one word
+    expect(cap("california")).to.equal("California");
+    // Capitalizes multiple words
+    expect(cap("new jersey")).to.equal("New Jersey");
+    // Capitalizes two-letter state/province abbreviations
+    expect(cap("fl")).to.equal("FL");
+    // Handles mixed words and abbreviations
+    expect(cap("new york city, ny")).to.equal("New York City, NY");
+  });
+
   it("adds an autocompleted item", async () => {
     let languageSetting = { ...setting, format: "language-code" };
     wrapper.setProps({ setting: languageSetting, value: ["abc"] });

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -208,6 +208,7 @@ export interface SettingData {
   instructions?: string;
   format?: string;
   urlBase?: any;
+  capitalize?: boolean;
 }
 
 export interface ProtocolData {


### PR DESCRIPTION
Resolves https://jira.nypl.org/browse/SIMPLY-2482; makes it so you can input lowercase values for the geographic settings.  (More broadly, makes it so InputList has an option for automatically capitalizing input.)

Goes with https://github.com/NYPL-Simplified/circulation/pull/1375 (which just adds `"geographic": True` to the two relevant settings).