### PR TITLE
replaced inherited getMedium w imported version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Changelog
 
+### v0.4.17
+#### Updated
+- Updated version of `opds-web-client` to v0.4.0 and changed reliance on `Book.getMedium` to imported `getMedium` and `getMediumSVG`.
+- Instantiates `ActionsCreator` and `DataFetcher` locally to be passed in to `ActionsProvider` to match updated API. 
+
 ### v0.4.16
 #### Fixed
 - Made sure the list curation "Load more" button is never hidden.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.4.11",
+  "version": "0.4.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -345,7 +345,8 @@
     "abab": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
-      "integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4="
+      "integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4=",
+      "dev": true
     },
     "abbrev": {
       "version": "1.1.1",
@@ -356,12 +357,14 @@
     "acorn": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
-      "integrity": "sha1-q259nYhqrKiwhbwzEreaGYQz8Oc="
+      "integrity": "sha1-q259nYhqrKiwhbwzEreaGYQz8Oc=",
+      "dev": true
     },
     "acorn-globals": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz",
       "integrity": "sha1-VbtemGkVB7dFedBRNBMhfDgMVM8=",
+      "dev": true,
       "requires": {
         "acorn": "^2.1.0"
       }
@@ -382,6 +385,11 @@
           "dev": true
         }
       }
+    },
+    "acorn-walk": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.1.1.tgz",
+      "integrity": "sha512-wdlPY2tm/9XBr7QkKlq0WQVgiuGTX6YWPyRyBviSoScBuLfTVQhvwg6wJ369GJ/1nPfTLMfnrFIfjqVg6d+jQQ=="
     },
     "agent-base": {
       "version": "4.3.0",
@@ -571,7 +579,8 @@
     "array-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
-      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
+      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+      "dev": true
     },
     "array-filter": {
       "version": "1.0.0",
@@ -1027,6 +1036,11 @@
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
       "dev": true
+    },
+    "browser-process-hrtime": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
+      "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow=="
     },
     "browser-stdout": {
       "version": "1.3.1",
@@ -1631,7 +1645,8 @@
     "content-type-parser": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.2.tgz",
-      "integrity": "sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ=="
+      "integrity": "sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ==",
+      "dev": true
     },
     "copy-concurrently": {
       "version": "1.0.5",
@@ -1806,12 +1821,14 @@
     "cssom": {
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
-      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
+      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+      "dev": true
     },
     "cssstyle": {
       "version": "0.2.37",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
       "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
+      "dev": true,
       "requires": {
         "cssom": "0.3.x"
       }
@@ -1939,6 +1956,46 @@
         }
       }
     },
+    "data-urls": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
+      "integrity": "sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==",
+      "requires": {
+        "abab": "^2.0.3",
+        "whatwg-mimetype": "^2.3.0",
+        "whatwg-url": "^8.0.0"
+      },
+      "dependencies": {
+        "abab": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.3.tgz",
+          "integrity": "sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg=="
+        },
+        "tr46": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.0.2.tgz",
+          "integrity": "sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==",
+          "requires": {
+            "punycode": "^2.1.1"
+          }
+        },
+        "webidl-conversions": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+          "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA=="
+        },
+        "whatwg-url": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.0.0.tgz",
+          "integrity": "sha512-41ou2Dugpij8/LPO5Pq64K5q++MnRCBpEHvQr26/mArEKTkCV5aoXIqyhuYtE0pkqScXwhf2JP57rkRTYM29lQ==",
+          "requires": {
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^2.0.0",
+            "webidl-conversions": "^5.0.0"
+          }
+        }
+      }
+    },
     "date-now": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
@@ -1959,6 +2016,11 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
+    },
+    "decimal.js": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.0.tgz",
+      "integrity": "sha512-vDPw+rDgn3bZe1+F/pyEwb1oMG2XTlRVgAa6B4KccTEpYgF8w6eQllVbQcfIJnZyvzFtFpxnpGtx8dd7DJp/Rw=="
     },
     "decimal.js-light": {
       "version": "2.5.0",
@@ -2172,6 +2234,21 @@
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
       "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
       "dev": true
+    },
+    "domexception": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
+      "integrity": "sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==",
+      "requires": {
+        "webidl-conversions": "^5.0.0"
+      },
+      "dependencies": {
+        "webidl-conversions": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+          "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA=="
+        }
+      }
     },
     "domhandler": {
       "version": "2.4.2",
@@ -2551,6 +2628,7 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.1.tgz",
       "integrity": "sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==",
+      "dev": true,
       "requires": {
         "esprima": "^3.1.3",
         "estraverse": "^4.2.0",
@@ -2685,7 +2763,8 @@
     "esprima": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-      "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+      "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+      "dev": true
     },
     "esrecurse": {
       "version": "4.2.1",
@@ -3376,8 +3455,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3401,15 +3479,13 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3426,22 +3502,19 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3572,8 +3645,7 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3587,7 +3659,6 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3604,7 +3675,6 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3613,15 +3683,13 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3642,7 +3710,6 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3731,8 +3798,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3746,7 +3812,6 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3842,8 +3907,7 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3885,7 +3949,6 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3907,7 +3970,6 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3956,15 +4018,13 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -4463,6 +4523,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
       "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+      "dev": true,
       "requires": {
         "whatwg-encoding": "^1.0.1"
       }
@@ -4726,6 +4787,11 @@
       "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
       "dev": true
     },
+    "ip-regex": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+      "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk="
+    },
     "is-accessor-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
@@ -4941,6 +5007,11 @@
         "isobject": "^3.0.1"
       }
     },
+    "is-potential-custom-element-name": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.0.tgz",
+      "integrity": "sha1-DFLlS8yjkbssSUsh6GJtczbG45c="
+    },
     "is-property": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
@@ -5092,6 +5163,7 @@
       "version": "9.9.1",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-9.9.1.tgz",
       "integrity": "sha1-hPOXKtOUq5YyM6+HJSEbzk0Bv9U=",
+      "dev": true,
       "requires": {
         "abab": "^1.0.0",
         "acorn": "^2.4.0",
@@ -5484,8 +5556,7 @@
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
-      "dev": true
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
     },
     "lodash.tail": {
       "version": "4.1.1",
@@ -6552,7 +6623,13 @@
     "nwmatcher": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.4.tgz",
-      "integrity": "sha512-3iuY4N5dhgMpCUrOVnuAdGrgxVqV2cJpM+XNccjR2DKOB1RUP0aA+wGXEiNziG/UKboFyGBIoKOaNlJxx8bciQ=="
+      "integrity": "sha512-3iuY4N5dhgMpCUrOVnuAdGrgxVqV2cJpM+XNccjR2DKOB1RUP0aA+wGXEiNziG/UKboFyGBIoKOaNlJxx8bciQ==",
+      "dev": true
+    },
+    "nwsapi": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
+      "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ=="
     },
     "oauth-sign": {
       "version": "0.9.0",
@@ -6715,9 +6792,9 @@
       }
     },
     "opds-web-client": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/opds-web-client/-/opds-web-client-0.3.4.tgz",
-      "integrity": "sha512-qpno/swMpFq+glPEJROlmF0AjGALvG2OpfgkVuGOodfJtnWp05TQa2bWzcBwbi4djPrODoRzko1ZhL7zDf8DhQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/opds-web-client/-/opds-web-client-0.4.0.tgz",
+      "integrity": "sha512-Xo6WWgecI0K5gGDVLPqbVCths+IBRDbZ3QvEs4AINqhIovZVNgs7c06/SlsjAEKf1obKtqkr9LcMfz5ebY7cmg==",
       "requires": {
         "@nypl/dgx-svg-icons": "^0.3.4",
         "dompurify": "^0.8.1",
@@ -6725,12 +6802,12 @@
         "font-awesome": "^4.7.0",
         "isomorphic-fetch": "^2.2.1",
         "js-cookie": "^2.1.2",
-        "jsdom": "9.9.1",
+        "jsdom": "^16.2.1",
         "moment": "^2.14.1",
         "opds-feed-parser": "0.0.17",
         "prop-types": "^15.7.2",
-        "react": "^16.8.6",
-        "react-dom": "^16.8.6",
+        "react": "^16.13.1",
+        "react-dom": "^16.13.1",
         "react-redux": "^7.1.0",
         "react-router": "^3.2.0",
         "redux": "4.0.1",
@@ -6741,6 +6818,134 @@
         "xml2js": "^0.4.16"
       },
       "dependencies": {
+        "abab": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.3.tgz",
+          "integrity": "sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg=="
+        },
+        "acorn": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+          "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg=="
+        },
+        "acorn-globals": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-6.0.0.tgz",
+          "integrity": "sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==",
+          "requires": {
+            "acorn": "^7.1.1",
+            "acorn-walk": "^7.1.1"
+          }
+        },
+        "cssom": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
+          "integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw=="
+        },
+        "cssstyle": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.2.0.tgz",
+          "integrity": "sha512-sEb3XFPx3jNnCAMtqrXPDeSgQr+jojtCeNf8cvMNMh1cG970+lljssvQDzPq6lmmJu2Vhqood/gtEomBiHOGnA==",
+          "requires": {
+            "cssom": "~0.3.6"
+          },
+          "dependencies": {
+            "cssom": {
+              "version": "0.3.8",
+              "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+              "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
+            }
+          }
+        },
+        "escodegen": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.1.tgz",
+          "integrity": "sha512-Bmt7NcRySdIfNPfU2ZoXDrrXsG9ZjvDxcAlMfDUgRBjLOWTuIACXPBFJH7Z+cLb40JeQco5toikyc9t9P8E9SQ==",
+          "requires": {
+            "esprima": "^4.0.1",
+            "estraverse": "^4.2.0",
+            "esutils": "^2.0.2",
+            "optionator": "^0.8.1",
+            "source-map": "~0.6.1"
+          }
+        },
+        "esprima": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+        },
+        "html-encoding-sniffer": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
+          "integrity": "sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==",
+          "requires": {
+            "whatwg-encoding": "^1.0.5"
+          }
+        },
+        "jsdom": {
+          "version": "16.2.2",
+          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.2.2.tgz",
+          "integrity": "sha512-pDFQbcYtKBHxRaP55zGXCJWgFHkDAYbKcsXEK/3Icu9nKYZkutUXfLBwbD+09XDutkYSHcgfQLZ0qvpAAm9mvg==",
+          "requires": {
+            "abab": "^2.0.3",
+            "acorn": "^7.1.1",
+            "acorn-globals": "^6.0.0",
+            "cssom": "^0.4.4",
+            "cssstyle": "^2.2.0",
+            "data-urls": "^2.0.0",
+            "decimal.js": "^10.2.0",
+            "domexception": "^2.0.1",
+            "escodegen": "^1.14.1",
+            "html-encoding-sniffer": "^2.0.1",
+            "is-potential-custom-element-name": "^1.0.0",
+            "nwsapi": "^2.2.0",
+            "parse5": "5.1.1",
+            "request": "^2.88.2",
+            "request-promise-native": "^1.0.8",
+            "saxes": "^5.0.0",
+            "symbol-tree": "^3.2.4",
+            "tough-cookie": "^3.0.1",
+            "w3c-hr-time": "^1.0.2",
+            "w3c-xmlserializer": "^2.0.0",
+            "webidl-conversions": "^6.0.0",
+            "whatwg-encoding": "^1.0.5",
+            "whatwg-mimetype": "^2.3.0",
+            "whatwg-url": "^8.0.0",
+            "ws": "^7.2.3",
+            "xml-name-validator": "^3.0.0"
+          }
+        },
+        "parse5": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+          "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug=="
+        },
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+        },
+        "react": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react/-/react-16.13.1.tgz",
+          "integrity": "sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "react-dom": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",
+          "integrity": "sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "scheduler": "^0.19.1"
+          }
+        },
         "redux": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.1.tgz",
@@ -6749,6 +6954,98 @@
             "loose-envify": "^1.4.0",
             "symbol-observable": "^1.2.0"
           }
+        },
+        "request": {
+          "version": "2.88.2",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+          "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.8.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.6",
+            "extend": "~3.0.2",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.2",
+            "har-validator": "~5.1.3",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.19",
+            "oauth-sign": "~0.9.0",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.2",
+            "safe-buffer": "^5.1.2",
+            "tough-cookie": "~2.5.0",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.3.2"
+          },
+          "dependencies": {
+            "tough-cookie": {
+              "version": "2.5.0",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+              "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+              "requires": {
+                "psl": "^1.1.28",
+                "punycode": "^2.1.1"
+              }
+            }
+          }
+        },
+        "scheduler": {
+          "version": "0.19.1",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+          "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "tough-cookie": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
+          "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
+          "requires": {
+            "ip-regex": "^2.1.0",
+            "psl": "^1.1.28",
+            "punycode": "^2.1.1"
+          }
+        },
+        "tr46": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.0.2.tgz",
+          "integrity": "sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==",
+          "requires": {
+            "punycode": "^2.1.1"
+          }
+        },
+        "webidl-conversions": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.0.0.tgz",
+          "integrity": "sha512-jTZAeJnc6D+yAOjygbJOs33kVQIk5H6fj9SFDOhIKjsf9HiAzL/c+tAJsc8ASWafvhNkH+wJZms47pmajkhatA=="
+        },
+        "whatwg-url": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.0.0.tgz",
+          "integrity": "sha512-41ou2Dugpij8/LPO5Pq64K5q++MnRCBpEHvQr26/mArEKTkCV5aoXIqyhuYtE0pkqScXwhf2JP57rkRTYM29lQ==",
+          "requires": {
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^2.0.0",
+            "webidl-conversions": "^5.0.0"
+          },
+          "dependencies": {
+            "webidl-conversions": {
+              "version": "5.0.0",
+              "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+              "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA=="
+            }
+          }
+        },
+        "xml-name-validator": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+          "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
         }
       }
     },
@@ -6990,7 +7287,8 @@
     "parse5": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
-      "integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ="
+      "integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ=",
+      "dev": true
     },
     "pascalcase": {
       "version": "0.1.1",
@@ -7982,6 +8280,31 @@
         }
       }
     },
+    "request-promise-core": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.3.tgz",
+      "integrity": "sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==",
+      "requires": {
+        "lodash": "^4.17.15"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        }
+      }
+    },
+    "request-promise-native": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.8.tgz",
+      "integrity": "sha512-dapwLGqkHtwL5AEbfenuzjTYg35Jd6KPytsC2/TLkVMz8rm+tNt72MGUWT1RP/aYawMpN6HqbNGBQaRcBtjQMQ==",
+      "requires": {
+        "request-promise-core": "1.1.3",
+        "stealthy-require": "^1.1.1",
+        "tough-cookie": "^2.3.3"
+      }
+    },
     "requestidlecallback": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/requestidlecallback/-/requestidlecallback-0.3.0.tgz",
@@ -8234,6 +8557,14 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
+    "saxes": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.0.tgz",
+      "integrity": "sha512-LXTZygxhf8lfwKaTP/8N9CsVdjTlea3teze4lL6u37ivbgGbV0GGMuNtS/I9rnD/HC2/txUM7Df4S2LVl1qhiA==",
+      "requires": {
+        "xmlchars": "^2.2.0"
+      }
     },
     "scheduler": {
       "version": "0.13.6",
@@ -8823,6 +9154,11 @@
         }
       }
     },
+    "stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+    },
     "stream-browserify": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
@@ -9349,7 +9685,8 @@
     "tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+      "dev": true
     },
     "trim-newlines": {
       "version": "1.0.0",
@@ -9912,6 +10249,29 @@
       "integrity": "sha512-iq+S7vZJE60yejDYM0ek6zg308+UZsdtPExWP9VZoCFCz1zkJoXFnAX7aZfd/ZwrkidzdUZL0C/ryW+JwAiIGw==",
       "dev": true
     },
+    "w3c-hr-time": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
+      "integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
+      "requires": {
+        "browser-process-hrtime": "^1.0.0"
+      }
+    },
+    "w3c-xmlserializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz",
+      "integrity": "sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==",
+      "requires": {
+        "xml-name-validator": "^3.0.0"
+      },
+      "dependencies": {
+        "xml-name-validator": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+          "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
+        }
+      }
+    },
     "warning": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
@@ -9934,7 +10294,8 @@
     "webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+      "dev": true
     },
     "webpack": {
       "version": "4.35.3",
@@ -10195,10 +10556,16 @@
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
       "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
     },
+    "whatwg-mimetype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+      "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g=="
+    },
     "whatwg-url": {
       "version": "4.8.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-4.8.0.tgz",
       "integrity": "sha1-0pgaqRSMHgCkHFphMRZqtGg7vMA=",
+      "dev": true,
       "requires": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -10267,10 +10634,16 @@
         "mkdirp": "^0.5.1"
       }
     },
+    "ws": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.3.tgz",
+      "integrity": "sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ=="
+    },
     "xml-name-validator": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
-      "integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU="
+      "integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU=",
+      "dev": true
     },
     "xml2js": {
       "version": "0.4.19",
@@ -10285,6 +10658,11 @@
       "version": "9.0.7",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
       "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+    },
+    "xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
     },
     "xregexp": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.4.16",
+  "version": "0.4.17",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",
@@ -36,7 +36,7 @@
     "library-simplified-reusable-components": "1.3.16",
     "numeral": "^2.0.6",
     "opds-feed-parser": "0.0.17",
-    "opds-web-client": "0.3.4",
+    "opds-web-client": "^0.4.0",
     "prop-types": "^15.7.2",
     "qs": "^6.2.0",
     "react": "^16.8.6",

--- a/src/components/BookEditForm.tsx
+++ b/src/components/BookEditForm.tsx
@@ -2,10 +2,17 @@ import * as React from "react";
 import EditableInput from "./EditableInput";
 import EditorField from "./EditorField";
 import { Form } from "library-simplified-reusable-components";
-import { BookData, ContributorData, RolesData, MediaData, LanguagesData } from "../interfaces";
+import {
+  BookData,
+  ContributorData,
+  RolesData,
+  MediaData,
+  LanguagesData,
+} from "../interfaces";
 import LanguageField from "./LanguageField";
 import { formatString } from "../utils/sharedFunctions";
 import Contributors from "./Contributors";
+import { getMedium } from "opds-web-client/lib/utils/book";
 
 export interface BookEditFormProps extends BookData {
   roles: RolesData;
@@ -21,14 +28,17 @@ export interface BookEditFormState {
 }
 
 /** Edit a book's metadata in the edit tab on the book details page. */
-export default class BookEditForm extends React.Component<BookEditFormProps, BookEditFormState> {
+export default class BookEditForm extends React.Component<
+  BookEditFormProps,
+  BookEditFormState
+> {
   private summaryRef = React.createRef<EditorField>();
   defaultContent = "<p>Update the summary for this book.</p>";
 
   constructor(props) {
     super(props);
     this.state = {
-      contributors: (props.authors || []).concat(props.contributors || [])
+      contributors: (props.authors || []).concat(props.contributors || []),
     };
     this.renderForm = this.renderForm.bind(this);
   }
@@ -44,7 +54,12 @@ export default class BookEditForm extends React.Component<BookEditFormProps, Boo
     );
   }
 
-  renderTextField(name: string, placeholder?: string, value?: string, hasLabel = true): JSX.Element {
+  renderTextField(
+    name: string,
+    placeholder?: string,
+    value?: string,
+    hasLabel = true
+  ): JSX.Element {
     const formattedName = formatString(name);
     const ariaLabel = !hasLabel ? `Field for ${formattedName}` : null;
     return (
@@ -63,20 +78,32 @@ export default class BookEditForm extends React.Component<BookEditFormProps, Boo
   }
 
   renderForm() {
-    const mediumValue = this.getMedium(this.props.medium);
-    const seriesPosition = this.props.seriesPosition !== undefined && this.props.seriesPosition !== null && String(this.props.seriesPosition);
+    const mediumValue = getMedium(this.props.medium);
+    const seriesPosition =
+      this.props.seriesPosition !== undefined &&
+      this.props.seriesPosition !== null &&
+      String(this.props.seriesPosition);
     return (
       <fieldset key="book-info">
         <legend className="visuallyHidden">Edit Book Metadata</legend>
-        { this.renderTextField("title") }
-        { this.renderTextField("subtitle") }
-        <Contributors disabled={this.props.disabled} roles={this.props.roles} contributors={this.state.contributors} />
+        {this.renderTextField("title")}
+        {this.renderTextField("subtitle")}
+        <Contributors
+          disabled={this.props.disabled}
+          roles={this.props.roles}
+          contributors={this.state.contributors}
+        />
         <div className="form-group">
           <label>Series</label>
           <div className="form-inline">
-            { this.renderTextField("series", "Name", null, false) }
+            {this.renderTextField("series", "Name", null, false)}
             <span>&nbsp;&nbsp;</span>
-            { this.renderTextField("series_position", "#", seriesPosition, false) }
+            {this.renderTextField(
+              "series_position",
+              "#",
+              seriesPosition,
+              false
+            )}
           </div>
         </div>
         <EditableInput
@@ -86,10 +113,16 @@ export default class BookEditForm extends React.Component<BookEditFormProps, Boo
           label="Medium"
           value={mediumValue}
         >
-          { this.props.media && Object.values(this.props.media).map(medium =>
-              <option value={medium} key={medium} aria-selected={mediumValue === medium}>{medium}</option>
-            )
-          }
+          {this.props.media &&
+            Object.values(this.props.media).map((medium) => (
+              <option
+                value={medium}
+                key={medium}
+                aria-selected={mediumValue === medium}
+              >
+                {medium}
+              </option>
+            ))}
         </EditableInput>
         <LanguageField
           disabled={this.props.disabled}
@@ -98,8 +131,8 @@ export default class BookEditForm extends React.Component<BookEditFormProps, Boo
           label="Language"
           value={this.props.language}
         />
-        { this.renderTextField("publisher") }
-        { this.renderTextField("imprint") }
+        {this.renderTextField("publisher")}
+        {this.renderTextField("imprint")}
         <EditableInput
           elementType="input"
           type="date"
@@ -143,12 +176,12 @@ export default class BookEditForm extends React.Component<BookEditFormProps, Boo
   }
 
   save(data: FormData) {
-    const summary = (this.summaryRef.current).getValue();
+    const summary = this.summaryRef.current.getValue();
     // Only update the summary if it was intentionally updated.
     if (summary !== this.defaultContent) {
       data.append("summary", summary);
     }
-    this.props.editBook(this.props.editLink.href, data).then(response => {
+    this.props.editBook(this.props.editLink.href, data).then((response) => {
       this.props.refresh();
     });
   }

--- a/src/components/BookEditForm.tsx
+++ b/src/components/BookEditForm.tsx
@@ -12,7 +12,6 @@ import {
 import LanguageField from "./LanguageField";
 import { formatString } from "../utils/sharedFunctions";
 import Contributors from "./Contributors";
-import { getMedium } from "opds-web-client/lib/utils/book";
 
 export interface BookEditFormProps extends BookData {
   roles: RolesData;
@@ -78,7 +77,7 @@ export default class BookEditForm extends React.Component<
   }
 
   renderForm() {
-    const mediumValue = getMedium(this.props.medium);
+    const mediumValue = this.getMedium(this.props.medium);
     const seriesPosition =
       this.props.seriesPosition !== undefined &&
       this.props.seriesPosition !== null &&

--- a/src/components/CustomListEntriesEditor.tsx
+++ b/src/components/CustomListEntriesEditor.tsx
@@ -7,11 +7,9 @@ import TrashIcon from "./icons/TrashIcon";
 import GrabIcon from "./icons/GrabIcon";
 import AddIcon from "./icons/AddIcon";
 import { Button } from "library-simplified-reusable-components";
-import {
-  AudioHeadphoneIcon,
-  BookIcon,
-} from "@nypl/dgx-svg-icons";
+import { AudioHeadphoneIcon, BookIcon } from "@nypl/dgx-svg-icons";
 import CatalogLink from "opds-web-client/lib/components/CatalogLink";
+import { getMedium, getMediumSVG } from "opds-web-client/lib/utils/book";
 import EditableInput from "./EditableInput";
 import { formatString } from "../utils/sharedFunctions";
 
@@ -19,7 +17,8 @@ export interface Entry extends BookData {
   medium?: string;
 }
 
-export interface CustomListEntriesEditorProps extends React.Props<CustomListEntriesEditor> {
+export interface CustomListEntriesEditorProps
+  extends React.Props<CustomListEntriesEditor> {
   entries?: Entry[];
   searchResults?: CollectionData;
   loadMoreSearchResults: (url: string) => Promise<CollectionData>;
@@ -42,7 +41,10 @@ export interface CustomListEntriesEditorState {
 }
 
 /** Drag and drop interface for adding books from search results to a custom list. */
-export default class CustomListEntriesEditor extends React.Component<CustomListEntriesEditorProps, CustomListEntriesEditorState> {
+export default class CustomListEntriesEditor extends React.Component<
+  CustomListEntriesEditorProps,
+  CustomListEntriesEditorState
+> {
   constructor(props) {
     super(props);
     this.state = {
@@ -93,8 +95,10 @@ export default class CustomListEntriesEditor extends React.Component<CustomListE
       } else if (totalEntriesServer - deleted.length !== 0) {
         // The "delete all" button was clicked so there are no books
         // in the visible list, but there could be more on the server.
-        entriesCount = totalEntriesServer > deleted.length ?
-          totalEntriesServer - deleted.length : 0;
+        entriesCount =
+          totalEntriesServer > deleted.length
+            ? totalEntriesServer - deleted.length
+            : 0;
         displayTotal = `0 - 0 of ${entriesCount}`;
         booksText = entriesCount === 1 ? "Book" : "Books";
         entryListDisplay = `Displaying ${displayTotal} ${booksText}`;
@@ -110,19 +114,27 @@ export default class CustomListEntriesEditor extends React.Component<CustomListE
     }
     let resultsToDisplay = searchResults && this.searchResultsNotInEntries();
     return (
-      <DragDropContext onDragStart={this.onDragStart} onDragEnd={this.onDragEnd}>
+      <DragDropContext
+        onDragStart={this.onDragStart}
+        onDragEnd={this.onDragEnd}
+      >
         <div className="custom-list-drag-and-drop">
           <div className="custom-list-search-results">
             <div className="droppable-header">
               <h4>Search Results</h4>
-              { searchResults && (resultsToDisplay.length > 0) &&
+              {searchResults && resultsToDisplay.length > 0 && (
                 <Button
                   key="addAll"
                   className="add-all-button"
                   callback={this.addAll}
-                  content={<span>Add all to list<ApplyIcon /></span>}
+                  content={
+                    <span>
+                      Add all to list
+                      <ApplyIcon />
+                    </span>
+                  }
                 />
-              }
+              )}
             </div>
             <Droppable
               droppableId="search-results"
@@ -131,67 +143,89 @@ export default class CustomListEntriesEditor extends React.Component<CustomListE
               {(provided, snapshot) => (
                 <ul
                   ref={provided.innerRef}
-                  className={snapshot.isDraggingOver ? "droppable dragging-over" : "droppable"}
-                  >
-                  { draggingFrom === "custom-list-entries" &&
-                    <p>Drag books here to remove them from the list.</p>
+                  className={
+                    snapshot.isDraggingOver
+                      ? "droppable dragging-over"
+                      : "droppable"
                   }
-                  { (draggingFrom !== "custom-list-entries") && searchResults && resultsToDisplay.map((book, i) =>
-                    <Draggable key={book.id} draggableId={book.id}>
-                      {(provided, snapshot) => (
-                        <li>
-                          <div
-                            className={"search-result" + (snapshot.isDragging ? " dragging" : "")}
-                            ref={provided.innerRef}
-                            style={provided.draggableStyle}
-                            {...provided.dragHandleProps}
-                          >
-                            <GrabIcon />
-                            <div>
-                              <div className="title">{ book.title }</div>
-                              <div className="authors">{ book.authors.join(", ") }</div>
-                            </div>
-                            {this.getMediumSVG(this.getMedium(book))}
-                            <div className="links">
-                              {this.getCatalogLink(book)}
-                              <Button
-                                callback={() => { this.add(book.id); }}
-                                className="right-align"
-                                content={<span>Add to list<AddIcon /></span>}
-                              />
-                            </div>
-                          </div>
-                          { provided.placeholder }
-                        </li>
-                      )}
-                    </Draggable>
+                >
+                  {draggingFrom === "custom-list-entries" && (
+                    <p>Drag books here to remove them from the list.</p>
                   )}
-                  { provided.placeholder }
+                  {draggingFrom !== "custom-list-entries" &&
+                    searchResults &&
+                    resultsToDisplay.map((book, i) => (
+                      <Draggable key={book.id} draggableId={book.id}>
+                        {(provided, snapshot) => (
+                          <li>
+                            <div
+                              className={
+                                "search-result" +
+                                (snapshot.isDragging ? " dragging" : "")
+                              }
+                              ref={provided.innerRef}
+                              style={provided.draggableStyle}
+                              {...provided.dragHandleProps}
+                            >
+                              <GrabIcon />
+                              <div>
+                                <div className="title">{book.title}</div>
+                                <div className="authors">
+                                  {book.authors.join(", ")}
+                                </div>
+                              </div>
+                              {getMediumSVG(getMedium(book))}
+                              <div className="links">
+                                {this.getCatalogLink(book)}
+                                <Button
+                                  callback={() => {
+                                    this.add(book.id);
+                                  }}
+                                  className="right-align"
+                                  content={
+                                    <span>
+                                      Add to list
+                                      <AddIcon />
+                                    </span>
+                                  }
+                                />
+                              </div>
+                            </div>
+                            {provided.placeholder}
+                          </li>
+                        )}
+                      </Draggable>
+                    ))}
+                  {provided.placeholder}
                 </ul>
               )}
-              </Droppable>
-            { searchResults && searchResults.nextPageUrl &&
+            </Droppable>
+            {searchResults && searchResults.nextPageUrl && (
               <LoadButton
                 isFetching={isFetchingMoreSearchResults}
                 loadMore={this.loadMore}
               />
-            }
+            )}
           </div>
 
           <div className="custom-list-entries">
             <div className="droppable-header">
               <h4>{entryListDisplay}</h4>
-              { (entries && entries.length > 0) &&
+              {entries && entries.length > 0 && (
                 <div>
-                  <span>Remove all currently visible items from list:
-                  </span>
+                  <span>Remove all currently visible items from list:</span>
                   <Button
                     className="danger delete-all-button top-align"
                     callback={this.deleteAll}
-                    content={<span>Delete<TrashIcon /></span>}
+                    content={
+                      <span>
+                        Delete
+                        <TrashIcon />
+                      </span>
+                    }
                   />
                 </div>
-              }
+              )}
             </div>
             <p>Drag search results here to add them to the list.</p>
             <Droppable
@@ -202,48 +236,65 @@ export default class CustomListEntriesEditor extends React.Component<CustomListE
                 <ul
                   ref={provided.innerRef}
                   id="custom-list-entries-droppable"
-                  className={snapshot.isDraggingOver ? " droppable dragging-over" : "droppable"}
+                  className={
+                    snapshot.isDraggingOver
+                      ? " droppable dragging-over"
+                      : "droppable"
+                  }
                 >
-                  { entries && entries.map((book, i) => (
+                  {entries &&
+                    entries.map((book, i) => (
                       <Draggable key={book.id} draggableId={book.id}>
                         {(provided, snapshot) => (
                           <li>
                             <div
-                              className={"custom-list-entry" + (snapshot.isDragging ? " dragging" : "")}
+                              className={
+                                "custom-list-entry" +
+                                (snapshot.isDragging ? " dragging" : "")
+                              }
                               ref={provided.innerRef}
                               style={provided.draggableStyle}
                               {...provided.dragHandleProps}
                             >
                               <GrabIcon />
                               <div>
-                                <div className="title">{ book.title }</div>
-                                <div className="authors">{ book.authors.join(", ") }</div>
+                                <div className="title">{book.title}</div>
+                                <div className="authors">
+                                  {book.authors.join(", ")}
+                                </div>
                               </div>
-                              {this.getMediumSVG(this.getMedium(book))}
+                              {getMediumSVG(getMedium(book))}
                               <div className="links">
                                 {this.getCatalogLink(book)}
                                 <Button
                                   className="small right-align"
-                                  callback={() => { this.delete(book.id); }}
-                                  content={<span>Remove from list<TrashIcon /></span>}
+                                  callback={() => {
+                                    this.delete(book.id);
+                                  }}
+                                  content={
+                                    <span>
+                                      Remove from list
+                                      <TrashIcon />
+                                    </span>
+                                  }
                                 />
                               </div>
                             </div>
-                            { provided.placeholder }
+                            {provided.placeholder}
                           </li>
                         )}
                       </Draggable>
                     ))}
-                  { provided.placeholder }
+                  {provided.placeholder}
                 </ul>
               )}
             </Droppable>
-            { nextPageUrl &&
+            {nextPageUrl && (
               <LoadButton
                 isFetching={isFetchingMoreCustomListEntries}
                 loadMore={this.loadMoreEntries}
               />
-            }
+            )}
           </div>
         </div>
       </DragDropContext>
@@ -272,7 +323,7 @@ export default class CustomListEntriesEditor extends React.Component<CustomListE
       // If there are any deleted entries and the user loads more entries,
       // we want to remove them from the entire combined list.
       if (this.state.deleted.length) {
-        this.state.deleted.forEach(deleteEntry => {
+        this.state.deleted.forEach((deleteEntry) => {
           nextProps.entries.forEach((entry, i) => {
             if (entry.id === deleteEntry.id) {
               nextProps.entries.splice(i, 1);
@@ -296,7 +347,9 @@ export default class CustomListEntriesEditor extends React.Component<CustomListE
         totalVisibleEntries: newEntries.length,
       });
 
-      const droppableList = document.getElementById("custom-list-entries-droppable");
+      const droppableList = document.getElementById(
+        "custom-list-entries-droppable"
+      );
 
       if (droppableList) {
         droppableList.scrollTo(0, 0);
@@ -336,8 +389,12 @@ export default class CustomListEntriesEditor extends React.Component<CustomListE
     }
 
     const svgMediumTypes = {
-      "http://bib.schema.org/Audiobook": <AudioHeadphoneIcon ariaHidden className="draggable-item-icon" />,
-      "http://schema.org/EBook": <BookIcon ariaHidden className="draggable-item-icon" />,
+      "http://bib.schema.org/Audiobook": (
+        <AudioHeadphoneIcon ariaHidden className="draggable-item-icon" />
+      ),
+      "http://schema.org/EBook": (
+        <BookIcon ariaHidden className="draggable-item-icon" />
+      ),
     };
 
     return svgMediumTypes[medium] || null;
@@ -365,19 +422,21 @@ export default class CustomListEntriesEditor extends React.Component<CustomListE
   }
 
   searchResultsNotInEntries() {
-    let entryIds = this.state.entries && this.state.entries.length ?
-      this.state.entries.map(entry => entry.id) : [];
-    let books = this.props.searchResults.books && this.props.searchResults.books.length ?
-      this.props.searchResults.books.filter(book => {
-        for (const entryId of entryIds) {
-          if (entryId === book.id) {
-            return false;
-          }
-        }
-        return true;
-      }) :
-      []
-    ;
+    let entryIds =
+      this.state.entries && this.state.entries.length
+        ? this.state.entries.map((entry) => entry.id)
+        : [];
+    let books =
+      this.props.searchResults.books && this.props.searchResults.books.length
+        ? this.props.searchResults.books.filter((book) => {
+            for (const entryId of entryIds) {
+              if (entryId === book.id) {
+                return false;
+              }
+            }
+            return true;
+          })
+        : [];
     return books;
   }
 
@@ -401,10 +460,17 @@ export default class CustomListEntriesEditor extends React.Component<CustomListE
     const source = result.source;
     const destination = result.destination;
 
-    if (source.droppableId === "search-results" && destination && destination.droppableId === "custom-list-entries") {
+    if (
+      source.droppableId === "search-results" &&
+      destination &&
+      destination.droppableId === "custom-list-entries"
+    ) {
       this.add(draggableId);
-    }
-    else if (source.droppableId === "custom-list-entries" && destination && destination.droppableId === "search-results") {
+    } else if (
+      source.droppableId === "custom-list-entries" &&
+      destination &&
+      destination.droppableId === "search-results"
+    ) {
       this.delete(draggableId);
     } else {
       this.setState({
@@ -423,7 +489,7 @@ export default class CustomListEntriesEditor extends React.Component<CustomListE
     let entry;
     for (const result of this.props.searchResults.books) {
       if (result.id === id) {
-        const medium = this.getMedium(result);
+        const medium = getMedium(result);
         const language = this.getLanguage(result);
         entry = {
           id: result.id,
@@ -437,11 +503,12 @@ export default class CustomListEntriesEditor extends React.Component<CustomListE
       }
     }
 
-    let added = this.state.added.filter(entry => entry.id !== id);
-    let inDeleted = this.state.deleted.filter(entry => entry.id === id);
-    let deleted = this.state.deleted.filter(entry => entry.id !== id);
-    let propEntries = this.props.entries ?
-      this.props.entries.filter(entry => entry.id === id) : [];
+    let added = this.state.added.filter((entry) => entry.id !== id);
+    let inDeleted = this.state.deleted.filter((entry) => entry.id === id);
+    let deleted = this.state.deleted.filter((entry) => entry.id !== id);
+    let propEntries = this.props.entries
+      ? this.props.entries.filter((entry) => entry.id === id)
+      : [];
     this.setState({
       draggingFrom: null,
       entries,
@@ -455,12 +522,14 @@ export default class CustomListEntriesEditor extends React.Component<CustomListE
 
   delete(id: string) {
     let entries = this.state.entries.slice(0);
-    let deleted = this.state.deleted.filter(entry => entry.id !== id);
-    let deletedEntry = this.state.entries.filter(entry => entry.id === id);
-    let added = this.state.added.filter(entry => entry.id !== id);
-    let inAdded = this.props.entries && this.props.entries.length ?
-      this.props.entries.filter(entry => entry.id === id) : [];
-    entries = entries.filter(entry => entry.id !== id);
+    let deleted = this.state.deleted.filter((entry) => entry.id !== id);
+    let deletedEntry = this.state.entries.filter((entry) => entry.id === id);
+    let added = this.state.added.filter((entry) => entry.id !== id);
+    let inAdded =
+      this.props.entries && this.props.entries.length
+        ? this.props.entries.filter((entry) => entry.id === id)
+        : [];
+    entries = entries.filter((entry) => entry.id !== id);
     this.setState({
       draggingFrom: null,
       entries,
@@ -488,7 +557,7 @@ export default class CustomListEntriesEditor extends React.Component<CustomListE
   addAll() {
     let entries = [];
     for (const result of this.searchResultsNotInEntries()) {
-      const medium = this.getMedium(result);
+      const medium = getMedium(result);
       const language = this.getLanguage(result);
       entries.push({
         id: result.id,
@@ -499,10 +568,11 @@ export default class CustomListEntriesEditor extends React.Component<CustomListE
         language,
       });
     }
-    let existingPropEntriesIds = this.props.entries ?
-      this.props.entries.map(entry => entry.id) : [];
-    let newEntriesIds = entries.map(entry => entry.id);
-    let newlyAdded = entries.filter(book => {
+    let existingPropEntriesIds = this.props.entries
+      ? this.props.entries.map((entry) => entry.id)
+      : [];
+    let newEntriesIds = entries.map((entry) => entry.id);
+    let newlyAdded = entries.filter((book) => {
       for (const newEntriesId of existingPropEntriesIds) {
         if (newEntriesId === book.id) {
           return false;
@@ -510,7 +580,7 @@ export default class CustomListEntriesEditor extends React.Component<CustomListE
       }
       return true;
     });
-    let deleted = this.state.deleted.filter(book => {
+    let deleted = this.state.deleted.filter((book) => {
       for (const newEntriesId of newEntriesIds) {
         if (newEntriesId === book.id) {
           return false;
@@ -537,9 +607,10 @@ export default class CustomListEntriesEditor extends React.Component<CustomListE
 
   deleteAll() {
     let entries = this.state.entries.slice(0);
-    let propEntriesId = this.props.entries ?
-      this.props.entries.map(entry => entry.id) : [];
-    let newlyDeleted = entries.filter(book => {
+    let propEntriesId = this.props.entries
+      ? this.props.entries.map((entry) => entry.id)
+      : [];
+    let newlyDeleted = entries.filter((book) => {
       for (const propEntryId of propEntriesId) {
         if (propEntryId === book.id) {
           return true;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -59,9 +59,9 @@ export interface LanguagesData {
 
 export interface RightsStatusData {
   [key: string]: {
-    name: string,
-    open_access: boolean,
-    allows_derivatives: boolean
+    name: string;
+    open_access: boolean;
+    allows_derivatives: boolean;
   };
 }
 
@@ -275,7 +275,7 @@ export interface ServicesWithRegistrationsData extends ServicesData {
   libraryRegistrations?: LibraryRegistrationData[];
 }
 
-export interface CollectionData extends ServiceData {}
+export interface CollectionData extends ServiceData { }
 
 export interface CollectionsData extends ServicesWithRegistrationsData {
   collections: CollectionData[];
@@ -285,7 +285,7 @@ export interface PathFor {
   (collectionUrl: string, bookUrl: string, tab?: string): string;
 }
 
-export interface AdminAuthServiceData extends ServiceData {}
+export interface AdminAuthServiceData extends ServiceData { }
 
 export interface AdminAuthServicesData extends ServicesData {
   admin_auth_services: AdminAuthServiceData[];
@@ -307,7 +307,7 @@ export interface IndividualAdminsData {
   allLibraries?: LibraryData[];
 }
 
-export interface PatronAuthServiceData extends ServiceData {}
+export interface PatronAuthServiceData extends ServiceData { }
 
 export interface PatronAuthServicesData extends ServicesData {
   patron_auth_services: PatronAuthServiceData[];
@@ -338,49 +338,49 @@ export interface SitewideSettingsData {
   all_settings: SettingData[];
 }
 
-export interface LoggingServiceData extends ServiceData {}
+export interface LoggingServiceData extends ServiceData { }
 
 export interface LoggingServicesData extends ServicesData {
   logging_services: LoggingServiceData[];
 }
 
-export interface MetadataServiceData extends ServiceData {}
+export interface MetadataServiceData extends ServiceData { }
 
 export interface MetadataServicesData extends ServicesData {
   metadata_services: MetadataServiceData[];
 }
 
-export interface AnalyticsServiceData extends ServiceData {}
+export interface AnalyticsServiceData extends ServiceData { }
 
 export interface AnalyticsServicesData extends ServicesData {
   analytics_services: AnalyticsServiceData[];
 }
 
-export interface CDNServiceData extends ServiceData {}
+export interface CDNServiceData extends ServiceData { }
 
 export interface CDNServicesData extends ServicesData {
   cdn_services: CDNServiceData[];
 }
 
-export interface SearchServiceData extends ServiceData {}
+export interface SearchServiceData extends ServiceData { }
 
 export interface SearchServicesData extends ServicesData {
   search_services: SearchServiceData[];
 }
 
-export interface StorageServiceData extends ServiceData {}
+export interface StorageServiceData extends ServiceData { }
 
 export interface StorageServicesData extends ServicesData {
   storage_services: StorageServiceData[];
 }
 
-export interface CatalogServiceData extends ServiceData {}
+export interface CatalogServiceData extends ServiceData { }
 
 export interface CatalogServicesData extends ServicesData {
   catalog_services: CatalogServiceData[];
 }
 
-export interface DiscoveryServiceData extends ServiceData {}
+export interface DiscoveryServiceData extends ServiceData { }
 
 export interface DiscoveryServicesData extends ServicesWithRegistrationsData {
   discovery_services: DiscoveryServiceData[];


### PR DESCRIPTION
Ok @EdwinGuzman this PR maps to https://github.com/NYPL-Simplified/opds-web-client/pull/258 and replaces inherited `this.getMedium` and `this.getMediumSVG` with the imported versions. 

This is a draft PR because it _does not_ update the `opds-web-client` package, which will be necessary to make this work. Once the PR in `opds-web-client` is published to npm, we can update the package in this PR and merge it.