### PR TITLE
Fix view detail link generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### v0.4.18
 #### Removed
 - Removed a reference to the unused `isActive` property of `opds-web-client`'s `router` context.
+#### Fixed
+- Fixed link construction for book `View Detail` button when creating a list in List Manager.
 
 ### v0.4.17
 #### Updated

--- a/src/components/CustomListEditor.tsx
+++ b/src/components/CustomListEditor.tsx
@@ -59,7 +59,8 @@ export default class CustomListEditor extends React.Component<CustomListEditorPr
     const listId = this.props.listId;
     const listTitle = this.props.list && this.props.list.title ? this.props.list.title : "";
     const nextPageUrl = this.props.list && this.props.list.nextPageUrl;
-    const opdsFeedUrl = `${this.props.library?.short_name}/lists/${listTitle}/crawlable`;
+    const crawlable = `${listTitle ? `lists/${listTitle}/` : ""}crawlable`;
+    const opdsFeedUrl = `${this.props.library?.short_name}/${crawlable}`;
     const hasChanges = this.hasChanges();
     // The "save this list" button should be disabled if there are no changes
     // or if the list's title is empty.


### PR DESCRIPTION
## JIRA Ticket

https://jira.nypl.org/browse/SIMPLY-2373

## What does this PR do?

Search results obtained while creating a new list were incorrectly constructed. This is because the link was always being constructed with the list title, but there is not yet a list when creating. The structure looked like this:
```
/<library-short-name>/lists/<list-title>/crawlable
```
or like this when creating (and there is not `list` yet:
```
/<library-short-name>/lists//crawlable
```

When creating a list, the the structure should look like:
```
/<library-short-name>/crawlable
```

## How should this be tested?

It would be good to add a test for this. I’m not a JS person, so it would be great if someone else could add a test or two for this.

I have performed manual live testing to convince myself that the links are generated correctly both when _editing_ and when _creating_ lists.

To recreate this error pre-fix:
- Enter List Manager and ensure that location URL ends in `/create'. If not, click the `Create New List` button and ensure that you have entered create mode.
- Perform a search that yields results.
- Click the `View Details` button for one of `Search Results` items.
- You should receive an error modal with text that begins like:
    ```
    Error
    Could not fetch data: https://<CM-instance>/<library>/lists//crawlable
    ```