### PR TITLE
Disable button if tests can't be run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v0.4.12
+#### Updated
+- Disabled the "run tests" button in cases in which tests cannot be run.
+
 ### v0.4.11
 #### Added
 - Enabled admins to configure the terms of service text and link displayed in the Footer.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/components/SelfTests.tsx
+++ b/src/components/SelfTests.tsx
@@ -70,7 +70,6 @@ export class SelfTests extends React.Component<SelfTestsProps, SelfTestsState> {
   render(): JSX.Element {
     const integration: ServiceData = this.state.mostRecent;
     const selfTestException = integration.self_test_results && integration.self_test_results.exception;
-    console.log(integration.self_test_results);
     const cannotRunTests = selfTestException && integration.self_test_results.disabled;
     const firstTime: boolean = selfTestException && selfTestException.includes("no attribute 'prior_test_results'");
     let results = [];

--- a/src/components/SelfTests.tsx
+++ b/src/components/SelfTests.tsx
@@ -70,7 +70,7 @@ export class SelfTests extends React.Component<SelfTestsProps, SelfTestsState> {
   render(): JSX.Element {
     const integration: ServiceData = this.state.mostRecent;
     const selfTestException = integration.self_test_results && integration.self_test_results.exception;
-    const cannotRunTests = selfTestException?.search(/[before you can  run self tests]/) >= 0;
+    const cannotRunTests = selfTestException?.search(/[before you can run self tests]/) >= 0;
     const firstTime: boolean = selfTestException && selfTestException.includes("no attribute 'prior_test_results'");
     let results = [];
     let resultIcon: JSX.Element;

--- a/src/components/SelfTests.tsx
+++ b/src/components/SelfTests.tsx
@@ -70,6 +70,7 @@ export class SelfTests extends React.Component<SelfTestsProps, SelfTestsState> {
   render(): JSX.Element {
     const integration: ServiceData = this.state.mostRecent;
     const selfTestException = integration.self_test_results && integration.self_test_results.exception;
+    const cannotRunTests = selfTestException?.search(/[before you can  run self tests]/) >= 0;
     const firstTime: boolean = selfTestException && selfTestException.includes("no attribute 'prior_test_results'");
     let results = [];
     let resultIcon: JSX.Element;
@@ -92,7 +93,7 @@ export class SelfTests extends React.Component<SelfTestsProps, SelfTestsState> {
     const runButton = (
       <Button
         callback={(e) => this.runSelfTests(e)}
-        disabled={this.props.isFetching}
+        disabled={cannotRunTests || this.props.isFetching}
         content="Run tests"
       />
     );

--- a/src/components/SelfTests.tsx
+++ b/src/components/SelfTests.tsx
@@ -70,7 +70,8 @@ export class SelfTests extends React.Component<SelfTestsProps, SelfTestsState> {
   render(): JSX.Element {
     const integration: ServiceData = this.state.mostRecent;
     const selfTestException = integration.self_test_results && integration.self_test_results.exception;
-    const cannotRunTests = selfTestException?.search(/[before you can run self tests]/) >= 0;
+    console.log(integration.self_test_results);
+    const cannotRunTests = selfTestException && integration.self_test_results.disabled;
     const firstTime: boolean = selfTestException && selfTestException.includes("no attribute 'prior_test_results'");
     let results = [];
     let resultIcon: JSX.Element;
@@ -89,7 +90,6 @@ export class SelfTests extends React.Component<SelfTestsProps, SelfTestsState> {
     }
     const isFetching = !!(this.props.isFetching && this.state.runTests);
     const failedSelfTest = (selfTestException && !firstTime) ? selfTestException : "";
-
     const runButton = (
       <Button
         callback={(e) => this.runSelfTests(e)}

--- a/src/components/__tests__/SelfTests-test.tsx
+++ b/src/components/__tests__/SelfTests-test.tsx
@@ -143,6 +143,18 @@ describe("SelfTests", () => {
     expect(wrapper.find("p").text()).to.equal("No self test results found.");
   });
 
+  it("should disable the button if the tests cannot be run", () => {
+    let selfTestResultsWithException = {
+      ...collections[0].self_test_results, ...{
+        exception: "You must associate this service with at least one library before you can run self tests for it."
+    }};
+    let collectionWithException = {...collections[0], ...{self_test_results: selfTestResultsWithException}};
+    wrapper = mount(
+      <SelfTests item={collectionWithException} type="collection" getSelfTests={stub()} />
+    );
+    expect(wrapper.find("button").props().disabled).to.be.true;
+  });
+
   it("should render the SelfTests component for new services", () => {
     let exception = "This integration has no attribute 'prior_test_results'";
     let self_test_results = {...collections[0].self_test_results, ...{exception}};
@@ -154,6 +166,7 @@ describe("SelfTests", () => {
     expect(wrapper.find("ul").length).to.equal(0);
     expect(wrapper.find(".description").text()).to.equal("There are no self test results yet.");
   });
+
 
   it("should render the SelfTests component with results", () => {
     expect(wrapper.render().hasClass("integration-selftests")).to.equal(true);
@@ -207,7 +220,7 @@ describe("SelfTests", () => {
     });
 
     it("should display the base error message when attempting to run self tests", () => {
-      wrapper = shallow(
+      wrapper = mount(
         <SelfTests
           item={collections[2]} type="collection" getSelfTests={stub()}
         />

--- a/src/components/__tests__/SelfTests-test.tsx
+++ b/src/components/__tests__/SelfTests-test.tsx
@@ -167,7 +167,6 @@ describe("SelfTests", () => {
     expect(wrapper.find(".description").text()).to.equal("There are no self test results yet.");
   });
 
-
   it("should render the SelfTests component with results", () => {
     expect(wrapper.render().hasClass("integration-selftests")).to.equal(true);
     expect(wrapper.find("ul").length).to.equal(1);

--- a/src/components/__tests__/SelfTests-test.tsx
+++ b/src/components/__tests__/SelfTests-test.tsx
@@ -220,7 +220,7 @@ describe("SelfTests", () => {
     });
 
     it("should display the base error message when attempting to run self tests", () => {
-      wrapper = mount(
+      wrapper = shallow(
         <SelfTests
           item={collections[2]} type="collection" getSelfTests={stub()}
         />

--- a/src/components/__tests__/SelfTests-test.tsx
+++ b/src/components/__tests__/SelfTests-test.tsx
@@ -144,10 +144,7 @@ describe("SelfTests", () => {
   });
 
   it("should disable the button if the tests cannot be run", () => {
-    let selfTestResultsWithException = {
-      ...collections[0].self_test_results, ...{
-        exception: "You must associate this service with at least one library before you can run self tests for it."
-    }};
+    let selfTestResultsWithException = {...collections[0].self_test_results, ...{ exception: "Exception!", disabled: true }};
     let collectionWithException = {...collections[0], ...{self_test_results: selfTestResultsWithException}};
     wrapper = mount(
       <SelfTests item={collectionWithException} type="collection" getSelfTests={stub()} />


### PR DESCRIPTION
Resolves https://jira.nypl.org/browse/SIMPLY-2493

It might be a better idea to hide the button altogether; opinions?

<img width="802" alt="Screen Shot 2020-02-14 at 1 54 23 PM" src="https://user-images.githubusercontent.com/42178216/74564706-aa7adf00-4f3d-11ea-94c1-0d1cb29d15e7.png">
