### PR TITLE
Separate search results from footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v0.4.15
+#### Fixed
+- Made sure the list curation "Load more" button is never hidden.
+
 ### v0.4.14
 #### Added
 - Added a message to clarify usage of new sorting feature.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/stylesheets/custom_list_entries_editor.scss
+++ b/src/stylesheets/custom_list_entries_editor.scss
@@ -3,14 +3,17 @@
   flex-direction: row;
   flex-grow: 1;
   height: 50%;
-  justify-content: center;
+  justify-content: space-between;
 }
 
 .custom-list-search-results, .custom-list-entries {
   display: flex;
+  border: 1px solid $medium-gray;
+  padding: 12px 24px 24px 24px;
+  border-radius: 4px;
   flex-direction: column;
   flex-basis: 47%;
-  margin: 15px 10px 0 10px;
+  margin: 15px 0;
   overflow-y: scroll;
   h4 {
     display: inline-block;


### PR DESCRIPTION
Resolves https://jira.nypl.org/browse/SIMPLY-2541.  I 1) put more space between the bottom of the button and its container, 2) put more space between the container and the footer, and 3) stuck a border on the container for some extra visual separation.

<img width="1430" alt="Screen Shot 2020-03-12 at 4 02 33 PM" src="https://user-images.githubusercontent.com/42178216/76562699-4dab0f80-647c-11ea-93bc-c80c865ed9b6.png">
