### PR TITLE
Adding opds-web-client version 0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v0.4.10
+#### Updated
+- Updated the version of `opds-web-client` to v0.3.4 and added ActionsProvider component wrapper to use the redux actions/dispatch hook.
+
 ### v0.4.9
 #### Added
 - Created a PairedMenus component to render a related InputList and dropdown menu and implemented it in the Lanes & Filters section of the Library Edit Form.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6715,9 +6715,9 @@
       }
     },
     "opds-web-client": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/opds-web-client/-/opds-web-client-0.3.2.tgz",
-      "integrity": "sha512-Lrx2wNcfcsEJd4HgstS/vs3LfgUA7cUrfPWPBA8KaldazAVaG6wr3EfZ3iUNP+stmVHNBQVJQVx6fD/hFeHmNg==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/opds-web-client/-/opds-web-client-0.3.4.tgz",
+      "integrity": "sha512-qpno/swMpFq+glPEJROlmF0AjGALvG2OpfgkVuGOodfJtnWp05TQa2bWzcBwbi4djPrODoRzko1ZhL7zDf8DhQ==",
       "requires": {
         "@nypl/dgx-svg-icons": "^0.3.4",
         "dompurify": "^0.8.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "library-simplified-reusable-components": "1.3.16",
     "numeral": "^2.0.6",
     "opds-feed-parser": "0.0.17",
-    "opds-web-client": "0.3.2",
+    "opds-web-client": "0.3.4",
     "prop-types": "^15.7.2",
     "qs": "^6.2.0",
     "react": "^16.8.6",

--- a/src/components/CatalogPage.tsx
+++ b/src/components/CatalogPage.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import * as ReactDOM from "react-dom";
 const OPDSCatalog = require("opds-web-client");
 import * as PropTypes from "prop-types";
+import { ActionsProvider } from "opds-web-client/lib/components/context/ActionsContext";
 import BookDetailsContainer from "./BookDetailsContainer";
 import Header from "./Header";
 import Footer from "./Footer";
@@ -53,16 +54,18 @@ export default class CatalogPage extends React.Component<CatalogPageProps, {}> {
 
     return (
       <>
-        <OPDSCatalog
-          collectionUrl={collectionUrl}
-          bookUrl={bookUrl}
-          BookDetailsContainer={BookDetailsContainer}
-          Header={Header}
-          pageTitleTemplate={pageTitleTemplate}
-          computeBreadcrumbs={computeBreadcrumbs}
-          CollectionContainer={EntryPointsContainer}
-          allLanguageSearch={true}
-        />
+        <ActionsProvider>
+          <OPDSCatalog
+            collectionUrl={collectionUrl}
+            bookUrl={bookUrl}
+            BookDetailsContainer={BookDetailsContainer}
+            Header={Header}
+            pageTitleTemplate={pageTitleTemplate}
+            computeBreadcrumbs={computeBreadcrumbs}
+            CollectionContainer={EntryPointsContainer}
+            allLanguageSearch={true}
+          />
+        </ActionsProvider>
         <Footer />
       </>
     );

--- a/src/components/__tests__/BookDetails-test.tsx
+++ b/src/components/__tests__/BookDetails-test.tsx
@@ -5,8 +5,9 @@ import * as React from "react";
 import { shallow } from "enzyme";
 
 import BookDetails from "../BookDetails";
+import { BookData } from "opds-web-client/lib/interfaces";
 
-let book = {
+let book: BookData = {
   id: "urn:librarysimplified.org/terms/id/3M%20ID/crrmnr9",
   url: "http://circulation.librarysimplified.org/works/3M/crrmnr9",
   title: "The Mayan Secrets",
@@ -15,7 +16,7 @@ let book = {
   summary: "&lt;b&gt;Sam and Remi Fargo race for treasure&#8212;and survival&#8212;in this lightning-paced new adventure from #1&lt;i&gt; New York Times&lt;/i&gt; bestselling author Clive Cussler.&lt;/b&gt;&lt;br /&gt;&lt;br /&gt;Husband-and-wife team Sam and Remi Fargo are in Mexico when they come upon a remarkable discovery&#8212;the mummified remainsof a man clutching an ancient sealed pot. Within the pot is a Mayan book larger than any known before.&lt;br /&gt;&lt;br /&gt;The book contains astonishing information about the Mayans, their cities, and about mankind itself. The secrets are so powerful that some people would do anything to possess them&#8212;as the Fargos are about to find out. Many men and women are going to die for that book.",
   imageUrl: "https://dlotdqc6pnwqb.cloudfront.net/3M/crrmnr9/cover.jpg",
   borrowUrl: "borrow url",
-  openAccessLinks: [{ url: "secrets.epub", type: "epub" }],
+  openAccessLinks: [{ url: "secrets.epub", type: "application/epub+zip" }],
   publisher: "Penguin Publishing Group",
   published: "February 29, 2016",
   categories: ["Children", "10-12", "Fiction", "Adventure", "Fantasy"],
@@ -79,18 +80,13 @@ let book = {
 describe("BookDetails", () => {
   let wrapper;
   let noop = stub().returns(new Promise((resolve, reject) => resolve()));
-  let fetchComplaintTypes = noop;
-  let postComplaint = noop;
-  let problemTypes = ["type1", "type2"];
 
   beforeEach(() => {
     wrapper = shallow(
       <BookDetails
         book={book}
         updateBook={noop}
-        fulfillBook={noop}
-        indirectFulfillBook={noop}
-        />
+      />
     );
   });
 


### PR DESCRIPTION
And also updated code to reflect new core code.

Some context around this update: the `opds-web-client` has a custom redux hook that is currently _only_ used in the `DownloadButton` component. This component downloads a direct epub, mobi, etc. type of file. Since those books can appear in the catalog for the admin, the catalog needs to be wrapped in the `ActionsProvider` in order for the hook to be available. This is only for this one use case but as the `opds-web-client` begins to use more hooks rather than the `connect` HOC, no change will need to be made.

Currently, the same behavior occurs where attempting to download an ebook opens up a new tab and a log in browser modal. So this works just as before, but the code implementation is newer.