### PR TITLE
remove isActive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v0.4.18
+#### Removed
+- Removed a reference to the unused `isActive` property of `opds-web-client`'s `router` context.
+
 ### v0.4.17
 #### Updated
 - Updated version of `opds-web-client` to v0.4.0 and changed reliance on `Book.getMedium` to imported `getMedium` and `getMediumSVG`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.4.17",
+  "version": "0.4.18",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6792,9 +6792,9 @@
       }
     },
     "opds-web-client": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/opds-web-client/-/opds-web-client-0.4.0.tgz",
-      "integrity": "sha512-Xo6WWgecI0K5gGDVLPqbVCths+IBRDbZ3QvEs4AINqhIovZVNgs7c06/SlsjAEKf1obKtqkr9LcMfz5ebY7cmg==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/opds-web-client/-/opds-web-client-0.4.1.tgz",
+      "integrity": "sha512-JfqX3ewX0/vkeVS0PEU1InvyboeyS/wPQ1U/xLyiZjgkX0iHY/w/1kXO6hA711F9vTrYw0rEUTN68AiP4L9g0w==",
       "requires": {
         "@nypl/dgx-svg-icons": "^0.3.4",
         "dompurify": "^0.8.1",
@@ -8559,9 +8559,9 @@
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "saxes": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.0.tgz",
-      "integrity": "sha512-LXTZygxhf8lfwKaTP/8N9CsVdjTlea3teze4lL6u37ivbgGbV0GGMuNtS/I9rnD/HC2/txUM7Df4S2LVl1qhiA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
+      "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
       "requires": {
         "xmlchars": "^2.2.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3455,7 +3455,8 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3479,13 +3480,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3502,19 +3505,22 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3645,7 +3651,8 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3659,6 +3666,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3675,6 +3683,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3683,13 +3692,15 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3710,6 +3721,7 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3798,7 +3810,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3812,6 +3825,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3907,7 +3921,8 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3949,6 +3964,7 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3970,6 +3986,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4018,13 +4035,15 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -6792,9 +6811,9 @@
       }
     },
     "opds-web-client": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/opds-web-client/-/opds-web-client-0.4.1.tgz",
-      "integrity": "sha512-JfqX3ewX0/vkeVS0PEU1InvyboeyS/wPQ1U/xLyiZjgkX0iHY/w/1kXO6hA711F9vTrYw0rEUTN68AiP4L9g0w==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/opds-web-client/-/opds-web-client-0.4.2.tgz",
+      "integrity": "sha512-vnjHeBPoRTexPR43+MhLUc17shvxIPRUC26o6YI6DxmpMEiD8q1c1tDNUJXFdA2/m+cdS+yciIAr3DOF3Wv8SQ==",
       "requires": {
         "@nypl/dgx-svg-icons": "^0.3.4",
         "dompurify": "^0.8.1",
@@ -7021,9 +7040,9 @@
           }
         },
         "webidl-conversions": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.0.0.tgz",
-          "integrity": "sha512-jTZAeJnc6D+yAOjygbJOs33kVQIk5H6fj9SFDOhIKjsf9HiAzL/c+tAJsc8ASWafvhNkH+wJZms47pmajkhatA=="
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+          "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w=="
         },
         "whatwg-url": {
           "version": "8.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.4.16",
+  "version": "0.4.17",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "library-simplified-reusable-components": "1.3.16",
     "numeral": "^2.0.6",
     "opds-feed-parser": "0.0.17",
-    "opds-web-client": "^0.4.0",
+    "opds-web-client": "^0.4.1",
     "prop-types": "^15.7.2",
     "qs": "^6.2.0",
     "react": "^16.8.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.4.17",
+  "version": "0.4.18",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "library-simplified-reusable-components": "1.3.16",
     "numeral": "^2.0.6",
     "opds-feed-parser": "0.0.17",
-    "opds-web-client": "^0.4.1",
+    "opds-web-client": "^0.4.2",
     "prop-types": "^15.7.2",
     "qs": "^6.2.0",
     "react": "^16.8.6",

--- a/src/components/__tests__/routing.ts
+++ b/src/components/__tests__/routing.ts
@@ -6,7 +6,6 @@ export const mockRouter = (push) => {
   return {
     push,
     createHref: (location) => "test href",
-    isActive: (location, onlyActiveOnIndex) => true
   };
 };
 


### PR DESCRIPTION
This PR removes references to the unused `isActive` property in `opds-web-client`'s `router` context. This is the corresponding PR in OWC: https://github.com/NYPL-Simplified/opds-web-client/pull/259