### PR TITLE
Search for items in the Lists admin without a language filter.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v0.4.7
+#### Updated
+- Added the query param `&language=all` for searches done in the List admin page to allow searches without a language filter.
+
 ### v0.4.6
 #### Updated
 - Implemented an optional case-insensitive configuration for InputList.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.4.4",
+  "version": "0.4.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/components/CustomListEditor.tsx
+++ b/src/components/CustomListEditor.tsx
@@ -340,11 +340,11 @@ export default class CustomListEditor extends React.Component<CustomListEditorPr
     }, 200);
   }
 
-  getEntryPointQuery() {
+  getSearchQueries() {
     const entryPointSelected = this.state.entryPointSelected;
-    let query = "";
+    let query = "&language=all";
     if (entryPointSelected && entryPointSelected !== "all") {
-      query = `&entrypoint=${encodeURIComponent(entryPointSelected)}`;
+      query += `&entrypoint=${encodeURIComponent(entryPointSelected)}`;
     }
 
     return query;
@@ -381,10 +381,16 @@ export default class CustomListEditor extends React.Component<CustomListEditorPr
     return entryPointsElms;
   }
 
+  /**
+   * search()
+   * Search for items along with an EntryPoint query and a default
+   * language query set to 'all', for librarians who may want to search
+   * for items without a language filter.
+   */
   search() {
     const searchTerms = encodeURIComponent((this.refs["searchTerms"] as HTMLInputElement).value);
-    const entryPointQuery = this.getEntryPointQuery();
-    const url = "/" + this.props.library + "/search?q=" + searchTerms + entryPointQuery;
+    const searchQueries = this.getSearchQueries();
+    const url = `/${this.props.library}/search?q=${searchTerms}${searchQueries}`;
     this.props.search(url);
   }
 }

--- a/src/components/__tests__/CustomListEditor-test.tsx
+++ b/src/components/__tests__/CustomListEditor-test.tsx
@@ -394,7 +394,7 @@ describe("CustomListEditor", () => {
     expect(inputs.at(1).props().checked).to.equal(false);
   });
 
-  it("searches", () => {
+  it("searches with a default of language set to 'all'", () => {
     wrapper = mount(
       <CustomListEditor
         library="library"
@@ -419,7 +419,7 @@ describe("CustomListEditor", () => {
     searchForm.simulate("submit");
 
     expect(search.callCount).to.equal(1);
-    expect(search.args[0][0]).to.equal("/library/search?q=test");
+    expect(search.args[0][0]).to.equal("/library/search?q=test&language=all");
   });
 
   it("optionally searches a title passed as a prop", () => {
@@ -444,7 +444,7 @@ describe("CustomListEditor", () => {
     let searchField = wrapper.find(".form-control");
     expect(searchField.getDOMNode().value).to.equal("test title");
     expect(search.callCount).to.equal(1);
-    expect(search.args[0][0]).to.equal("/library/search?q=test%20title");
+    expect(search.args[0][0]).to.equal("/library/search?q=test%20title&language=all");
 
   });
 
@@ -480,7 +480,7 @@ describe("CustomListEditor", () => {
 
     expect(search.callCount).to.equal(1);
     expect(search.args[0][0])
-      .to.equal("/library/search?q=harry%20potter&entrypoint=Book");
+      .to.equal("/library/search?q=harry%20potter&language=all&entrypoint=Book");
   });
 
   it("searches with ebook selected", () => {
@@ -515,7 +515,7 @@ describe("CustomListEditor", () => {
 
     expect(search.callCount).to.equal(1);
     expect(search.args[0][0])
-      .to.equal("/library/search?q=oliver%20twist&entrypoint=Audio");
+      .to.equal("/library/search?q=oliver%20twist&language=all&entrypoint=Audio");
   });
 
   it("should keep the same state when the list prop gets updated", () => {


### PR DESCRIPTION
Resolves [SIMPLY-1213](https://jira.nypl.org/browse/SIMPLY-1213).

This was originally completed to allow librarians and admins to search for items without a language filter. That part was done in `opds-web-client` for the search form but the custom lists search is a different component so it never adds the `&language=all` query for searches.