### PR TITLE
Announcements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ### v0.4.20
 #### Added
-- Implemented a new LibraryEditForm section so that admins can manage announcements.
+- Implemented a new LibraryEditForm section so that admins can manage library-specific announcements.
 
 ### v0.4.19
-#### Added
-- Implemented a new LibraryEditForm section so that admins can manage announcements.
+#### Fixed
+- Fixed a bug preventing scrolling through the available lists on the Lanes page.
 
 ### v0.4.18
 #### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v0.4.19
+#### Added
+- Implemented a new LibraryEditForm section so that admins can manage announcements.
+
 ### v0.4.18
 #### Removed
 - Removed a reference to the unused `isActive` property of `opds-web-client`'s `router` context.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.4.18",
+  "version": "0.4.19",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/components/Announcement.tsx
+++ b/src/components/Announcement.tsx
@@ -8,8 +8,9 @@ export interface AnnouncementProps {
   startDate?: string;
   endDate?: string;
   onChange?: () => void;
-  delete?: (content: string) => void;
-  edit?: (content: string) => void;
+  id?: number;
+  delete?: (id: number) => void;
+  edit?: (id: number) => Promise<void>;
 }
 
 export default class Announcement extends React.Component<AnnouncementProps, {}> {
@@ -20,11 +21,11 @@ export default class Announcement extends React.Component<AnnouncementProps, {}>
   }
   edit(e) {
     e.preventDefault();
-    this.props.edit(this.props.content);
+    this.props.edit(this.props.id);
   }
   delete(e) {
     e.preventDefault();
-    this.props.delete(this.props.content);
+    this.props.delete(this.props.id);
   }
   format(date) {
     let [year, month, day] = date.split("-");

--- a/src/components/Announcement.tsx
+++ b/src/components/Announcement.tsx
@@ -1,16 +1,13 @@
 import * as React from "react";
-import EditableInput from "./EditableInput";
-import AnnouncementForm from "./AnnouncementForm";
 import { Button } from "library-simplified-reusable-components";
 
 export interface AnnouncementProps {
-  content?: string;
-  start?: string;
-  finish?: string;
-  onChange?: () => void;
-  id?: number;
-  delete?: (id: number) => void;
-  edit?: (id: number) => Promise<void>;
+  content: string;
+  start: string;
+  finish: string;
+  id: string;
+  delete: (id: string) => void;
+  edit: (id: string) => Promise<void>;
 }
 
 export default class Announcement extends React.Component<AnnouncementProps, {}> {
@@ -19,22 +16,24 @@ export default class Announcement extends React.Component<AnnouncementProps, {}>
     this.delete = this.delete.bind(this);
     this.edit = this.edit.bind(this);
   }
-  edit(e) {
+  edit(e: Event) {
     e.preventDefault();
     this.props.edit(this.props.id);
   }
-  delete(e) {
+  delete(e: Event) {
     e.preventDefault();
     this.props.delete(this.props.id);
   }
-  format(date) {
+  format(date: string): string {
+    // The date is stored in the format year-month-day, because that's the format that the date picker
+    // in AnnouncementForm understands.  But month/day/year looks nicer for display purposes.
     if (date) {
       let [year, month, day] = date.split("-");
       return `${month}/${day}/${year}`;
     }
     return "";
   }
-  render() {
+  render(): JSX.Element {
     let announcement = (
       <section className="announcement-info">
         <section className="dates">
@@ -57,20 +56,16 @@ export default class Announcement extends React.Component<AnnouncementProps, {}>
         className="left-align"
       />
     );
-    let renderAnnouncement = () => {
-      return (
-        <div className="announcement">
-          { announcement }
-          <hr />
-          <section className="buttons">
-            { editButton }
-            { deleteButton }
-          </section>
-        </div>
-      );
-    };
+
     return (
-      renderAnnouncement()
+      <div className="announcement">
+        { announcement }
+        <hr />
+        <section className="buttons">
+          { editButton }
+          { deleteButton }
+        </section>
+      </div>
     );
   }
 }

--- a/src/components/Announcement.tsx
+++ b/src/components/Announcement.tsx
@@ -2,7 +2,6 @@ import * as React from "react";
 import EditableInput from "./EditableInput";
 import AnnouncementForm from "./AnnouncementForm";
 import { Button } from "library-simplified-reusable-components";
-// import { Droppable, Draggable } from "react-beautiful-dnd";
 
 export interface AnnouncementProps {
   content?: string;
@@ -36,7 +35,10 @@ export default class Announcement extends React.Component<AnnouncementProps, {}>
   render() {
     let announcement =
       <section className="announcement-info">
-        <span>{this.props.content}: {this.format(this.props.startDate)} to {this.format(this.props.endDate)}</span>
+        <section className="dates">
+          {this.format(this.props.startDate)} – {this.format(this.props.endDate)}
+        </section>
+        <span>{this.props.content}</span>
       </section>
     let editButton = (
       <Button
@@ -49,12 +51,14 @@ export default class Announcement extends React.Component<AnnouncementProps, {}>
       <Button
         content="Delete"
         onClick={(e) => this.delete(e)}
+        className="left-align"
       />
     )
     let renderAnnouncement = (provided?, snapshot?) => {
       return (
         <li className="announcement">
           { announcement }
+          <hr />
           <section className="buttons">
             { editButton }
             { deleteButton }
@@ -64,7 +68,6 @@ export default class Announcement extends React.Component<AnnouncementProps, {}>
     }
     return (
       renderAnnouncement()
-      // <Draggable draggableId={this.props.content} key={this.props.content}>{(provided, snapshot) => renderAnnouncement(provided, snapshot)}</Draggable>
     )
   }
 }

--- a/src/components/Announcement.tsx
+++ b/src/components/Announcement.tsx
@@ -2,12 +2,13 @@ import * as React from "react";
 import EditableInput from "./EditableInput";
 import AnnouncementForm from "./AnnouncementForm";
 import { Button } from "library-simplified-reusable-components";
-import { Droppable, Draggable } from "react-beautiful-dnd";
+// import { Droppable, Draggable } from "react-beautiful-dnd";
 
 export interface AnnouncementProps {
   content?: string;
   startDate?: string;
   endDate?: string;
+  position?: number;
   onChange?: () => void;
   editable?: boolean;
   delete?: (content: string) => void;
@@ -30,8 +31,11 @@ export default class Announcement extends React.Component<AnnouncementProps, {}>
     this.props.delete(this.props.content);
   }
   render() {
+    // <span className="position">#{this.props.position}</span>
     let announcement =
-      <span>{this.props.content}: {this.props.startDate} to {this.props.endDate}</span>;
+      <section className="announcement-info">
+        <span>{this.props.content}: {this.props.startDate} to {this.props.endDate}</span>
+      </section>
     let editButton = (
       <Button
         content="Edit"
@@ -45,7 +49,7 @@ export default class Announcement extends React.Component<AnnouncementProps, {}>
         onClick={(e) => this.delete(e)}
       />
     )
-    let renderAnnouncement = (provided, snapshot) => {
+    let renderAnnouncement = (provided?, snapshot?) => {
       return (
         <li className="announcement">
           { announcement }
@@ -57,7 +61,8 @@ export default class Announcement extends React.Component<AnnouncementProps, {}>
       )
     }
     return (
-      <Draggable draggableId={this.props.content} key={this.props.content}>{(provided, snapshot) => renderAnnouncement(provided, snapshot)}</Draggable>
+      renderAnnouncement()
+      // <Draggable draggableId={this.props.content} key={this.props.content}>{(provided, snapshot) => renderAnnouncement(provided, snapshot)}</Draggable>
     )
   }
 }

--- a/src/components/Announcement.tsx
+++ b/src/components/Announcement.tsx
@@ -27,7 +27,6 @@ export default class Announcement extends React.Component<AnnouncementProps, {}>
   }
   delete(e) {
     e.preventDefault();
-    console.log(this.props);
     this.props.delete(this.props.content);
   }
   render() {

--- a/src/components/Announcement.tsx
+++ b/src/components/Announcement.tsx
@@ -7,7 +7,7 @@ export interface AnnouncementProps {
   finish: string;
   id: string;
   delete: (id: string) => void;
-  edit: (id: string) => Promise<void>;
+  edit: (id: string) => void;
 }
 
 export default class Announcement extends React.Component<AnnouncementProps, {}> {

--- a/src/components/Announcement.tsx
+++ b/src/components/Announcement.tsx
@@ -5,8 +5,8 @@ import { Button } from "library-simplified-reusable-components";
 
 export interface AnnouncementProps {
   content?: string;
-  startDate?: string;
-  endDate?: string;
+  start?: string;
+  finish?: string;
   onChange?: () => void;
   id?: number;
   delete?: (id: number) => void;
@@ -28,14 +28,17 @@ export default class Announcement extends React.Component<AnnouncementProps, {}>
     this.props.delete(this.props.id);
   }
   format(date) {
-    let [year, month, day] = date.split("-");
-    return `${month}/${day}/${year}`;
+    if (date) {
+      let [year, month, day] = date.split("-");
+      return `${month}/${day}/${year}`;
+    }
+    return "";
   }
   render() {
     let announcement = (
       <section className="announcement-info">
         <section className="dates">
-          {this.format(this.props.startDate)} – {this.format(this.props.endDate)}
+          {this.format(this.props.start)} – {this.format(this.props.finish)}
         </section>
         <span>{this.props.content}</span>
       </section>

--- a/src/components/Announcement.tsx
+++ b/src/components/Announcement.tsx
@@ -29,11 +29,14 @@ export default class Announcement extends React.Component<AnnouncementProps, {}>
     e.preventDefault();
     this.props.delete(this.props.content);
   }
+  format(date) {
+    let [year, month, day] = date.split("-");
+    return `${month}/${day}/${year}`;
+  }
   render() {
-    // <span className="position">#{this.props.position}</span>
     let announcement =
       <section className="announcement-info">
-        <span>{this.props.content}: {this.props.startDate} to {this.props.endDate}</span>
+        <span>{this.props.content}: {this.format(this.props.startDate)} to {this.format(this.props.endDate)}</span>
       </section>
     let editButton = (
       <Button

--- a/src/components/Announcement.tsx
+++ b/src/components/Announcement.tsx
@@ -1,0 +1,63 @@
+import * as React from "react";
+import EditableInput from "./EditableInput";
+import AnnouncementForm from "./AnnouncementForm";
+import { Button } from "library-simplified-reusable-components";
+import { Droppable, Draggable } from "react-beautiful-dnd";
+
+export interface AnnouncementProps {
+  content?: string;
+  startDate?: string;
+  endDate?: string;
+  onChange?: () => void;
+  editable?: boolean;
+  delete?: (content: string) => void;
+  edit?: (content: string) => void;
+}
+
+export default class Announcement extends React.Component<AnnouncementProps, {}> {
+  constructor(props: AnnouncementProps) {
+    super(props);
+    this.delete = this.delete.bind(this);
+    this.edit = this.edit.bind(this);
+  }
+  edit(e) {
+    e.preventDefault();
+    this.props.edit(this.props.content);
+  }
+  delete(e) {
+    e.preventDefault();
+    console.log(this.props);
+    this.props.delete(this.props.content);
+  }
+  render() {
+    let announcement =
+      <span>{this.props.content}: {this.props.startDate} to {this.props.endDate}</span>;
+    let editButton = (
+      <Button
+        content="Edit"
+        onClick={(e) => this.edit(e)}
+        className="left-align"
+      />
+    )
+    let deleteButton = (
+      <Button
+        content="Delete"
+        onClick={(e) => this.delete(e)}
+      />
+    )
+    let renderAnnouncement = (provided, snapshot) => {
+      return (
+        <li className="announcement">
+          { announcement }
+          <section className="buttons">
+            { editButton }
+            { deleteButton }
+          </section>
+        </li>
+      )
+    }
+    return (
+      <Draggable draggableId={this.props.content} key={this.props.content}>{(provided, snapshot) => renderAnnouncement(provided, snapshot)}</Draggable>
+    )
+  }
+}

--- a/src/components/Announcement.tsx
+++ b/src/components/Announcement.tsx
@@ -7,9 +7,7 @@ export interface AnnouncementProps {
   content?: string;
   startDate?: string;
   endDate?: string;
-  position?: number;
   onChange?: () => void;
-  editable?: boolean;
   delete?: (content: string) => void;
   edit?: (content: string) => void;
 }
@@ -33,41 +31,42 @@ export default class Announcement extends React.Component<AnnouncementProps, {}>
     return `${month}/${day}/${year}`;
   }
   render() {
-    let announcement =
+    let announcement = (
       <section className="announcement-info">
         <section className="dates">
           {this.format(this.props.startDate)} – {this.format(this.props.endDate)}
         </section>
         <span>{this.props.content}</span>
       </section>
+    );
     let editButton = (
       <Button
         content="Edit"
         onClick={(e) => this.edit(e)}
         className="left-align"
       />
-    )
+    );
     let deleteButton = (
       <Button
         content="Delete"
         onClick={(e) => this.delete(e)}
         className="left-align"
       />
-    )
-    let renderAnnouncement = (provided?, snapshot?) => {
+    );
+    let renderAnnouncement = () => {
       return (
-        <li className="announcement">
+        <div className="announcement">
           { announcement }
           <hr />
           <section className="buttons">
             { editButton }
             { deleteButton }
           </section>
-        </li>
-      )
-    }
+        </div>
+      );
+    };
     return (
       renderAnnouncement()
-    )
+    );
   }
 }

--- a/src/components/AnnouncementForm.tsx
+++ b/src/components/AnnouncementForm.tsx
@@ -32,8 +32,11 @@ export default class AnnouncementForm extends React.Component<AnnouncementFormPr
     let finish = this.formatDate(new Date(today.setMonth(today.getMonth() + 2)));
     return [start, finish];
   }
-  formatDate(date: Date): string {
-    let [month, day, year] = date.toLocaleDateString().split("/");
+  formatDate(date: Date | string): string {
+    if (typeof date === "string" && date.indexOf("/") === -1) {
+      return date;
+    }
+    let [month, day, year] = typeof date === "string" ? date.split("/") : date.toLocaleDateString().split("/");
     return `${year}-${month.toString().length === 1 ? "0" + month : month}-${day.toString().length === 1 ? "0" + day : day}`;
   }
   updateContent(content: string) {
@@ -77,8 +80,8 @@ export default class AnnouncementForm extends React.Component<AnnouncementFormPr
     // Switch from creating a new announcement to editing an existing one.
     // if (newProps.content !== this.props.content) {
     if (newProps.content?.length > 0) {
-      let formatDate = (dateString) => this.formatDate(new Date(dateString));
-      this.setState({ content: newProps.content, start: formatDate(newProps.start), finish: formatDate(newProps.finish) });
+      let [content, start, finish] = [newProps.content, newProps.start, newProps.finish];
+      this.setState({ content: content, start: this.formatDate(start), finish: this.formatDate(finish) });
     }
   }
   render(): JSX.Element {

--- a/src/components/AnnouncementForm.tsx
+++ b/src/components/AnnouncementForm.tsx
@@ -46,7 +46,17 @@ export default class AnnouncementForm extends React.Component<AnnouncementFormPr
   add(e) {
     e.preventDefault();
     this.props.add({ content: this.state.content, startDate: this.state.startDate, endDate: this.state.endDate });
-    this.setState({ content: "", startDate: "", endDate: "" });
+    let [start, end] = this.getDefaultDates()
+    this.setState({content: "", startDate: start, endDate: end});
+  }
+  cancel(e) {
+    e.preventDefault();
+    if (this.props.content) {
+      this.add(e);
+    } else {
+      let [start, end] = this.getDefaultDates()
+      this.setState({content: "", startDate: start, endDate: end});
+    }
   }
   componentWillReceiveProps(newProps: AnnouncementFormProps) {
     if (newProps.content !== this.props.content) {
@@ -54,12 +64,21 @@ export default class AnnouncementForm extends React.Component<AnnouncementFormPr
     }
   }
   render(): JSX.Element {
+    let shouldDisable = () => {
+      if (!this.state.content || !this.state.startDate || !this.state.endDate) {
+        return true;
+      } else if (this.state.content.length < 15 || this.state.content.length > 300){
+        return true;
+      }
+      return false;
+    }
     return (
       <div>
-        <EditableInput type="text" value={this.state.content} label="Content" optionalText={false} onChange={(e) => this.updateContent(e)} />
+        <EditableInput className={this.state.content.length < 15 && "too-short"} elementType="textarea" type="text" minlength={15} maxlength={300} value={this.state.content} label="Content (15–300 characters)" optionalText={false} onChange={(e) => this.updateContent(e)} description={`(${this.state.content.length}/300)`} />
         <EditableInput type="date" max={this.state.endDate} value={this.state.startDate} label="Start" optionalText={false} onChange={(e) => this.updateStartDate(e)} description="If no start date is chosen, the default start date is today's date."/>
         <EditableInput type="date" min={this.state.startDate} value={this.state.endDate} label="End" optionalText={false} onChange={(e) => this.updateEndDate(e)} description="If no expiration date is chosen, the default expiration date is 2 months from the start date." />
-        <Button callback={(e) => this.add(e)} className="left-align" disabled={!(this.state.content && this.state.startDate && this.state.endDate)}/>
+        <Button callback={(e) => this.add(e)} className="inline left-align" disabled={shouldDisable()}/>
+        <Button callback={(e) => this.cancel(e)} content="Cancel" className="inline left-align" />
       </div>
     );
   }

--- a/src/components/AnnouncementForm.tsx
+++ b/src/components/AnnouncementForm.tsx
@@ -74,9 +74,25 @@ export default class AnnouncementForm extends React.Component<AnnouncementFormPr
     }
     return (
       <div>
-        <EditableInput className={this.state.content.length < 15 && "too-short"} elementType="textarea" type="text" minlength={15} maxlength={300} value={this.state.content} label="Content (15–300 characters)" optionalText={false} onChange={(e) => this.updateContent(e)} description={`(${this.state.content.length}/300)`} />
-        <EditableInput type="date" max={this.state.endDate} value={this.state.startDate} label="Start" optionalText={false} onChange={(e) => this.updateStartDate(e)} description="If no start date is chosen, the default start date is today's date."/>
-        <EditableInput type="date" min={this.state.startDate} value={this.state.endDate} label="End" optionalText={false} onChange={(e) => this.updateEndDate(e)} description="If no expiration date is chosen, the default expiration date is 2 months from the start date." />
+        <EditableInput className={(this.state.content.length < 15 || this.state.content.length >= 300) && "wrong-length"} elementType="textarea" type="text" minlength={15} maxlength={300} value={this.state.content} label="Content (15–300 characters)" optionalText={false} onChange={(e) => this.updateContent(e)} description={`(${this.state.content.length}/300)`} />
+        <EditableInput
+          type="date"
+          max={this.state.endDate}
+          value={this.state.startDate}
+          label="Start"
+          optionalText={true}
+          onChange={(e) => this.updateStartDate(e)}
+          description="If no start date is chosen, the default start date is today's date."
+        />
+        <EditableInput
+          type="date"
+          min={this.state.startDate}
+          value={this.state.endDate}
+          label="End"
+          optionalText={true}
+          onChange={(e) => this.updateEndDate(e)}
+          description="If no expiration date is chosen, the default expiration date is 2 months from the start date."
+        />
         <Button callback={(e) => this.add(e)} className="inline left-align" disabled={shouldDisable()}/>
         <Button callback={(e) => this.cancel(e)} content="Cancel" className="inline left-align" />
       </div>

--- a/src/components/AnnouncementForm.tsx
+++ b/src/components/AnnouncementForm.tsx
@@ -6,8 +6,7 @@ export interface AnnouncementFormProps {
   content?: string;
   startDate?: string;
   endDate?: string;
-  onChange?: () => void;
-  add?: (announcement: any) => void;
+  add: (announcement: any) => void;
 }
 
 export interface AnnouncementFormState {

--- a/src/components/AnnouncementForm.tsx
+++ b/src/components/AnnouncementForm.tsx
@@ -6,6 +6,7 @@ export interface AnnouncementFormProps {
   content?: string;
   startDate?: string;
   endDate?: string;
+  position?: number;
   onChange?: () => void;
   add?: (announcement: any) => void;
 }
@@ -14,6 +15,7 @@ export interface AnnouncementFormState {
   content?: string;
   startDate?: string;
   endDate?: string;
+  position?: number;
 }
 
 export default class AnnouncementForm extends React.Component<AnnouncementFormProps, AnnouncementFormState>{
@@ -21,29 +23,34 @@ export default class AnnouncementForm extends React.Component<AnnouncementFormPr
     super(props);
     this.updateStartDate = this.updateStartDate.bind(this);
     this.updateEndDate = this.updateEndDate.bind(this);
-    this.getValue = this.getValue.bind(this);
-    this.state = {content: this.props.content || "", startDate: this.props.startDate || "", endDate: this.props.endDate || ""};
+    // this.updatePosition = this.updatePosition.bind(this);
+    this.state = {content: this.props.content || "", startDate: this.formatStartDate(this.props.startDate) || this.formatStartDate(), endDate: this.props.endDate || "", position: this.props.position || null};
+  }
+  formatStartDate(date?) {
+    let today = new Date();
+    let [month, day, year] = date?.split("/") || today.toLocaleDateString().split("/");
+    return `${year}-${month.length === 1 ? "0" + month : month}-${day}`;
   }
   updateContent(content) {
     this.setState({ content });
-    this.props.onChange();
   }
   updateStartDate(startDate) {
     this.setState({ startDate });
-    this.props.onChange();
   }
   updateEndDate(endDate) {
     this.setState({ endDate });
-    this.props.onChange();
   }
+  // updatePosition(position) {
+  //   this.setState({ position: parseInt(position) });
+  // }
   add(e) {
     e.preventDefault();
-    this.props.add({ content: this.state.content, startDate: this.state.startDate, endDate: this.state.endDate });
-    this.setState({ content: "", startDate: "", endDate: "" });
+    this.props.add({ content: this.state.content, startDate: this.state.startDate, endDate: this.state.endDate, position: this.state.position });
+    this.setState({ content: "", startDate: "", endDate: "", position: null });
   }
   componentWillReceiveProps(newProps: AnnouncementFormProps) {
     if (newProps.content !== this.props.content) {
-      this.setState({ content: newProps.content, startDate: newProps.startDate, endDate: newProps.endDate });
+      this.setState({ content: newProps.content, startDate: this.formatStartDate(newProps.startDate), endDate: newProps.endDate });
     }
   }
   render(): JSX.Element {
@@ -55,15 +62,18 @@ export default class AnnouncementForm extends React.Component<AnnouncementFormPr
       type: "list"
     }
     return (
-      <div className="">
+      // <EditableInput elementType="select" name="position" label="Position" ref="position" value={this.state.position} onChange={(e) => this.updatePosition(e)}>
+      // <option aria-selected={!this.state.position}></option>
+      // <option aria-selected={this.state.position === 1}>1</option>
+      // <option aria-selected={this.state.position === 2}>2</option>
+      // <option aria-selected={this.state.position === 3}>3</option>
+      // </EditableInput>
+      <div>
         <EditableInput type="text" value={this.state.content} label="Content" optionalText={false} onChange={(e) => this.updateContent(e)} />
-        <EditableInput type="date" max={this.state.endDate} value={this.state.startDate} label="Start" optionalText={false} onChange={(e) => this.updateStartDate(e)} />
-        <EditableInput type="date" min={this.state.startDate} value={this.state.endDate} label="End" optionalText={false} onChange={(e) => this.updateEndDate(e)} />
-        <Button callback={(e) => this.add(e)} className="left-align" content="Add" disabled={!(this.state.content && this.state.startDate && this.state.endDate)}/>
+        <EditableInput type="date" max={this.state.endDate} value={this.state.startDate} label="Start" optionalText={false} onChange={(e) => this.updateStartDate(e)} description="If no start date is chosen, the default start date is today's date."/>
+        <EditableInput type="date" min={this.state.startDate} value={this.state.endDate} label="End" optionalText={false} onChange={(e) => this.updateEndDate(e)} description="If no expiration date is chosen, the default expiration date is 2 months from the start date." />
+        <Button callback={(e) => this.add(e)} className="left-align" content="Add" disabled={!(this.state.content && this.state.startDate && this.state.endDate && this.state.position)}/>
       </div>
     );
-  }
-  getValue() {
-    return `${this.state.content}: ${this.state.startDate} to ${this.state.endDate}`;
   }
 }

--- a/src/components/AnnouncementForm.tsx
+++ b/src/components/AnnouncementForm.tsx
@@ -80,7 +80,7 @@ export default class AnnouncementForm extends React.Component<AnnouncementFormPr
     // Switch from creating a new announcement to editing an existing one.
     // if (newProps.content !== this.props.content) {
     if (newProps.content?.length > 0) {
-      let [content, start, finish] = [newProps.content, newProps.start, newProps.finish];
+      const { content, start, finish } = newProps;
       this.setState({ content: content, start: this.formatDate(start), finish: this.formatDate(finish) });
     }
   }
@@ -97,12 +97,12 @@ export default class AnnouncementForm extends React.Component<AnnouncementFormPr
     };
     return (
       <div className="announcement-form">
-        <EditableInput className={wrongLength && "wrong-length"} elementType="textarea" type="text" minLength={15} maxLength={350} value={this.state.content} label="Content (15-350 characters)" optionalText={false} onChange={(e) => this.updateContent(e)} description={`(${this.state.content.length}/350)`} />
+        <EditableInput className={wrongLength && "wrong-length"} elementType="textarea" type="text" minLength={15} maxLength={350} value={this.state.content} label="Content (15-350 characters)" optionalText={false} onChange={(e) => this.updateContent(e)} description={`(Current length: ${this.state.content.length}/350)`} />
         <EditableInput
           type="date"
           max={this.state.finish}
           value={this.state.start}
-          label="Start"
+          label="Start Date"
           optionalText={true}
           onChange={(e) => this.updateStartDate(e)}
           description="If no start date is chosen, the default start date is today's date."
@@ -111,7 +111,7 @@ export default class AnnouncementForm extends React.Component<AnnouncementFormPr
           type="date"
           min={this.state.start}
           value={this.state.finish}
-          label="End"
+          label="End Date"
           optionalText={true}
           onChange={(e) => this.updateEndDate(e)}
           description="If no expiration date is chosen, the default expiration date is 2 months from the start date."

--- a/src/components/AnnouncementForm.tsx
+++ b/src/components/AnnouncementForm.tsx
@@ -6,6 +6,7 @@ export interface AnnouncementFormProps {
   content?: string;
   start?: string;
   finish?: string;
+  id?: string;
   add: (announcement: any) => void;
 }
 
@@ -13,6 +14,7 @@ export interface AnnouncementFormState {
   content?: string;
   start?: string;
   finish?: string;
+  id?: string;
 }
 
 export default class AnnouncementForm extends React.Component<AnnouncementFormProps, AnnouncementFormState> {
@@ -53,8 +55,9 @@ export default class AnnouncementForm extends React.Component<AnnouncementFormPr
     this.setState({ finish });
   }
   add(e: Event) {
+    // Add the current announcement to the list of announcements in the parent component (AnnouncementsSection)
     e.preventDefault();
-    this.props.add({ content: this.state.content, start: this.state.start, finish: this.state.finish });
+    this.props.add({ content: this.state.content, start: this.state.start, finish: this.state.finish, id: this.props.id || null });
     // Restore the form to default dates and an empty content field.
     let [start, finish] = this.getDefaultDates();
     this.setState({content: "", start: start, finish: finish});
@@ -72,23 +75,26 @@ export default class AnnouncementForm extends React.Component<AnnouncementFormPr
   }
   componentWillReceiveProps(newProps: AnnouncementFormProps) {
     // Switch from creating a new announcement to editing an existing one.
-    if (newProps.content !== this.props.content) {
-      this.setState({ content: newProps.content, start: this.formatDate(new Date(newProps.start)), finish: this.formatDate(new Date(newProps.finish)) });
+    // if (newProps.content !== this.props.content) {
+    if (newProps.content?.length > 0) {
+      let formatDate = (dateString) => this.formatDate(new Date(dateString));
+      this.setState({ content: newProps.content, start: formatDate(newProps.start), finish: formatDate(newProps.finish) });
     }
   }
   render(): JSX.Element {
     // None of the fields can be blank.  Content must be between 15 and 350 characters.
+    let wrongLength = this.state.content.length < 15 || this.state.content.length >= 350;
     let shouldDisable = () => {
       if (!this.state.content || !this.state.start || !this.state.finish) {
         return true;
-      } else if (this.state.content.length < 15 || this.state.content.length > 350) {
+      } else if (wrongLength) {
         return true;
       }
       return false;
     };
     return (
       <div className="announcement-form">
-        <EditableInput className={(this.state.content.length < 15 || this.state.content.length >= 350) && "wrong-length"} elementType="textarea" type="text" minLength={15} maxLength={350} value={this.state.content} label="Content (15-350 characters)" optionalText={false} onChange={(e) => this.updateContent(e)} description={`(${this.state.content.length}/350)`} />
+        <EditableInput className={wrongLength && "wrong-length"} elementType="textarea" type="text" minLength={15} maxLength={350} value={this.state.content} label="Content (15-350 characters)" optionalText={false} onChange={(e) => this.updateContent(e)} description={`(${this.state.content.length}/350)`} />
         <EditableInput
           type="date"
           max={this.state.finish}

--- a/src/components/AnnouncementForm.tsx
+++ b/src/components/AnnouncementForm.tsx
@@ -6,7 +6,6 @@ export interface AnnouncementFormProps {
   content?: string;
   start?: string;
   finish?: string;
-  id?: number;
   add: (announcement: any) => void;
 }
 
@@ -14,7 +13,6 @@ export interface AnnouncementFormState {
   content?: string;
   start?: string;
   finish?: string;
-  id?: number;
 }
 
 export default class AnnouncementForm extends React.Component<AnnouncementFormProps, AnnouncementFormState> {
@@ -26,6 +24,7 @@ export default class AnnouncementForm extends React.Component<AnnouncementFormPr
     this.state = {content: "", start: start, finish: finish};
   }
   getDefaultDates(): string[] {
+    // By default, the start date is today's date and the end date is two months from today.
     let today = new Date();
     let start = this.formatDate(today);
     let finish = this.formatDate(new Date(today.setMonth(today.getMonth() + 2)));
@@ -44,27 +43,32 @@ export default class AnnouncementForm extends React.Component<AnnouncementFormPr
   updateEndDate(finish: string) {
     this.setState({ finish });
   }
-  add(e) {
+  add(e: Event) {
     e.preventDefault();
     this.props.add({ content: this.state.content, start: this.state.start, finish: this.state.finish });
+    // Restore the form to default dates and an empty content field.
     let [start, finish] = this.getDefaultDates();
     this.setState({content: "", start: start, finish: finish});
   }
-  cancel(e) {
+  cancel(e: Event) {
     e.preventDefault();
+    // If an existing announcement was being edited, just put it back into the list.
     if (this.props.content) {
       this.add(e);
     } else {
+      // Blank out the content field and restore the dates to their defaults.
       let [start, finish] = this.getDefaultDates();
       this.setState({content: "", start: start, finish: finish});
     }
   }
   componentWillReceiveProps(newProps: AnnouncementFormProps) {
+    // Switch from creating a new announcement to editing an existing one.
     if (newProps.content !== this.props.content) {
       this.setState({ content: newProps.content, start: this.formatDate(new Date(newProps.start)), finish: this.formatDate(new Date(newProps.finish)) });
     }
   }
   render(): JSX.Element {
+    // None of the fields can be blank.  Content must be between 15 and 350 characters.
     let shouldDisable = () => {
       if (!this.state.content || !this.state.start || !this.state.finish) {
         return true;
@@ -94,8 +98,8 @@ export default class AnnouncementForm extends React.Component<AnnouncementFormPr
           onChange={(e) => this.updateEndDate(e)}
           description="If no expiration date is chosen, the default expiration date is 2 months from the start date."
         />
-        <Button callback={(e) => this.add(e)} className="inline left-align" disabled={shouldDisable()}/>
-        <Button callback={(e) => this.cancel(e)} content="Cancel" className="inline left-align" />
+        <Button callback={(e: Event) => this.add(e)} className="inline left-align" disabled={shouldDisable()}/>
+        <Button callback={(e: Event) => this.cancel(e)} content="Cancel" className="inline left-align" />
       </div>
     );
   }

--- a/src/components/AnnouncementForm.tsx
+++ b/src/components/AnnouncementForm.tsx
@@ -6,6 +6,7 @@ export interface AnnouncementFormProps {
   content?: string;
   startDate?: string;
   endDate?: string;
+  id?: number;
   add: (announcement: any) => void;
 }
 
@@ -13,6 +14,7 @@ export interface AnnouncementFormState {
   content?: string;
   startDate?: string;
   endDate?: string;
+  id?: number;
 }
 
 export default class AnnouncementForm extends React.Component<AnnouncementFormProps, AnnouncementFormState> {

--- a/src/components/AnnouncementForm.tsx
+++ b/src/components/AnnouncementForm.tsx
@@ -6,7 +6,6 @@ export interface AnnouncementFormProps {
   content?: string;
   startDate?: string;
   endDate?: string;
-  position?: number;
   onChange?: () => void;
   add?: (announcement: any) => void;
 }
@@ -15,7 +14,6 @@ export interface AnnouncementFormState {
   content?: string;
   startDate?: string;
   endDate?: string;
-  position?: number;
 }
 
 export default class AnnouncementForm extends React.Component<AnnouncementFormProps, AnnouncementFormState>{
@@ -23,54 +21,45 @@ export default class AnnouncementForm extends React.Component<AnnouncementFormPr
     super(props);
     this.updateStartDate = this.updateStartDate.bind(this);
     this.updateEndDate = this.updateEndDate.bind(this);
-    // this.updatePosition = this.updatePosition.bind(this);
-    this.state = {content: this.props.content || "", startDate: this.formatStartDate(this.props.startDate) || this.formatStartDate(), endDate: this.props.endDate || "", position: this.props.position || null};
+    let [start, end] = this.getDefaultDates()
+    this.state = {content: "", startDate: start, endDate: end};
   }
-  formatStartDate(date?) {
+  getDefaultDates(): string[] {
     let today = new Date();
-    let [month, day, year] = date?.split("/") || today.toLocaleDateString().split("/");
-    return `${year}-${month.length === 1 ? "0" + month : month}-${day}`;
+    let startDate = this.formatDate(today);
+    let endDate = this.formatDate(new Date(today.setMonth(today.getMonth() + 2)));
+    return [startDate, endDate];
   }
-  updateContent(content) {
+  formatDate(date: Date): string {
+    let [month, day, year] = date.toLocaleDateString().split("/");
+    return `${year}-${month.toString().length === 1 ? "0" + month : month}-${day.toString().length === 1 ? "0" + day : day}`;
+  }
+  updateContent(content: string) {
     this.setState({ content });
   }
-  updateStartDate(startDate) {
+  updateStartDate(startDate: string) {
     this.setState({ startDate });
   }
-  updateEndDate(endDate) {
+  updateEndDate(endDate: string) {
     this.setState({ endDate });
   }
-
   add(e) {
     e.preventDefault();
-    this.props.add({ content: this.state.content, startDate: this.state.startDate, endDate: this.state.endDate, position: this.state.position });
-    this.setState({ content: "", startDate: "", endDate: "", position: null });
+    this.props.add({ content: this.state.content, startDate: this.state.startDate, endDate: this.state.endDate });
+    this.setState({ content: "", startDate: "", endDate: "" });
   }
   componentWillReceiveProps(newProps: AnnouncementFormProps) {
     if (newProps.content !== this.props.content) {
-      this.setState({ content: newProps.content, startDate: this.formatStartDate(newProps.startDate), endDate: newProps.endDate });
+      this.setState({ content: newProps.content, startDate: this.formatDate(new Date(newProps.startDate)), endDate: this.formatDate(new Date(newProps.endDate)) });
     }
   }
   render(): JSX.Element {
-    let sampleSetting = {
-      description: "announcements",
-      format: "date-range",
-      key: "announcements",
-      label: "Announcements",
-      type: "list"
-    }
     return (
-      // <EditableInput elementType="select" name="position" label="Position" ref="position" value={this.state.position} onChange={(e) => this.updatePosition(e)}>
-      // <option aria-selected={!this.state.position}></option>
-      // <option aria-selected={this.state.position === 1}>1</option>
-      // <option aria-selected={this.state.position === 2}>2</option>
-      // <option aria-selected={this.state.position === 3}>3</option>
-      // </EditableInput>
       <div>
         <EditableInput type="text" value={this.state.content} label="Content" optionalText={false} onChange={(e) => this.updateContent(e)} />
         <EditableInput type="date" max={this.state.endDate} value={this.state.startDate} label="Start" optionalText={false} onChange={(e) => this.updateStartDate(e)} description="If no start date is chosen, the default start date is today's date."/>
         <EditableInput type="date" min={this.state.startDate} value={this.state.endDate} label="End" optionalText={false} onChange={(e) => this.updateEndDate(e)} description="If no expiration date is chosen, the default expiration date is 2 months from the start date." />
-        <Button callback={(e) => this.add(e)} className="left-align" content="Add" disabled={!(this.state.content && this.state.startDate && this.state.endDate && this.state.position)}/>
+        <Button callback={(e) => this.add(e)} className="left-align" disabled={!(this.state.content && this.state.startDate && this.state.endDate)}/>
       </div>
     );
   }

--- a/src/components/AnnouncementForm.tsx
+++ b/src/components/AnnouncementForm.tsx
@@ -1,0 +1,69 @@
+import * as React from "react";
+import EditableInput from "./EditableInput";
+import { Button } from "library-simplified-reusable-components";
+
+export interface AnnouncementFormProps {
+  content?: string;
+  startDate?: string;
+  endDate?: string;
+  onChange?: () => void;
+  add?: (announcement: any) => void;
+}
+
+export interface AnnouncementFormState {
+  content?: string;
+  startDate?: string;
+  endDate?: string;
+}
+
+export default class AnnouncementForm extends React.Component<AnnouncementFormProps, AnnouncementFormState>{
+  constructor(props: AnnouncementFormProps) {
+    super(props);
+    this.updateStartDate = this.updateStartDate.bind(this);
+    this.updateEndDate = this.updateEndDate.bind(this);
+    this.getValue = this.getValue.bind(this);
+    this.state = {content: this.props.content || "", startDate: this.props.startDate || "", endDate: this.props.endDate || ""};
+  }
+  updateContent(content) {
+    this.setState({ content });
+    this.props.onChange();
+  }
+  updateStartDate(startDate) {
+    this.setState({ startDate });
+    this.props.onChange();
+  }
+  updateEndDate(endDate) {
+    this.setState({ endDate });
+    this.props.onChange();
+  }
+  add(e) {
+    e.preventDefault();
+    this.props.add({ content: this.state.content, startDate: this.state.startDate, endDate: this.state.endDate });
+    this.setState({ content: "", startDate: "", endDate: "" });
+  }
+  componentWillReceiveProps(newProps: AnnouncementFormProps) {
+    if (newProps.content !== this.props.content) {
+      this.setState({ content: newProps.content, startDate: newProps.startDate, endDate: newProps.endDate });
+    }
+  }
+  render(): JSX.Element {
+    let sampleSetting = {
+      description: "announcements",
+      format: "date-range",
+      key: "announcements",
+      label: "Announcements",
+      type: "list"
+    }
+    return (
+      <div className="">
+        <EditableInput type="text" value={this.state.content} label="Content" optionalText={false} onChange={(e) => this.updateContent(e)} />
+        <EditableInput type="date" max={this.state.endDate} value={this.state.startDate} label="Start" optionalText={false} onChange={(e) => this.updateStartDate(e)} />
+        <EditableInput type="date" min={this.state.startDate} value={this.state.endDate} label="End" optionalText={false} onChange={(e) => this.updateEndDate(e)} />
+        <Button callback={(e) => this.add(e)} className="left-align" content="Add" disabled={!(this.state.content && this.state.startDate && this.state.endDate)}/>
+      </div>
+    );
+  }
+  getValue() {
+    return `${this.state.content}: ${this.state.startDate} to ${this.state.endDate}`;
+  }
+}

--- a/src/components/AnnouncementForm.tsx
+++ b/src/components/AnnouncementForm.tsx
@@ -16,12 +16,12 @@ export interface AnnouncementFormState {
   endDate?: string;
 }
 
-export default class AnnouncementForm extends React.Component<AnnouncementFormProps, AnnouncementFormState>{
+export default class AnnouncementForm extends React.Component<AnnouncementFormProps, AnnouncementFormState> {
   constructor(props: AnnouncementFormProps) {
     super(props);
     this.updateStartDate = this.updateStartDate.bind(this);
     this.updateEndDate = this.updateEndDate.bind(this);
-    let [start, end] = this.getDefaultDates()
+    let [start, end] = this.getDefaultDates();
     this.state = {content: "", startDate: start, endDate: end};
   }
   getDefaultDates(): string[] {
@@ -46,7 +46,7 @@ export default class AnnouncementForm extends React.Component<AnnouncementFormPr
   add(e) {
     e.preventDefault();
     this.props.add({ content: this.state.content, startDate: this.state.startDate, endDate: this.state.endDate });
-    let [start, end] = this.getDefaultDates()
+    let [start, end] = this.getDefaultDates();
     this.setState({content: "", startDate: start, endDate: end});
   }
   cancel(e) {
@@ -54,7 +54,7 @@ export default class AnnouncementForm extends React.Component<AnnouncementFormPr
     if (this.props.content) {
       this.add(e);
     } else {
-      let [start, end] = this.getDefaultDates()
+      let [start, end] = this.getDefaultDates();
       this.setState({content: "", startDate: start, endDate: end});
     }
   }
@@ -67,14 +67,14 @@ export default class AnnouncementForm extends React.Component<AnnouncementFormPr
     let shouldDisable = () => {
       if (!this.state.content || !this.state.startDate || !this.state.endDate) {
         return true;
-      } else if (this.state.content.length < 15 || this.state.content.length > 300){
+      } else if (this.state.content.length < 15 || this.state.content.length > 350) {
         return true;
       }
       return false;
-    }
+    };
     return (
-      <div>
-        <EditableInput className={(this.state.content.length < 15 || this.state.content.length >= 300) && "wrong-length"} elementType="textarea" type="text" minlength={15} maxlength={300} value={this.state.content} label="Content (15–300 characters)" optionalText={false} onChange={(e) => this.updateContent(e)} description={`(${this.state.content.length}/300)`} />
+      <div className="announcement-form">
+        <EditableInput className={(this.state.content.length < 15 || this.state.content.length >= 350) && "wrong-length"} elementType="textarea" type="text" minLength={15} maxLength={350} value={this.state.content} label="Content (15-350 characters)" optionalText={false} onChange={(e) => this.updateContent(e)} description={`(${this.state.content.length}/350)`} />
         <EditableInput
           type="date"
           max={this.state.endDate}

--- a/src/components/AnnouncementForm.tsx
+++ b/src/components/AnnouncementForm.tsx
@@ -40,9 +40,7 @@ export default class AnnouncementForm extends React.Component<AnnouncementFormPr
   updateEndDate(endDate) {
     this.setState({ endDate });
   }
-  // updatePosition(position) {
-  //   this.setState({ position: parseInt(position) });
-  // }
+
   add(e) {
     e.preventDefault();
     this.props.add({ content: this.state.content, startDate: this.state.startDate, endDate: this.state.endDate, position: this.state.position });

--- a/src/components/AnnouncementForm.tsx
+++ b/src/components/AnnouncementForm.tsx
@@ -4,16 +4,16 @@ import { Button } from "library-simplified-reusable-components";
 
 export interface AnnouncementFormProps {
   content?: string;
-  startDate?: string;
-  endDate?: string;
+  start?: string;
+  finish?: string;
   id?: number;
   add: (announcement: any) => void;
 }
 
 export interface AnnouncementFormState {
   content?: string;
-  startDate?: string;
-  endDate?: string;
+  start?: string;
+  finish?: string;
   id?: number;
 }
 
@@ -22,14 +22,14 @@ export default class AnnouncementForm extends React.Component<AnnouncementFormPr
     super(props);
     this.updateStartDate = this.updateStartDate.bind(this);
     this.updateEndDate = this.updateEndDate.bind(this);
-    let [start, end] = this.getDefaultDates();
-    this.state = {content: "", startDate: start, endDate: end};
+    let [start, finish] = this.getDefaultDates();
+    this.state = {content: "", start: start, finish: finish};
   }
   getDefaultDates(): string[] {
     let today = new Date();
-    let startDate = this.formatDate(today);
-    let endDate = this.formatDate(new Date(today.setMonth(today.getMonth() + 2)));
-    return [startDate, endDate];
+    let start = this.formatDate(today);
+    let finish = this.formatDate(new Date(today.setMonth(today.getMonth() + 2)));
+    return [start, finish];
   }
   formatDate(date: Date): string {
     let [month, day, year] = date.toLocaleDateString().split("/");
@@ -38,35 +38,35 @@ export default class AnnouncementForm extends React.Component<AnnouncementFormPr
   updateContent(content: string) {
     this.setState({ content });
   }
-  updateStartDate(startDate: string) {
-    this.setState({ startDate });
+  updateStartDate(start: string) {
+    this.setState({ start });
   }
-  updateEndDate(endDate: string) {
-    this.setState({ endDate });
+  updateEndDate(finish: string) {
+    this.setState({ finish });
   }
   add(e) {
     e.preventDefault();
-    this.props.add({ content: this.state.content, startDate: this.state.startDate, endDate: this.state.endDate });
-    let [start, end] = this.getDefaultDates();
-    this.setState({content: "", startDate: start, endDate: end});
+    this.props.add({ content: this.state.content, start: this.state.start, finish: this.state.finish });
+    let [start, finish] = this.getDefaultDates();
+    this.setState({content: "", start: start, finish: finish});
   }
   cancel(e) {
     e.preventDefault();
     if (this.props.content) {
       this.add(e);
     } else {
-      let [start, end] = this.getDefaultDates();
-      this.setState({content: "", startDate: start, endDate: end});
+      let [start, finish] = this.getDefaultDates();
+      this.setState({content: "", start: start, finish: finish});
     }
   }
   componentWillReceiveProps(newProps: AnnouncementFormProps) {
     if (newProps.content !== this.props.content) {
-      this.setState({ content: newProps.content, startDate: this.formatDate(new Date(newProps.startDate)), endDate: this.formatDate(new Date(newProps.endDate)) });
+      this.setState({ content: newProps.content, start: this.formatDate(new Date(newProps.start)), finish: this.formatDate(new Date(newProps.finish)) });
     }
   }
   render(): JSX.Element {
     let shouldDisable = () => {
-      if (!this.state.content || !this.state.startDate || !this.state.endDate) {
+      if (!this.state.content || !this.state.start || !this.state.finish) {
         return true;
       } else if (this.state.content.length < 15 || this.state.content.length > 350) {
         return true;
@@ -78,8 +78,8 @@ export default class AnnouncementForm extends React.Component<AnnouncementFormPr
         <EditableInput className={(this.state.content.length < 15 || this.state.content.length >= 350) && "wrong-length"} elementType="textarea" type="text" minLength={15} maxLength={350} value={this.state.content} label="Content (15-350 characters)" optionalText={false} onChange={(e) => this.updateContent(e)} description={`(${this.state.content.length}/350)`} />
         <EditableInput
           type="date"
-          max={this.state.endDate}
-          value={this.state.startDate}
+          max={this.state.finish}
+          value={this.state.start}
           label="Start"
           optionalText={true}
           onChange={(e) => this.updateStartDate(e)}
@@ -87,8 +87,8 @@ export default class AnnouncementForm extends React.Component<AnnouncementFormPr
         />
         <EditableInput
           type="date"
-          min={this.state.startDate}
-          value={this.state.endDate}
+          min={this.state.start}
+          value={this.state.finish}
           label="End"
           optionalText={true}
           onChange={(e) => this.updateEndDate(e)}

--- a/src/components/AnnouncementForm.tsx
+++ b/src/components/AnnouncementForm.tsx
@@ -39,6 +39,15 @@ export default class AnnouncementForm extends React.Component<AnnouncementFormPr
   }
   updateStartDate(start: string) {
     this.setState({ start });
+    // The first time you change the start date, the end date updates to be two months later.
+    // Presumably, if the end date has already been changed away from the default, then it's already where
+    // you want it, and it would just be annoying/confusing for it to keep jumping around every time you change the start date,
+    if (this.state.finish === this.getDefaultDates()[1]) {
+      let startDate = new Date(start);
+      let newMonth = startDate.getMonth() + 2;
+      let finishDate = startDate.setMonth(newMonth);
+      this.setState({ finish: this.formatDate(new Date(finishDate)) });
+    }
   }
   updateEndDate(finish: string) {
     this.setState({ finish });

--- a/src/components/AnnouncementsSection.tsx
+++ b/src/components/AnnouncementsSection.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { SettingData } from "../interfaces";
+import { SettingData, AnnouncementData } from "../interfaces";
 import AnnouncementForm from "./AnnouncementForm";
 import Announcement from "./Announcement";
 
@@ -7,19 +7,14 @@ export interface AnnouncementsSectionProps {
   setting: SettingData;
   value?: Array<any>;
 }
-export interface AnnouncementData {
-  id?: number;
-  content: string;
-  start: string;
-  finish: string;
-}
+
 export interface AnnouncementsSectionState {
   currentAnnouncements: Array<AnnouncementData>;
   editing?: any;
 }
 
 export default class AnnouncementsSection extends React.Component<AnnouncementsSectionProps, AnnouncementsSectionState> {
-  constructor(props) {
+  constructor(props: AnnouncementsSectionProps) {
     super(props);
     this.addAnnouncement = this.addAnnouncement.bind(this);
     this.deleteAnnouncement = this.deleteAnnouncement.bind(this);
@@ -27,19 +22,19 @@ export default class AnnouncementsSection extends React.Component<AnnouncementsS
     this.getValue = this.getValue.bind(this);
     this.state = { currentAnnouncements: Array.isArray(this.props.value) ? this.props.value : [] };
   }
-  addAnnouncement(announcement) {
+  addAnnouncement(announcement: AnnouncementData) {
     let announcements = this.state.currentAnnouncements;
     this.setState({ currentAnnouncements: announcements.concat(announcement) });
   }
-  deleteAnnouncement(id: number) {
+  deleteAnnouncement(id: string) {
     if (window.confirm("This will remove this announcement from your list. Are you sure you want to continue?")) {
       this.setState({ currentAnnouncements: this.state.currentAnnouncements.filter(a => a.id !== id), editing: null});
     }
   }
-  async editAnnouncement(id: number) {
+  async editAnnouncement(id: string) {
     await this.setState({ editing: this.state.currentAnnouncements.find(a => a.id === id), currentAnnouncements: this.state.currentAnnouncements.filter(a => a.id !== id) });
   }
-  renderAnnouncement(a) {
+  renderAnnouncement(a: AnnouncementData): JSX.Element {
     return (
       <Announcement
         key={a.content}
@@ -52,7 +47,7 @@ export default class AnnouncementsSection extends React.Component<AnnouncementsS
       />
     );
   }
-  renderList() {
+  renderList(): JSX.Element {
     return (
       <ul className="announcements-ul">
         {
@@ -65,7 +60,7 @@ export default class AnnouncementsSection extends React.Component<AnnouncementsS
       </ul>
     );
   }
-  render() {
+  render(): JSX.Element {
     return (
       <div className="announcements-section">
         { this.state.currentAnnouncements.length > 0 && this.renderList() }
@@ -73,7 +68,7 @@ export default class AnnouncementsSection extends React.Component<AnnouncementsS
       </div>
     );
   }
-  getValue() {
+  getValue(): Array<AnnouncementData> {
     return this.state.currentAnnouncements;
   }
 }

--- a/src/components/AnnouncementsSection.tsx
+++ b/src/components/AnnouncementsSection.tsx
@@ -31,13 +31,13 @@ export default class AnnouncementsSection extends React.Component<AnnouncementsS
     let announcements = this.state.currentAnnouncements;
     this.setState({ currentAnnouncements: announcements.concat(announcement) });
   }
-  deleteAnnouncement(content) {
+  deleteAnnouncement(id: number) {
     if (window.confirm("This will remove this announcement from your list. Are you sure you want to continue?")) {
-      this.setState({ currentAnnouncements: this.state.currentAnnouncements.filter(a => a.content !== content), editing: null});
+      this.setState({ currentAnnouncements: this.state.currentAnnouncements.filter(a => a.id !== id), editing: null});
     }
   }
-  async editAnnouncement(content) {
-    await this.setState({ editing: this.state.currentAnnouncements.filter(a => a.content === content)[0], currentAnnouncements: this.state.currentAnnouncements.filter(a => a.content !== content) });
+  async editAnnouncement(id: number) {
+    await this.setState({ editing: this.state.currentAnnouncements.find(a => a.id === id), currentAnnouncements: this.state.currentAnnouncements.filter(a => a.id !== id) });
   }
   renderAnnouncement(a) {
     return (
@@ -46,6 +46,7 @@ export default class AnnouncementsSection extends React.Component<AnnouncementsS
         content={a.content}
         startDate={a.startDate}
         endDate={a.endDate}
+        id={a.id}
         delete={this.deleteAnnouncement}
         edit={this.editAnnouncement}
       />

--- a/src/components/AnnouncementsSection.tsx
+++ b/src/components/AnnouncementsSection.tsx
@@ -54,10 +54,17 @@ export default class AnnouncementsSection extends React.Component<AnnouncementsS
     );
   }
   renderList(): JSX.Element {
+    let compareStartDate = (x, y) => {
+      if (x.start < y.start) {
+        return -1;
+      } else if (x.start > y.start) {
+        return 1;
+      }
+    };
     return (
       <ul className="announcements-ul">
         {
-          Array.isArray(this.state.currentAnnouncements) && this.state.currentAnnouncements.map(a =>
+          Array.isArray(this.state.currentAnnouncements) && this.state.currentAnnouncements.sort(compareStartDate).map(a =>
               <li key={a.id}>
                 {this.renderAnnouncement(a)}
               </li>

--- a/src/components/AnnouncementsSection.tsx
+++ b/src/components/AnnouncementsSection.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { SettingData } from "../interfaces";
 import AnnouncementForm from "./AnnouncementForm";
 import Announcement from "./Announcement";
-import { DragDropContext, Droppable, Draggable } from "react-beautiful-dnd";
+// import { DragDropContext, Droppable, Draggable } from "react-beautiful-dnd";
 
 export interface AnnouncementsSectionProps {
   setting: SettingData;
@@ -19,76 +19,137 @@ export default class AnnouncementsSection extends React.Component<AnnouncementsS
     this.addAnnouncement = this.addAnnouncement.bind(this);
     this.deleteAnnouncement = this.deleteAnnouncement.bind(this);
     this.editAnnouncement = this.editAnnouncement.bind(this);
-    this.onDragStart = this.onDragStart.bind(this);
-    this.onDragEnd = this.onDragEnd.bind(this);
+    // this.onDragStart = this.onDragStart.bind(this);
+    // this.onDragEnd = this.onDragEnd.bind(this);
     this.state = { currentAnnouncements: this.props.value || [] }
   }
-  onDragStart(initial) {
-    console.log("HIT");
-    document.body.classList.add("dragging");
-    const draggableId = initial.draggableId;
-    const draggingFrom = initial.source.droppableId;
-    console.log(draggableId, draggingFrom);
-      // this.props.drag({ draggableId, draggingFrom });
-  }
-  onDragEnd() {
-    console.log("DRAG END");
-  }
+  // onDragStart(initial) {
+  //   console.log("HIT");
+  //   document.body.classList.add("dragging");
+  //   const draggableId = initial.draggableId;
+  //   const draggingFrom = initial.source.droppableId;
+  //     // this.props.drag({ draggableId, draggingFrom });
+  // }
+  // onDragEnd() {
+  //   console.log("DRAG END");
+  // }
   addAnnouncement(announcement) {
-    this.setState({ currentAnnouncements: this.state.currentAnnouncements.concat(announcement) });
+    let announcements = this.state.currentAnnouncements;
+    // let positionConflict = this.state.currentAnnouncements.filter(a => a.position === announcement.position);
+    // let oldAnnouncement = this.state.currentAnnouncements.filter(a => a.content === announcement.content);
+    // if (positionConflict[0]) {
+    //   let extra = this.state.currentAnnouncements.filter(a => a.content !== announcement.content && a.content !== positionConflict[0].content);
+    //   announcements = this.reorder(positionConflict[0], announcement.position, extra[0] || null);
+    // }
+    this.setState({ currentAnnouncements: announcements.concat(announcement) });
   }
   deleteAnnouncement(content) {
     this.setState({ currentAnnouncements: this.state.currentAnnouncements.filter(a => a.content !== content), editing: null});
   }
+  reorder(conflicting, position, extra?) {
+    if (this.state.currentAnnouncements.length < 2) {
+      let newIndex = position === 1 ? 2 : 1;
+      let updated = {...conflicting, ...{position: newIndex}};
+      return [updated];
+    } else {
+      let third = this.state.currentAnnouncements.find(a => a.content !== conflicting.content);
+      if (position === 2 && third.position === 3) {
+        let updated = {...conflicting, ...{position: 3}};
+        third = {...third, ...{position: 1}};
+        return [updated, third];
+      } else if (position === 3 && third.position === 2) {
+        let updated = {...conflicting, ...{position: 1}};
+        return [updated, third];
+      }
+      else if (position == 1 && third.position === 2) {
+        let updated = {...conflicting, ...{position: 2}};
+        third = {...third, ...{position: 3}};
+        return [updated, third];
+      }
+      else if (position == 3 && third.position === 1) {
+        let updated = {...conflicting, ...{position: 1}};
+        third = {...third, ...{position: 2}};
+        return [updated, third];
+      }
+      else if (position == 1 && third.position === 3) {
+        let updated = {...conflicting, ...{position: 2}};
+        return [updated, third];
+      }
+    }
+  }
   async editAnnouncement(content) {
     await this.setState({ editing: this.state.currentAnnouncements.filter(a => a.content === content)[0], currentAnnouncements: this.state.currentAnnouncements.filter(a => a.content !== content) });
   }
-  renderAnnouncement(a, provided, snapshot) {
+  renderAnnouncement(a, provided?, snapshot?) {
     return (
       <Announcement
-        ref={provided.innerRefk}
-        {...provided.draggbleProps}
-        {...provided.dragHandleProps}
         key={a.content}
         content={a.content}
         startDate={a.startDate}
         endDate={a.endDate}
+        position={a.position}
         delete={this.deleteAnnouncement}
         edit={this.editAnnouncement}
       />
     );
+    // return (
+    //   <Announcement
+    //     ref={provided.innerRefk}
+    //     {...provided.draggbleProps}
+    //     {...provided.dragHandleProps}
+    //     key={a.content}
+    //     content={a.content}
+    //     startDate={a.startDate}
+    //     endDate={a.endDate}
+    //     position={a.position}
+    //     delete={this.deleteAnnouncement}
+    //     edit={this.editAnnouncement}
+    //   />
+    // );
   }
   renderList() {
     return (
-      <Droppable droppableId="droppable">
-        {
-          (provided, snapshot) => {
-            return (
-              <ul {...provided.droppableProps} ref={provided.innerRef} className={"announcements-ul " + (snapshot.isDraggingOver ? "droppable dragging-over" : "droppable")}>
+
+              <ul className="announcements-ul">
                 {
-                  this.state.currentAnnouncements.map(a => {
-                    return (
-                      <Draggable
-                        key={a.content}
-                        draggableId={a.content}
-                      >{(provided, snapshot) => this.renderAnnouncement(a, provided, snapshot)}
-                      </Draggable>
-                    )
-                  })
+                  this.state.currentAnnouncements.map(a =>
+                      <li key={a.content}>
+                        {this.renderAnnouncement(a)}
+                      </li>
+                  )
                 }
-                {provided.placeholder}
               </ul>
-            )}
-        }
-      </Droppable>
     );
+    // return (
+    //   <Droppable droppableId="droppable">
+    //     {
+    //       (provided, snapshot) => {
+    //         return (
+    //           <ul {...provided.droppableProps} ref={provided.innerRef} className={"announcements-ul " + (snapshot.isDraggingOver ? "droppable dragging-over" : "droppable")}>
+    //             {
+    //               this.state.currentAnnouncements.map(a => {
+    //                 return (
+    //                   <Draggable
+    //                     key={a.content}
+    //                     draggableId={a.content}
+    //                   >{(provided, snapshot) => this.renderAnnouncement(a, provided, snapshot)}
+    //                   </Draggable>
+    //                 )
+    //               })
+    //             }
+    //             {provided.placeholder}
+    //           </ul>
+    //         )}
+    //     }
+    //   </Droppable>
+    // );
   }
   render() {
+    // <DragDropContext onDragStart={this.onDragStart} onDragEnd={this.onDragEnd}>
+    // </DragDropContext>
     return (
       <div className="announcements-section">
-        <DragDropContext onDragStart={this.onDragStart} onDragEnd={this.onDragEnd}>
-          { this.renderList() }
-        </DragDropContext>
+        { this.renderList() }
         { this.state.currentAnnouncements.length < 3 && <AnnouncementForm add={this.addAnnouncement} content={this.state.editing?.content} startDate={this.state.editing?.startDate} endDate={this.state.editing?.endDate} /> }
       </div>
     )

--- a/src/components/AnnouncementsSection.tsx
+++ b/src/components/AnnouncementsSection.tsx
@@ -18,7 +18,7 @@ export default class AnnouncementsSection extends React.Component<AnnouncementsS
     this.addAnnouncement = this.addAnnouncement.bind(this);
     this.deleteAnnouncement = this.deleteAnnouncement.bind(this);
     this.editAnnouncement = this.editAnnouncement.bind(this);
-    this.state = { currentAnnouncements: this.props.value || [] }
+    this.state = { currentAnnouncements: this.props.value || [] };
   }
   addAnnouncement(announcement) {
     let announcements = this.state.currentAnnouncements;
@@ -32,14 +32,13 @@ export default class AnnouncementsSection extends React.Component<AnnouncementsS
   async editAnnouncement(content) {
     await this.setState({ editing: this.state.currentAnnouncements.filter(a => a.content === content)[0], currentAnnouncements: this.state.currentAnnouncements.filter(a => a.content !== content) });
   }
-  renderAnnouncement(a, provided?, snapshot?) {
+  renderAnnouncement(a) {
     return (
       <Announcement
         key={a.content}
         content={a.content}
         startDate={a.startDate}
         endDate={a.endDate}
-        position={a.position}
         delete={this.deleteAnnouncement}
         edit={this.editAnnouncement}
       />
@@ -64,6 +63,6 @@ export default class AnnouncementsSection extends React.Component<AnnouncementsS
         { this.state.currentAnnouncements.length > 0 && this.renderList() }
         { this.state.currentAnnouncements.length < 3 && <AnnouncementForm add={this.addAnnouncement} content={this.state.editing?.content} startDate={this.state.editing?.startDate} endDate={this.state.editing?.endDate} /> }
       </div>
-    )
+    );
   }
 }

--- a/src/components/AnnouncementsSection.tsx
+++ b/src/components/AnnouncementsSection.tsx
@@ -1,0 +1,96 @@
+import * as React from "react";
+import { SettingData } from "../interfaces";
+import AnnouncementForm from "./AnnouncementForm";
+import Announcement from "./Announcement";
+import { DragDropContext, Droppable, Draggable } from "react-beautiful-dnd";
+
+export interface AnnouncementsSectionProps {
+  setting: SettingData;
+  value?: Array<any>;
+}
+export interface AnnouncementsSectionState {
+  currentAnnouncements: Array<any>;
+  editing?: any;
+}
+
+export default class AnnouncementsSection extends React.Component<AnnouncementsSectionProps, AnnouncementsSectionState> {
+  constructor(props) {
+    super(props);
+    this.addAnnouncement = this.addAnnouncement.bind(this);
+    this.deleteAnnouncement = this.deleteAnnouncement.bind(this);
+    this.editAnnouncement = this.editAnnouncement.bind(this);
+    this.onDragStart = this.onDragStart.bind(this);
+    this.onDragEnd = this.onDragEnd.bind(this);
+    this.state = { currentAnnouncements: this.props.value || [] }
+  }
+  onDragStart(initial) {
+    console.log("HIT");
+    document.body.classList.add("dragging");
+    const draggableId = initial.draggableId;
+    const draggingFrom = initial.source.droppableId;
+    console.log(draggableId, draggingFrom);
+      // this.props.drag({ draggableId, draggingFrom });
+  }
+  onDragEnd() {
+    console.log("DRAG END");
+  }
+  addAnnouncement(announcement) {
+    this.setState({ currentAnnouncements: this.state.currentAnnouncements.concat(announcement) });
+  }
+  deleteAnnouncement(content) {
+    this.setState({ currentAnnouncements: this.state.currentAnnouncements.filter(a => a.content !== content), editing: null});
+  }
+  async editAnnouncement(content) {
+    await this.setState({ editing: this.state.currentAnnouncements.filter(a => a.content === content)[0], currentAnnouncements: this.state.currentAnnouncements.filter(a => a.content !== content) });
+  }
+  renderAnnouncement(a, provided, snapshot) {
+    return (
+      <Announcement
+        ref={provided.innerRefk}
+        {...provided.draggbleProps}
+        {...provided.dragHandleProps}
+        key={a.content}
+        content={a.content}
+        startDate={a.startDate}
+        endDate={a.endDate}
+        delete={this.deleteAnnouncement}
+        edit={this.editAnnouncement}
+      />
+    );
+  }
+  renderList() {
+    return (
+      <Droppable droppableId="droppable">
+        {
+          (provided, snapshot) => {
+            return (
+              <ul {...provided.droppableProps} ref={provided.innerRef} className={"announcements-ul " + (snapshot.isDraggingOver ? "droppable dragging-over" : "droppable")}>
+                {
+                  this.state.currentAnnouncements.map(a => {
+                    return (
+                      <Draggable
+                        key={a.content}
+                        draggableId={a.content}
+                      >{(provided, snapshot) => this.renderAnnouncement(a, provided, snapshot)}
+                      </Draggable>
+                    )
+                  })
+                }
+                {provided.placeholder}
+              </ul>
+            )}
+        }
+      </Droppable>
+    );
+  }
+  render() {
+    return (
+      <div className="announcements-section">
+        <DragDropContext onDragStart={this.onDragStart} onDragEnd={this.onDragEnd}>
+          { this.renderList() }
+        </DragDropContext>
+        { this.state.currentAnnouncements.length < 3 && <AnnouncementForm add={this.addAnnouncement} content={this.state.editing?.content} startDate={this.state.editing?.startDate} endDate={this.state.editing?.endDate} /> }
+      </div>
+    )
+  }
+}

--- a/src/components/AnnouncementsSection.tsx
+++ b/src/components/AnnouncementsSection.tsx
@@ -149,7 +149,7 @@ export default class AnnouncementsSection extends React.Component<AnnouncementsS
     // </DragDropContext>
     return (
       <div className="announcements-section">
-        { this.renderList() }
+        { this.state.currentAnnouncements.length > 0 && this.renderList() }
         { this.state.currentAnnouncements.length < 3 && <AnnouncementForm add={this.addAnnouncement} content={this.state.editing?.content} startDate={this.state.editing?.startDate} endDate={this.state.editing?.endDate} /> }
       </div>
     )

--- a/src/components/AnnouncementsSection.tsx
+++ b/src/components/AnnouncementsSection.tsx
@@ -31,14 +31,14 @@ export default class AnnouncementsSection extends React.Component<AnnouncementsS
       this.setState({ currentAnnouncements: this.state.currentAnnouncements.filter(a => a.id !== id), editing: null});
     }
   }
-  async editAnnouncement(id: string) {
+  editAnnouncement(id: string) {
     let editing = this.state.currentAnnouncements.find(a => a.id === id);
     let currentAnnouncements = this.state.currentAnnouncements.filter(a => a.id !== id);
     if (this.state.editing && this.state.editing.id !== id) {
       // Switch between editing two announcements without making the first one disappear.
       currentAnnouncements = currentAnnouncements.concat(this.state.editing);
     }
-    await this.setState({ editing, currentAnnouncements });
+    this.setState({ editing, currentAnnouncements });
   }
   renderAnnouncement(a: AnnouncementData): JSX.Element {
     return (
@@ -63,6 +63,8 @@ export default class AnnouncementsSection extends React.Component<AnnouncementsS
     };
     return (
       <ul className="announcements-ul">
+        <h4>Scheduled Announcements:</h4>
+        <hr />
         {
           Array.isArray(this.state.currentAnnouncements) && this.state.currentAnnouncements.sort(compareStartDate).map(a =>
               <li key={a.id}>
@@ -87,6 +89,7 @@ export default class AnnouncementsSection extends React.Component<AnnouncementsS
   render(): JSX.Element {
     return (
       <div className="announcements-section">
+        { null }
         { this.state.currentAnnouncements.length > 0 && this.renderList() }
         { this.state.currentAnnouncements.length < 3 && this.renderForm() }
       </div>

--- a/src/components/AnnouncementsSection.tsx
+++ b/src/components/AnnouncementsSection.tsx
@@ -7,8 +7,14 @@ export interface AnnouncementsSectionProps {
   setting: SettingData;
   value?: Array<any>;
 }
+export interface AnnouncementData {
+  id?: number;
+  content: string;
+  startDate: string;
+  endDate: string;
+}
 export interface AnnouncementsSectionState {
-  currentAnnouncements: Array<any>;
+  currentAnnouncements: Array<AnnouncementData>;
   editing?: any;
 }
 
@@ -18,6 +24,7 @@ export default class AnnouncementsSection extends React.Component<AnnouncementsS
     this.addAnnouncement = this.addAnnouncement.bind(this);
     this.deleteAnnouncement = this.deleteAnnouncement.bind(this);
     this.editAnnouncement = this.editAnnouncement.bind(this);
+    this.getValue = this.getValue.bind(this);
     this.state = { currentAnnouncements: this.props.value || [] };
   }
   addAnnouncement(announcement) {
@@ -64,5 +71,8 @@ export default class AnnouncementsSection extends React.Component<AnnouncementsS
         { this.state.currentAnnouncements.length < 3 && <AnnouncementForm add={this.addAnnouncement} content={this.state.editing?.content} startDate={this.state.editing?.startDate} endDate={this.state.editing?.endDate} /> }
       </div>
     );
+  }
+  getValue() {
+    return this.state.currentAnnouncements;
   }
 }

--- a/src/components/AnnouncementsSection.tsx
+++ b/src/components/AnnouncementsSection.tsx
@@ -35,7 +35,7 @@ export default class AnnouncementsSection extends React.Component<AnnouncementsS
     let editing = this.state.currentAnnouncements.find(a => a.id === id);
     let currentAnnouncements = this.state.currentAnnouncements.filter(a => a.id !== id);
     if (this.state.editing && this.state.editing.id !== id) {
-      // Switch between editing two announcements without making the first one disappear. 
+      // Switch between editing two announcements without making the first one disappear.
       currentAnnouncements = currentAnnouncements.concat(this.state.editing);
     }
     await this.setState({ editing, currentAnnouncements });

--- a/src/components/AnnouncementsSection.tsx
+++ b/src/components/AnnouncementsSection.tsx
@@ -10,8 +10,8 @@ export interface AnnouncementsSectionProps {
 export interface AnnouncementData {
   id?: number;
   content: string;
-  startDate: string;
-  endDate: string;
+  start: string;
+  finish: string;
 }
 export interface AnnouncementsSectionState {
   currentAnnouncements: Array<AnnouncementData>;
@@ -25,7 +25,7 @@ export default class AnnouncementsSection extends React.Component<AnnouncementsS
     this.deleteAnnouncement = this.deleteAnnouncement.bind(this);
     this.editAnnouncement = this.editAnnouncement.bind(this);
     this.getValue = this.getValue.bind(this);
-    this.state = { currentAnnouncements: this.props.value || [] };
+    this.state = { currentAnnouncements: Array.isArray(this.props.value) ? this.props.value : [] };
   }
   addAnnouncement(announcement) {
     let announcements = this.state.currentAnnouncements;
@@ -44,8 +44,8 @@ export default class AnnouncementsSection extends React.Component<AnnouncementsS
       <Announcement
         key={a.content}
         content={a.content}
-        startDate={a.startDate}
-        endDate={a.endDate}
+        start={a.start}
+        finish={a.finish}
         id={a.id}
         delete={this.deleteAnnouncement}
         edit={this.editAnnouncement}
@@ -56,7 +56,7 @@ export default class AnnouncementsSection extends React.Component<AnnouncementsS
     return (
       <ul className="announcements-ul">
         {
-          this.state.currentAnnouncements.map(a =>
+          Array.isArray(this.state.currentAnnouncements) && this.state.currentAnnouncements.map(a =>
               <li key={a.content}>
                 {this.renderAnnouncement(a)}
               </li>
@@ -69,7 +69,7 @@ export default class AnnouncementsSection extends React.Component<AnnouncementsS
     return (
       <div className="announcements-section">
         { this.state.currentAnnouncements.length > 0 && this.renderList() }
-        { this.state.currentAnnouncements.length < 3 && <AnnouncementForm add={this.addAnnouncement} content={this.state.editing?.content} startDate={this.state.editing?.startDate} endDate={this.state.editing?.endDate} /> }
+        { this.state.currentAnnouncements.length < 3 && <AnnouncementForm add={this.addAnnouncement} content={this.state.editing?.content} start={this.state.editing?.start} finish={this.state.editing?.finish} /> }
       </div>
     );
   }

--- a/src/components/AnnouncementsSection.tsx
+++ b/src/components/AnnouncementsSection.tsx
@@ -2,7 +2,6 @@ import * as React from "react";
 import { SettingData } from "../interfaces";
 import AnnouncementForm from "./AnnouncementForm";
 import Announcement from "./Announcement";
-// import { DragDropContext, Droppable, Draggable } from "react-beautiful-dnd";
 
 export interface AnnouncementsSectionProps {
   setting: SettingData;
@@ -19,62 +18,15 @@ export default class AnnouncementsSection extends React.Component<AnnouncementsS
     this.addAnnouncement = this.addAnnouncement.bind(this);
     this.deleteAnnouncement = this.deleteAnnouncement.bind(this);
     this.editAnnouncement = this.editAnnouncement.bind(this);
-    // this.onDragStart = this.onDragStart.bind(this);
-    // this.onDragEnd = this.onDragEnd.bind(this);
     this.state = { currentAnnouncements: this.props.value || [] }
   }
-  // onDragStart(initial) {
-  //   console.log("HIT");
-  //   document.body.classList.add("dragging");
-  //   const draggableId = initial.draggableId;
-  //   const draggingFrom = initial.source.droppableId;
-  //     // this.props.drag({ draggableId, draggingFrom });
-  // }
-  // onDragEnd() {
-  //   console.log("DRAG END");
-  // }
   addAnnouncement(announcement) {
     let announcements = this.state.currentAnnouncements;
-    // let positionConflict = this.state.currentAnnouncements.filter(a => a.position === announcement.position);
-    // let oldAnnouncement = this.state.currentAnnouncements.filter(a => a.content === announcement.content);
-    // if (positionConflict[0]) {
-    //   let extra = this.state.currentAnnouncements.filter(a => a.content !== announcement.content && a.content !== positionConflict[0].content);
-    //   announcements = this.reorder(positionConflict[0], announcement.position, extra[0] || null);
-    // }
     this.setState({ currentAnnouncements: announcements.concat(announcement) });
   }
   deleteAnnouncement(content) {
-    this.setState({ currentAnnouncements: this.state.currentAnnouncements.filter(a => a.content !== content), editing: null});
-  }
-  reorder(conflicting, position, extra?) {
-    if (this.state.currentAnnouncements.length < 2) {
-      let newIndex = position === 1 ? 2 : 1;
-      let updated = {...conflicting, ...{position: newIndex}};
-      return [updated];
-    } else {
-      let third = this.state.currentAnnouncements.find(a => a.content !== conflicting.content);
-      if (position === 2 && third.position === 3) {
-        let updated = {...conflicting, ...{position: 3}};
-        third = {...third, ...{position: 1}};
-        return [updated, third];
-      } else if (position === 3 && third.position === 2) {
-        let updated = {...conflicting, ...{position: 1}};
-        return [updated, third];
-      }
-      else if (position == 1 && third.position === 2) {
-        let updated = {...conflicting, ...{position: 2}};
-        third = {...third, ...{position: 3}};
-        return [updated, third];
-      }
-      else if (position == 3 && third.position === 1) {
-        let updated = {...conflicting, ...{position: 1}};
-        third = {...third, ...{position: 2}};
-        return [updated, third];
-      }
-      else if (position == 1 && third.position === 3) {
-        let updated = {...conflicting, ...{position: 2}};
-        return [updated, third];
-      }
+    if (window.confirm("This will remove this announcement from your list. Are you sure you want to continue?")) {
+      this.setState({ currentAnnouncements: this.state.currentAnnouncements.filter(a => a.content !== content), editing: null});
     }
   }
   async editAnnouncement(content) {
@@ -92,61 +44,21 @@ export default class AnnouncementsSection extends React.Component<AnnouncementsS
         edit={this.editAnnouncement}
       />
     );
-    // return (
-    //   <Announcement
-    //     ref={provided.innerRefk}
-    //     {...provided.draggbleProps}
-    //     {...provided.dragHandleProps}
-    //     key={a.content}
-    //     content={a.content}
-    //     startDate={a.startDate}
-    //     endDate={a.endDate}
-    //     position={a.position}
-    //     delete={this.deleteAnnouncement}
-    //     edit={this.editAnnouncement}
-    //   />
-    // );
   }
   renderList() {
     return (
-
-              <ul className="announcements-ul">
-                {
-                  this.state.currentAnnouncements.map(a =>
-                      <li key={a.content}>
-                        {this.renderAnnouncement(a)}
-                      </li>
-                  )
-                }
-              </ul>
+      <ul className="announcements-ul">
+        {
+          this.state.currentAnnouncements.map(a =>
+              <li key={a.content}>
+                {this.renderAnnouncement(a)}
+              </li>
+          )
+        }
+      </ul>
     );
-    // return (
-    //   <Droppable droppableId="droppable">
-    //     {
-    //       (provided, snapshot) => {
-    //         return (
-    //           <ul {...provided.droppableProps} ref={provided.innerRef} className={"announcements-ul " + (snapshot.isDraggingOver ? "droppable dragging-over" : "droppable")}>
-    //             {
-    //               this.state.currentAnnouncements.map(a => {
-    //                 return (
-    //                   <Draggable
-    //                     key={a.content}
-    //                     draggableId={a.content}
-    //                   >{(provided, snapshot) => this.renderAnnouncement(a, provided, snapshot)}
-    //                   </Draggable>
-    //                 )
-    //               })
-    //             }
-    //             {provided.placeholder}
-    //           </ul>
-    //         )}
-    //     }
-    //   </Droppable>
-    // );
   }
   render() {
-    // <DragDropContext onDragStart={this.onDragStart} onDragEnd={this.onDragEnd}>
-    // </DragDropContext>
     return (
       <div className="announcements-section">
         { this.state.currentAnnouncements.length > 0 && this.renderList() }

--- a/src/components/AnnouncementsSection.tsx
+++ b/src/components/AnnouncementsSection.tsx
@@ -89,7 +89,6 @@ export default class AnnouncementsSection extends React.Component<AnnouncementsS
   render(): JSX.Element {
     return (
       <div className="announcements-section">
-        { null }
         { this.state.currentAnnouncements.length > 0 && this.renderList() }
         { this.state.currentAnnouncements.length < 3 && this.renderForm() }
       </div>

--- a/src/components/EditableInput.tsx
+++ b/src/components/EditableInput.tsx
@@ -13,8 +13,8 @@ export interface EditableInputProps extends React.HTMLProps<EditableInput> {
   clientError?: boolean;
   extraContent?: string | JSX.Element;
   className?: string;
-  minlength?: number;
-  maxlength?: number;
+  minLength?: number;
+  maxLength?: number;
 }
 
 export interface EditableInputState {
@@ -81,7 +81,7 @@ export default class EditableInput extends React.Component<EditableInputProps, E
   renderElement() {
     const {
       type, elementType, placeholder, accept, list, min, max, children,
-      disabled, readOnly, name, validation, style, minlength, maxlength
+      disabled, readOnly, name, validation, style, minLength, maxLength
     } = this.props;
 
     return React.createElement(elementType || "input", {
@@ -101,8 +101,8 @@ export default class EditableInput extends React.Component<EditableInputProps, E
       list,
       min,
       max,
-      minlength,
-      maxlength,
+      minLength,
+      maxLength,
       ["aria-label"]: this.props["aria-label"]
     }, children);
   }

--- a/src/components/EditableInput.tsx
+++ b/src/components/EditableInput.tsx
@@ -44,9 +44,6 @@ export default class EditableInput extends React.Component<EditableInputProps, E
       type, elementType, optionalText, required, description, clientError, error,
       label, extraContent,
     } = this.props;
-    if (type === "date" || elementType === "date") {
-      console.log("!!!", this.state.value);
-    }
     const checkboxOrRadioOrSelect = !!(
       type === "checkbox" || type === "radio" || elementType === "select"
     );

--- a/src/components/EditableInput.tsx
+++ b/src/components/EditableInput.tsx
@@ -44,6 +44,9 @@ export default class EditableInput extends React.Component<EditableInputProps, E
       type, elementType, optionalText, required, description, clientError, error,
       label, extraContent,
     } = this.props;
+    if (type === "date" || elementType === "date") {
+      console.log("!!!", this.state.value);
+    }
     const checkboxOrRadioOrSelect = !!(
       type === "checkbox" || type === "radio" || elementType === "select"
     );

--- a/src/components/EditableInput.tsx
+++ b/src/components/EditableInput.tsx
@@ -13,6 +13,8 @@ export interface EditableInputProps extends React.HTMLProps<EditableInput> {
   clientError?: boolean;
   extraContent?: string | JSX.Element;
   className?: string;
+  minlength?: number;
+  maxlength?: number;
 }
 
 export interface EditableInputState {
@@ -79,7 +81,7 @@ export default class EditableInput extends React.Component<EditableInputProps, E
   renderElement() {
     const {
       type, elementType, placeholder, accept, list, min, max, children,
-      disabled, readOnly, name, validation, style,
+      disabled, readOnly, name, validation, style, minlength, maxlength
     } = this.props;
 
     return React.createElement(elementType || "input", {
@@ -99,6 +101,8 @@ export default class EditableInput extends React.Component<EditableInputProps, E
       list,
       min,
       max,
+      minlength,
+      maxlength,
       ["aria-label"]: this.props["aria-label"]
     }, children);
   }

--- a/src/components/InputList.tsx
+++ b/src/components/InputList.tsx
@@ -66,6 +66,31 @@ export default class InputList extends React.Component<InputListProps, InputList
     // Hide the "Add" button if there are no options left
     let showButton = !this.state.options || this.state.options.length > 0;
     let hasListItems = this.state.listItems && this.state.listItems.length > 0;
+    let element: string | JSX.Element;
+    if (setting.format === "language-code") {
+      element = (
+        <LanguageField
+          disabled={this.props.disabled}
+          ref="addListItem"
+          name={setting.key}
+          languages={this.props.additionalData}
+          onChange={this.updateNewItem}
+        />
+      );
+    } else if (setting.type === "menu") {
+      element = this.renderMenu(setting);
+    } else {
+      element = (
+        this.props.createEditableInput(setting, {
+          value: null,
+          disabled: this.props.disabled,
+          onChange: this.updateNewItem,
+          ref: "addListItem",
+          label: null,
+          description: null
+        })
+      );
+    }
     return (
       <div className="input-list">
         { this.props.labelAndDescription && this.props.labelAndDescription(setting) }
@@ -74,25 +99,7 @@ export default class InputList extends React.Component<InputListProps, InputList
         { hasListItems && this.renderList(this.state.listItems, setting) }
         <div className="add-list-item-container">
           <span className="add-list-item">
-            {  setting.format === "language-code" ?
-                <LanguageField
-                  disabled={this.props.disabled}
-                  ref="addListItem"
-                  name={setting.key}
-                  languages={this.props.additionalData}
-                  onChange={this.updateNewItem}
-                /> :
-                setting.type === "menu" ?
-                  this.renderMenu(setting) :
-                  this.props.createEditableInput(setting, {
-                    value: null,
-                    disabled: this.props.disabled,
-                    onChange: this.updateNewItem,
-                    ref: "addListItem",
-                    label: null,
-                    description: null
-                  })
-            }
+            { element }
           </span>
           { showButton &&
             <Button

--- a/src/components/Lane.tsx
+++ b/src/components/Lane.tsx
@@ -42,7 +42,6 @@ export default class Lane extends React.Component<LaneProps, LaneState> {
     let { lane, active, snapshot, provided, renderLanes } = this.props;
     let hasSublanes = lane.sublanes && !!lane.sublanes.length;
     let hasCustomLists = lane.custom_list_ids && !!lane.custom_list_ids.length;
-
     return (
       <li key={lane.id}>
         <div

--- a/src/components/LibraryEditForm.tsx
+++ b/src/components/LibraryEditForm.tsx
@@ -128,7 +128,7 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
               key: "announcements",
               label: "Announcements",
               type: "list"}}
-              value={[{content: "FIRST", startDate: "05/19/2020", endDate: "END", position: 1}, {content: "SECOND", startDate: "START", endDate: "END", position: 2}]}
+              value={[{content: "FIRST", startDate: "05/19/2020", endDate: "05/21/2020", position: 1}, {content: "SECOND", startDate: "START", endDate: "END", position: 2}]}
         />
       }
       openByDefault={true}

--- a/src/components/LibraryEditForm.tsx
+++ b/src/components/LibraryEditForm.tsx
@@ -120,7 +120,7 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
       id={`library-form-announcements`}
       headerText={`Announcements (Optional)`}
       onEnter={this.submit}
-      key={"announcements"}
+      key="announcements"
       content={
         <AnnouncementsSection setting={{
               description: "announcements",
@@ -129,6 +129,7 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
               label: "Announcements",
               type: "list"}}
               value={[{content: "FIRST ANNOUNCEMENT", startDate: "2020-05-19", endDate: "2020-05-21", position: 1}, {content: "SECOND ANNOUNCEMENT", startDate: "2020-06-01", endDate: "2020-08-01", position: 2}]}
+              ref="announcements"
         />
       }
       openByDefault={true}
@@ -203,6 +204,10 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
   }
 
   submit(data: FormData) {
+    let announcements = (this.refs["announcements"] as any).getValue();
+    let announcementList = [];
+    announcements.forEach(a => announcementList.push(a));
+    data?.set("announcements", JSON.stringify(announcementList));
     this.props.save(data);
   }
 

--- a/src/components/LibraryEditForm.tsx
+++ b/src/components/LibraryEditForm.tsx
@@ -128,7 +128,7 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
               key: "announcements",
               label: "Announcements",
               type: "list"}}
-              value={[{content: "cat", startDate: "START", endDate: "END"}]}
+              value={[{content: "FIRST", startDate: "05/19/2020", endDate: "END", position: 1}, {content: "SECOND", startDate: "START", endDate: "END", position: 2}]}
         />
       }
       openByDefault={true}

--- a/src/components/LibraryEditForm.tsx
+++ b/src/components/LibraryEditForm.tsx
@@ -114,6 +114,17 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
 
   renderForms(categories: {[key: string]: LibrarySettingField[]}) {
     let forms = [];
+    let tempAnnouncementsForm =
+    <Panel
+      id={`library-form-announcements`}
+      headerText={`Announcements (Optional)`}
+      onEnter={this.submit}
+      key={"announcements"}
+      content={<div></div>}
+      openByDefault={true}
+    />;
+    forms.push(tempAnnouncementsForm);
+    console.log(forms);
     let categoryNames = Object.keys(categories);
     categoryNames.forEach((name) => {
       let form =

--- a/src/components/LibraryEditForm.tsx
+++ b/src/components/LibraryEditForm.tsx
@@ -132,17 +132,12 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
 
   renderAnnouncements(setting: SettingData, value) {
     return (
-      <AnnouncementsSection setting={{
-            description: "announcements",
-            format: "date-range",
-            key: "announcements",
-            label: "Announcements",
-            type: "list"}}
+      <AnnouncementsSection
+            setting={{...setting, ...{format: "date-range"}}}
             value={value && JSON.parse(value)}
             ref="announcements"
       />
     );
-    // value={[{content: "FIRST ANNOUNCEMENT", startDate: "2020-05-19", endDate: "2020-05-21", id: 1}, {content: "SECOND ANNOUNCEMENT", startDate: "2020-06-01", endDate: "2020-08-01", id: 2}]}
   }
 
   renderPairedMenus(setting: SettingData, fields: LibrarySettingField[]) {

--- a/src/components/LibraryEditForm.tsx
+++ b/src/components/LibraryEditForm.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import EditableInput from "./EditableInput";
 import ProtocolFormField from "./ProtocolFormField";
 import { findDefault, clearForm } from "../utils/sharedFunctions";
-import { LibrariesData, LibraryData, LibrarySettingField, SettingData } from "../interfaces";
+import { LibrariesData, LibraryData, LibrarySettingField, SettingData, AnnouncementData } from "../interfaces";
 import { Panel, Form } from "library-simplified-reusable-components";
 import { FetchErrorData } from "opds-web-client/lib/interfaces";
 import PairedMenus from "./PairedMenus";
@@ -207,7 +207,7 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
   submit(data: FormData) {
     let announcements = (this.refs["announcements"] as any).getValue();
     let announcementList = [];
-    announcements.forEach(a => announcementList.push(a));
+    announcements.forEach((a: AnnouncementData) => announcementList.push(a));
     data?.set("announcements", JSON.stringify(announcementList));
     this.props.save(data);
   }

--- a/src/components/LibraryEditForm.tsx
+++ b/src/components/LibraryEditForm.tsx
@@ -128,7 +128,7 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
               key: "announcements",
               label: "Announcements",
               type: "list"}}
-              value={[{content: "FIRST ANNOUNCEMENT", startDate: "2020-05-19", endDate: "2020-05-21", position: 1}, {content: "SECOND ANNOUNCEMENT", startDate: "2020-06-01", endDate: "2020-08-01", position: 2}]}
+              value={[{content: "FIRST ANNOUNCEMENT", startDate: "2020-05-19", endDate: "2020-05-21", id: 1}, {content: "SECOND ANNOUNCEMENT", startDate: "2020-06-01", endDate: "2020-08-01", id: 2}]}
               ref="announcements"
         />
       }

--- a/src/components/LibraryEditForm.tsx
+++ b/src/components/LibraryEditForm.tsx
@@ -178,7 +178,7 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
     let render = (setting) => {
       if (setting.paired) {
         return this.renderPairedMenus(setting, fields);
-      } else if (setting.format === "announcements") {
+      } else if (setting.type === "announcements") {
         return this.renderAnnouncements(setting, settingValue(setting));
       } else if (!setting.skip) {
         return (

--- a/src/components/LibraryEditForm.tsx
+++ b/src/components/LibraryEditForm.tsx
@@ -115,26 +115,6 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
 
   renderForms(categories: {[key: string]: LibrarySettingField[]}) {
     let forms = [];
-    let tempAnnouncementsForm =
-    <Panel
-      id={`library-form-announcements`}
-      headerText={`Announcements (Optional)`}
-      onEnter={this.submit}
-      key="announcements"
-      content={
-        <AnnouncementsSection setting={{
-              description: "announcements",
-              format: "date-range",
-              key: "announcements",
-              label: "Announcements",
-              type: "list"}}
-              value={[{content: "FIRST ANNOUNCEMENT", startDate: "2020-05-19", endDate: "2020-05-21", id: 1}, {content: "SECOND ANNOUNCEMENT", startDate: "2020-06-01", endDate: "2020-08-01", id: 2}]}
-              ref="announcements"
-        />
-      }
-      openByDefault={true}
-    />;
-    forms.push(tempAnnouncementsForm);
     let categoryNames = Object.keys(categories);
     categoryNames.forEach((name) => {
       let form =
@@ -148,6 +128,21 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
       forms.push(form);
     });
     return forms;
+  }
+
+  renderAnnouncements(setting: SettingData, value) {
+    return (
+      <AnnouncementsSection setting={{
+            description: "announcements",
+            format: "date-range",
+            key: "announcements",
+            label: "Announcements",
+            type: "list"}}
+            value={value && JSON.parse(value)}
+            ref="announcements"
+      />
+    );
+    // value={[{content: "FIRST ANNOUNCEMENT", startDate: "2020-05-19", endDate: "2020-05-21", id: 1}, {content: "SECOND ANNOUNCEMENT", startDate: "2020-06-01", endDate: "2020-08-01", id: 2}]}
   }
 
   renderPairedMenus(setting: SettingData, fields: LibrarySettingField[]) {
@@ -180,13 +175,13 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
       }
       return setting.default;
     };
-    return (
-      <fieldset>
-        <legend className="visuallyHidden">Additional Fields</legend>
-        { fields.map(setting => setting.paired ?
-          this.renderPairedMenus(setting, fields)
-        :
-          !setting.skip &&
+    let render = (setting) => {
+      if (setting.paired) {
+        return this.renderPairedMenus(setting, fields);
+      } else if (setting.format === "announcements") {
+        return this.renderAnnouncements(setting, settingValue(setting));
+      } else if (!setting.skip) {
+        return (
           <ProtocolFormField
             key={setting.key}
             ref={setting.key}
@@ -198,7 +193,13 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
             error={this.props.error}
             readOnly={setting.readOnly}
           />
-        )}
+        );
+      }
+    };
+    return (
+      <fieldset>
+        <legend className="visuallyHidden">Additional Fields</legend>
+        { fields.map(setting => render(setting))}
       </fieldset>
     );
   }

--- a/src/components/LibraryEditForm.tsx
+++ b/src/components/LibraryEditForm.tsx
@@ -6,6 +6,7 @@ import { LibrariesData, LibraryData, LibrarySettingField, SettingData } from "..
 import { Panel, Form } from "library-simplified-reusable-components";
 import { FetchErrorData } from "opds-web-client/lib/interfaces";
 import PairedMenus from "./PairedMenus";
+import AnnouncementsSection from "./AnnouncementsSection";
 
 export interface LibraryEditFormProps {
   data: LibrariesData;
@@ -120,11 +121,19 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
       headerText={`Announcements (Optional)`}
       onEnter={this.submit}
       key={"announcements"}
-      content={<div></div>}
+      content={
+        <AnnouncementsSection setting={{
+              description: "announcements",
+              format: "date-range",
+              key: "announcements",
+              label: "Announcements",
+              type: "list"}}
+              value={[{content: "cat", startDate: "START", endDate: "END"}]}
+        />
+      }
       openByDefault={true}
     />;
     forms.push(tempAnnouncementsForm);
-    console.log(forms);
     let categoryNames = Object.keys(categories);
     categoryNames.forEach((name) => {
       let form =

--- a/src/components/LibraryEditForm.tsx
+++ b/src/components/LibraryEditForm.tsx
@@ -128,7 +128,7 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
               key: "announcements",
               label: "Announcements",
               type: "list"}}
-              value={[{content: "FIRST", startDate: "05/19/2020", endDate: "05/21/2020", position: 1}, {content: "SECOND", startDate: "START", endDate: "END", position: 2}]}
+              value={[{content: "FIRST ANNOUNCEMENT", startDate: "2020-05-19", endDate: "2020-05-21", position: 1}, {content: "SECOND ANNOUNCEMENT", startDate: "2020-06-01", endDate: "2020-08-01", position: 2}]}
         />
       }
       openByDefault={true}

--- a/src/components/__tests__/Announcement-test.tsx
+++ b/src/components/__tests__/Announcement-test.tsx
@@ -1,0 +1,50 @@
+import { expect } from "chai";
+import { stub } from "sinon";
+
+import * as React from "react";
+import { mount } from "enzyme";
+
+import Announcement from "../Announcement";
+
+describe("Announcement", () => {
+  let wrapper;
+  let stubDelete = stub();
+  let stubEdit = stub();
+  beforeEach(() => {
+    wrapper = mount(
+      <Announcement
+        content="test"
+        start="2020-05-12"
+        finish="2020-05-28"
+        id="1"
+        delete={stubDelete}
+        edit={stubEdit}
+      />
+    );
+  });
+  it("renders the content and dates", () => {
+    expect(wrapper.find("section").at(0).prop("className")).to.equal("announcement-info");
+    let dates = wrapper.find(".dates");
+    expect(dates.text()).to.equal("05/12/2020 – 05/28/2020");
+    let content = wrapper.find("span");
+    expect(content.text()).to.equal("test");
+  });
+  it("renders an edit button", () => {
+    let editButton = wrapper.find(".buttons").children().at(0);
+    expect(editButton.text()).to.equal("Edit");
+    editButton.simulate("click");
+    expect(stubEdit.callCount).to.equal(1);
+    expect(stubEdit.args[0][0]).to.equal("1");
+  });
+  it("renders a delete button", () => {
+    let deleteButton = wrapper.find(".buttons").children().at(1);
+    expect(deleteButton.text()).to.equal("Delete");
+    deleteButton.simulate("click");
+    expect(stubDelete.callCount).to.equal(1);
+    expect(stubDelete.args[0][0]).to.equal("1");
+  });
+  it("formats dates", () => {
+    let date = "2020-03-14";
+    expect(wrapper.instance().format(date)).to.equal("03/14/2020");
+  });
+});

--- a/src/components/__tests__/AnnouncementForm-test.tsx
+++ b/src/components/__tests__/AnnouncementForm-test.tsx
@@ -1,0 +1,150 @@
+import { expect } from "chai";
+import { stub, spy } from "sinon";
+
+import * as React from "react";
+import { mount } from "enzyme";
+
+import AnnouncementForm from "../AnnouncementForm";
+import EditableInput from "../EditableInput";
+
+describe("AnnouncementForm", () => {
+  let wrapper;
+  let add;
+  beforeEach(() => {
+    add = stub();
+    wrapper = mount(
+      <AnnouncementForm add={add} />
+    );
+  });
+  it("renders the input fields", () => {
+    let fields = wrapper.find(EditableInput);
+    expect(fields.length).to.equal(3);
+    checkDefaultValues();
+
+    let contentField = fields.at(0);
+    expect(contentField.props().elementType).to.equal("textarea");
+    expect(contentField.props().minLength).to.equal(15);
+    expect(contentField.props().maxLength).to.equal(350);
+    expect(contentField.props().label).to.equal("Content (15-350 characters)");
+    expect(contentField.props().description).to.equal("(0/350)");
+
+    let startDateField = fields.at(1);
+    expect(startDateField.props().type).to.equal("date");
+    expect(startDateField.props().label).to.equal("Start");
+    expect(startDateField.props().description).to.equal("If no start date is chosen, the default start date is today's date.");
+
+    let endDateField = fields.at(2);
+    expect(endDateField.props().type).to.equal("date");
+    expect(endDateField.props().label).to.equal("End");
+    expect(endDateField.props().description).to.equal("If no expiration date is chosen, the default expiration date is 2 months from the start date.");
+  });
+  it("renders the buttons", () => {
+    let buttons = wrapper.find("button");
+    expect(buttons.length).to.equal(2);
+    expect(buttons.at(0).text()).to.equal("Submit");
+    expect(buttons.at(1).text()).to.equal("Cancel");
+  });
+  it("keeps track of whether the content is too short or too long", () => {
+    let counter = wrapper.find(".description").at(0);
+    expect(counter.text()).to.equal("(0/350)");
+    expect(counter.parent().hasClass("wrong-length")).to.be.true;
+    expect(wrapper.find("button").at(0).prop("disabled")).to.be.true;
+
+    fillOutForm();
+
+    counter = wrapper.find(".description").at(0);
+    expect(counter.text()).to.equal("(66/350)");
+    expect(counter.parent().hasClass("wrong-length")).to.be.false;
+    expect(wrapper.find("button").at(0).prop("disabled")).not.to.be.true;
+
+    let longString = "Here's some extremely/gratuitously long content.  The point of the content is just to get up to 350 characters so that I can test whether the class name will change.  I realize even as I am typing this that it probably would have been a better idea to do it with filler text; oh well...?  Anyway, I have now written the most boring announcement EVER.";
+    let contentField = wrapper.find("textarea");
+    contentField.getDOMNode().value = longString;
+    contentField.simulate("change");
+
+    counter = wrapper.find(".description").at(0);
+    expect(counter.text()).to.equal("(350/350)");
+    expect(counter.parent().hasClass("wrong-length")).to.be.true;
+  });
+  let fillOutForm = () => {
+    checkDefaultState();
+    checkDefaultValues();
+    expect(add.callCount).to.equal(0);
+
+    let contentString = "Here is some sample content which comes out to over 15 characters.";
+    let contentField = wrapper.find("textarea");
+    contentField.getDOMNode().value = contentString;
+    contentField.simulate("change");
+    let start = wrapper.find("input").at(0);
+    start.getDOMNode().value = "2020-06-01";
+    start.simulate("change");
+    let finish = wrapper.find("input").at(1);
+    finish.getDOMNode().value = "2020-07-01";
+    finish.simulate("change");
+
+    expect(wrapper.state().content).to.equal(contentString);
+    expect(wrapper.state().start).to.equal("2020-06-01");
+    expect(wrapper.state().finish).to.equal("2020-07-01");
+  };
+  let checkDefaultState = () => {
+    expect(wrapper.state().content).to.equal("");
+    expect(wrapper.state().start).to.equal(wrapper.instance().getDefaultDates()[0]);
+    expect(wrapper.state().finish).to.equal(wrapper.instance().getDefaultDates()[1]);
+  };
+  let checkDefaultValues = () => {
+    expect(wrapper.find("textarea").text()).to.equal("");
+    expect(wrapper.find("input").at(0).props().value).to.equal(wrapper.instance().getDefaultDates()[0]);
+    expect(wrapper.find("input").at(1).props().value).to.equal(wrapper.instance().getDefaultDates()[1]);
+  };
+  it("adds a new announcement", () => {
+    fillOutForm();
+    wrapper.find("button").at(0).simulate("click");
+    expect(add.callCount).to.equal(1);
+    expect(add.args[0][0].content).to.equal("Here is some sample content which comes out to over 15 characters.");
+    expect(add.args[0][0].start).to.equal("2020-06-01");
+    expect(add.args[0][0].finish).to.equal("2020-07-01");
+  });
+  it("cancels adding a new announcement", () => {
+    fillOutForm();
+    wrapper.find("button").at(1).simulate("click");
+    checkDefaultState();
+    checkDefaultValues();
+  });
+  it("edits an existing announcement", () => {
+    wrapper.setProps({ content: "Here is some sample content which comes out to over 15 characters.", start: "07/01/2020", finish: "08/01/2020"});
+    expect(wrapper.state().content).to.equal("Here is some sample content which comes out to over 15 characters.");
+    expect(wrapper.state().start).to.equal("2020-07-01");
+    expect(wrapper.state().finish).to.equal("2020-08-01");
+    expect(wrapper.find("textarea").text()).to.equal("Here is some sample content which comes out to over 15 characters.");
+    expect(wrapper.find("input").at(0).props().value).to.equal("2020-07-01");
+    expect(wrapper.find("input").at(1).props().value).to.equal("2020-08-01");
+    let contentField = wrapper.find("textarea");
+    contentField.getDOMNode().value = "Here is an edited version of the content";
+    contentField.simulate("change");
+    wrapper.find("button").at(0).simulate("click");
+    expect(add.callCount).to.equal(1);
+    expect(add.args[0][0].content).to.equal("Here is an edited version of the content");
+    checkDefaultState();
+    checkDefaultValues();
+  });
+  it("cancels editing an existing announcement", () => {
+    let spyCancel = spy(wrapper.instance(), "cancel");
+    wrapper.setProps({ content: "Here is some sample content which comes out to over 15 characters.", start: "07/01/2020", finish: "08/01/2020"});
+    expect(wrapper.state().content).to.equal("Here is some sample content which comes out to over 15 characters.");
+    expect(wrapper.state().start).to.equal("2020-07-01");
+    expect(wrapper.state().finish).to.equal("2020-08-01");
+    expect(wrapper.find("textarea").text()).to.equal("Here is some sample content which comes out to over 15 characters.");
+    expect(wrapper.find("input").at(0).props().value).to.equal("2020-07-01");
+    expect(wrapper.find("input").at(1).props().value).to.equal("2020-08-01");
+    let contentField = wrapper.find("textarea");
+    contentField.getDOMNode().value = "Here is an edited version of the content";
+    contentField.simulate("change");
+    wrapper.find("button").at(1).simulate("click");
+    expect(add.callCount).to.equal(1);
+    expect(add.args[0][0].content).to.equal("Here is an edited version of the content");
+    expect(spyCancel.callCount).to.equal(1);
+    checkDefaultState();
+    checkDefaultValues();
+    spyCancel.restore();
+  });
+});

--- a/src/components/__tests__/AnnouncementForm-test.tsx
+++ b/src/components/__tests__/AnnouncementForm-test.tsx
@@ -26,16 +26,16 @@ describe("AnnouncementForm", () => {
     expect(contentField.props().minLength).to.equal(15);
     expect(contentField.props().maxLength).to.equal(350);
     expect(contentField.props().label).to.equal("Content (15-350 characters)");
-    expect(contentField.props().description).to.equal("(0/350)");
+    expect(contentField.props().description).to.equal("(Current length: 0/350)");
 
     let startDateField = fields.at(1);
     expect(startDateField.props().type).to.equal("date");
-    expect(startDateField.props().label).to.equal("Start");
+    expect(startDateField.props().label).to.equal("Start Date");
     expect(startDateField.props().description).to.equal("If no start date is chosen, the default start date is today's date.");
 
     let endDateField = fields.at(2);
     expect(endDateField.props().type).to.equal("date");
-    expect(endDateField.props().label).to.equal("End");
+    expect(endDateField.props().label).to.equal("End Date");
     expect(endDateField.props().description).to.equal("If no expiration date is chosen, the default expiration date is 2 months from the start date.");
   });
   it("renders the buttons", () => {
@@ -46,14 +46,14 @@ describe("AnnouncementForm", () => {
   });
   it("keeps track of whether the content is too short or too long", () => {
     let counter = wrapper.find(".description").at(0);
-    expect(counter.text()).to.equal("(0/350)");
+    expect(counter.text()).to.equal("(Current length: 0/350)");
     expect(counter.parent().hasClass("wrong-length")).to.be.true;
     expect(wrapper.find("button").at(0).prop("disabled")).to.be.true;
 
     fillOutForm();
 
     counter = wrapper.find(".description").at(0);
-    expect(counter.text()).to.equal("(66/350)");
+    expect(counter.text()).to.equal("(Current length: 66/350)");
     expect(counter.parent().hasClass("wrong-length")).to.be.false;
     expect(wrapper.find("button").at(0).prop("disabled")).not.to.be.true;
 
@@ -63,7 +63,7 @@ describe("AnnouncementForm", () => {
     contentField.simulate("change");
 
     counter = wrapper.find(".description").at(0);
-    expect(counter.text()).to.equal("(350/350)");
+    expect(counter.text()).to.equal("(Current length: 350/350)");
     expect(counter.parent().hasClass("wrong-length")).to.be.true;
   });
   let fillOutForm = () => {

--- a/src/components/__tests__/AnnouncementsSection-test.tsx
+++ b/src/components/__tests__/AnnouncementsSection-test.tsx
@@ -36,6 +36,7 @@ describe("AnnouncementsSection", () => {
     );
   });
   it("renders a list of announcements", () => {
+    expect(wrapper.find("ul").find("h4").text()).to.equal("Scheduled Announcements:");
     let list = wrapper.find(".announcements-ul");
     let announcement1 = list.find(".announcement").at(0);
     let announcement2 = list.find(".announcement").at(1);

--- a/src/components/__tests__/AnnouncementsSection-test.tsx
+++ b/src/components/__tests__/AnnouncementsSection-test.tsx
@@ -60,7 +60,7 @@ describe("AnnouncementsSection", () => {
 
   });
   it("edits an announcement", () => {
-    expect(wrapper.state().editing).to.be.undefined;
+    expect(wrapper.state().editing).to.be.null;
     expect(wrapper.state().currentAnnouncements.length).to.equal(2);
     expect(wrapper.find(".announcement").length).to.equal(2);
     let editButton = wrapper.find("button").at(0);

--- a/src/components/__tests__/AnnouncementsSection-test.tsx
+++ b/src/components/__tests__/AnnouncementsSection-test.tsx
@@ -1,0 +1,88 @@
+import { expect } from "chai";
+import { stub } from "sinon";
+
+import * as React from "react";
+import { mount } from "enzyme";
+
+import AnnouncementsSection from "../AnnouncementsSection";
+
+describe("AnnouncementsSection", () => {
+  let wrapper;
+  let announcements = [
+    {
+      content: "First Announcement",
+      start: "2020-05-12",
+      finish: "2020-06-12",
+      id: 1
+    },
+    {
+      content: "Second Announcement",
+      start: "2020-05-28",
+      finish: "2020-06-28",
+      id: 2
+    }
+  ];
+  let setting = {
+    description: "announcements",
+    format: "date-range",
+    key: "announcements",
+    label: "Announcements",
+    type: "list"
+  };
+
+  beforeEach(() => {
+    wrapper = mount(
+      <AnnouncementsSection setting={setting} value={announcements} />
+    );
+  });
+  it("renders a list of announcements", () => {
+    let list = wrapper.find(".announcements-ul");
+    let announcement1 = list.find(".announcement").at(0);
+    let announcement2 = list.find(".announcement").at(1);
+    expect(announcement1.find("span").text()).to.equal("First Announcement");
+    expect(announcement1.find(".dates").text()).to.equal("05/12/2020 – 06/12/2020");
+    expect(announcement2.find("span").text()).to.equal("Second Announcement");
+    expect(announcement2.find(".dates").text()).to.equal("05/28/2020 – 06/28/2020");
+  });
+  it("renders a form", () => {
+    expect(wrapper.find(".announcement-form").length).to.equal(1);
+  });
+  it("adds an announcement", () => {
+    expect(wrapper.state().currentAnnouncements.length).to.equal(2);
+    expect(wrapper.find(".announcement").length).to.equal(2);
+    let form = wrapper.find(".announcement-form");
+    let textarea = form.find("textarea");
+    textarea.getDOMNode().value = "Third Announcement";
+    textarea.simulate("change");
+    form.find("button").at(0).simulate("click");
+    expect(wrapper.state().currentAnnouncements.length).to.equal(3);
+    expect(wrapper.find(".announcement").length).to.equal(3);
+
+  });
+  it("edits an announcement", () => {
+    expect(wrapper.state().editing).to.be.undefined;
+    expect(wrapper.state().currentAnnouncements.length).to.equal(2);
+    expect(wrapper.find(".announcement").length).to.equal(2);
+    let editButton = wrapper.find("button").at(0);
+    expect(editButton.text()).to.equal("Edit");
+    editButton.simulate("click");
+    expect(wrapper.state().editing.content).to.equal("First Announcement");
+    expect(wrapper.state().editing.start).to.equal("2020-05-12");
+    expect(wrapper.state().editing.finish).to.equal("2020-06-12");
+    expect(wrapper.state().currentAnnouncements.length).to.equal(1);
+    expect(wrapper.state().currentAnnouncements[0].content).to.equal("Second Announcement");
+    expect(wrapper.find(".announcement").length).to.equal(1);
+  });
+  it("deletes an announcement", () => {
+    let confirmStub = stub(window, "confirm").returns(true);
+    expect(wrapper.state().currentAnnouncements.length).to.equal(2);
+    expect(wrapper.find(".announcement").length).to.equal(2);
+    let deleteButton = wrapper.find("button").at(1);
+    expect(deleteButton.text()).to.equal("Delete");
+    deleteButton.simulate("click");
+    expect(wrapper.state().currentAnnouncements.length).to.equal(1);
+    expect(wrapper.find(".announcement").length).to.equal(1);
+    expect(wrapper.find(".announcement").at(0).text()).to.contain("Second Announcement");
+    confirmStub.restore();
+  });
+});

--- a/src/components/__tests__/LibraryEditForm-test.tsx
+++ b/src/components/__tests__/LibraryEditForm-test.tsx
@@ -10,6 +10,7 @@ import { Panel, Button, Form } from "library-simplified-reusable-components";
 import ProtocolFormField from "../ProtocolFormField";
 import PairedMenus from "../PairedMenus";
 import InputList from "../InputList";
+import AnnouncementsSection from "../AnnouncementsSection";
 
 describe("LibraryEditForm", () => {
   let wrapper;
@@ -21,7 +22,8 @@ describe("LibraryEditForm", () => {
     settings: {
       "privacy-policy": "http://privacy",
       "copyright": "http://copyright",
-      "featured_lane_size": "20"
+      "featured_lane_size": "20",
+      "announcements": "[{\"content\": \"Announcement #1\", \"start\": \"2020-06-15\", \"finish\": \"2020-08-15\"}]"
     }
   };
   let settingFields = [
@@ -30,7 +32,8 @@ describe("LibraryEditForm", () => {
     { key: "logo", label: "Logo", category: "Client Interface Customization" },
     { key: "large_collections", label: "Languages", category: "Languages" },
     { key: "featured_lane_size", label: "Maximum number of books in the 'featured' lanes", category: "Lanes & Filters", type: "number"},
-    { key: "service_area", label: "Service Area", category: "Geographic Areas", type: "list" }
+    { key: "service_area", label: "Service Area", category: "Geographic Areas", type: "list" },
+    { key: "announcements", label: "Announcements", category: "Announcements", format: "announcements" }
   ];
 
   let editableInputByName = (name) => {
@@ -140,6 +143,14 @@ describe("LibraryEditForm", () => {
       expect(dropdown.prop("name")).to.equal("dropdown");
       expect(dropdown.children().length).to.equal(1);
       expect(dropdown.children().at(0).prop("value")).to.equal(inputListSetting.default[0]);
+    });
+
+    it("renders the Announcements component", () => {
+      wrapper.setProps({ item: libraryData });
+      let announcements = wrapper.find(AnnouncementsSection);
+      expect(announcements.length).to.equal(1);
+      expect(announcements.props().setting.key).to.equal("announcements");
+      expect(announcements.props().value).to.eql(JSON.parse(libraryData.settings.announcements));
     });
 
     it("subdivides fields", () => {

--- a/src/components/__tests__/LibraryEditForm-test.tsx
+++ b/src/components/__tests__/LibraryEditForm-test.tsx
@@ -33,7 +33,7 @@ describe("LibraryEditForm", () => {
     { key: "large_collections", label: "Languages", category: "Languages" },
     { key: "featured_lane_size", label: "Maximum number of books in the 'featured' lanes", category: "Lanes & Filters", type: "number"},
     { key: "service_area", label: "Service Area", category: "Geographic Areas", type: "list" },
-    { key: "announcements", label: "Announcements", category: "Announcements", format: "announcements" }
+    { key: "announcements", label: "Announcements", category: "Announcements", type: "announcements" }
   ];
 
   let editableInputByName = (name) => {

--- a/src/components/__tests__/LibraryEditForm-test.tsx
+++ b/src/components/__tests__/LibraryEditForm-test.tsx
@@ -144,7 +144,7 @@ describe("LibraryEditForm", () => {
 
     it("subdivides fields", () => {
       let collapsible = wrapper.find(".panel");
-      expect(collapsible.length).to.equal(6);
+      expect(collapsible.length).to.equal(7);
 
       let basic = collapsible.at(0).find(".panel-heading");
       expect(basic.text()).to.contain("Basic Information");
@@ -169,7 +169,7 @@ describe("LibraryEditForm", () => {
 
     it("has a save button", () => {
       let form = wrapper.find(Form);
-      let saveButton = form.find(Button).at(1);
+      let saveButton = form.find(Button).last();
       expect(saveButton.text()).to.equal("Submit");
       expect(form.prop("onSubmit")).to.equal(wrapper.instance().submit);
     });
@@ -190,7 +190,7 @@ describe("LibraryEditForm", () => {
     });
 
     it("calls save when the save button is clicked", () => {
-      let saveButton = wrapper.find(Button).at(1);
+      let saveButton = wrapper.find(Button).last();
       saveButton.simulate("click");
       expect(save.callCount).to.equal(1);
     });
@@ -203,7 +203,7 @@ describe("LibraryEditForm", () => {
     it("submits data", () => {
       wrapper.setProps({ item: libraryData });
 
-      let saveButton = wrapper.find(Button).at(1);
+      let saveButton = wrapper.find(Button).last();
       saveButton.simulate("click");
 
       expect(save.callCount).to.equal(1);

--- a/src/components/__tests__/LibraryEditForm-test.tsx
+++ b/src/components/__tests__/LibraryEditForm-test.tsx
@@ -23,7 +23,7 @@ describe("LibraryEditForm", () => {
       "privacy-policy": "http://privacy",
       "copyright": "http://copyright",
       "featured_lane_size": "20",
-      "announcements": "[{\"content\": \"Announcement #1\", \"start\": \"2020-06-15\", \"finish\": \"2020-08-15\"}]"
+      "announcements": "[{\"content\": \"Announcement #1\", \"start\": \"2020-06-15\", \"finish\": \"2020-08-15\", \"id\": \"1\"}]"
     }
   };
   let settingFields = [

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -442,9 +442,8 @@ export interface LanesData {
 }
 
 export interface AnnouncementData {
-
-}
-
-export interface AnnouncementsData {
-
+  id: string;
+  content: string;
+  start: string;
+  finish: string;
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -175,7 +175,7 @@ export interface LibraryData {
   name?: string;
   short_name?: string;
   settings?: {
-    [key: string]: string | string[];
+    [key: string]: string | string[] | {}[];
   };
 }
 
@@ -439,4 +439,12 @@ export interface LaneData {
 
 export interface LanesData {
   lanes: LaneData[];
+}
+
+export interface AnnouncementData {
+
+}
+
+export interface AnnouncementsData {
+
 }

--- a/src/stylesheets/announcements.scss
+++ b/src/stylesheets/announcements.scss
@@ -2,6 +2,7 @@
    ul.announcements-ul {
     border: 1px solid $blue-dark;
     padding: 16px 16px 6px 16px;
+    list-style: none;
     li.announcement {
       display: flex;
       flex-direction: column;
@@ -10,6 +11,21 @@
       margin: 0 0 10px 0;
       background: $gray-tint;
       padding: 16px;
+      .announcement-info {
+        border-bottom: 1px solid $dark-gray;
+        justify-content: space-between;
+        padding-bottom: 8px;
+        margin-bottom: 8px;
+        .position {
+          display: block;
+          padding: 6px 8px;
+          height: 36px;
+          width: 36px;
+          background: white;
+          border: 1px solid $blue-dark;
+          color: $blue-dark;
+        }
+      }
       section {
         display: flex;
         justify-content: flex-start;

--- a/src/stylesheets/announcements.scss
+++ b/src/stylesheets/announcements.scss
@@ -3,6 +3,9 @@
     border: 1px solid $blue-dark;
     padding: 16px 16px 6px 16px;
     list-style: none;
+    > hr {
+      border-color: $blue-dark;
+    }
     .announcement {
       display: flex;
       flex-direction: column;

--- a/src/stylesheets/announcements.scss
+++ b/src/stylesheets/announcements.scss
@@ -1,0 +1,19 @@
+.announcements-section {
+   ul.announcements-ul {
+    border: 1px solid $blue-dark;
+    padding: 16px 16px 6px 16px;
+    li.announcement {
+      display: flex;
+      flex-direction: column;
+      width: 100%;
+      border: 1px solid $dark-gray;
+      margin: 0 0 10px 0;
+      background: $gray-tint;
+      padding: 16px;
+      section {
+        display: flex;
+        justify-content: flex-start;
+      }
+    }
+  }
+}

--- a/src/stylesheets/announcements.scss
+++ b/src/stylesheets/announcements.scss
@@ -32,4 +32,7 @@
       }
     }
   }
+  .form-group.too-short p.description {
+    color: $red;
+  }
 }

--- a/src/stylesheets/announcements.scss
+++ b/src/stylesheets/announcements.scss
@@ -7,28 +7,39 @@
       display: flex;
       flex-direction: column;
       width: 100%;
-      border: 1px solid $dark-gray;
       margin: 0 0 10px 0;
-      background: $gray-tint;
-      padding: 16px;
       .announcement-info {
-        border-bottom: 1px solid $dark-gray;
         justify-content: space-between;
-        padding-bottom: 8px;
-        margin-bottom: 8px;
-        .position {
-          display: block;
-          padding: 6px 8px;
-          height: 36px;
-          width: 36px;
-          background: white;
-          border: 1px solid $blue-dark;
-          color: $blue-dark;
-        }
       }
       section {
         display: flex;
         justify-content: flex-start;
+        &:first-child {
+          flex-direction: column;
+        }
+        span {
+          padding: 16px 12px;
+          border-left: 1px solid $blue-dark;
+          border-right: 1px solid $blue-dark;
+        }
+        .dates {
+          background: $gray-tint;
+          display: block;
+          padding: 16px 12px;
+          font-weight: bold;
+          border: 1px solid $dark-gray;
+        }
+      }
+      hr {
+        width: 96%;
+        border-color: $blue-dark;
+        margin: 0 auto;
+      }
+      .buttons {
+        padding: 10px 8px 0 10px;
+        border-left: 1px solid $blue-dark;
+        border-right: 1px solid $blue-dark;
+        border-bottom: 1px solid $blue-dark;
       }
     }
   }

--- a/src/stylesheets/announcements.scss
+++ b/src/stylesheets/announcements.scss
@@ -1,9 +1,9 @@
 .announcements-section {
-   ul.announcements-ul {
+  ul.announcements-ul {
     border: 1px solid $blue-dark;
     padding: 16px 16px 6px 16px;
     list-style: none;
-    li.announcement {
+    .announcement {
       display: flex;
       flex-direction: column;
       width: 100%;
@@ -23,8 +23,8 @@
           border-right: 1px solid $blue-dark;
         }
         .dates {
-          background: $gray-tint;
           display: block;
+          background: $gray-tint;
           padding: 16px 12px;
           font-weight: bold;
           border: 1px solid $dark-gray;

--- a/src/stylesheets/announcements.scss
+++ b/src/stylesheets/announcements.scss
@@ -43,7 +43,7 @@
       }
     }
   }
-  .form-group.too-short p.description {
+  .form-group.wrong-length p.description {
     color: $red;
   }
 }

--- a/src/stylesheets/app.scss
+++ b/src/stylesheets/app.scss
@@ -7,6 +7,7 @@
 @import "global";
 
 @import "admin_auth_service_edit_form";
+@import "announcements";
 @import "badge";
 @import "book_details_container";
 @import "book_details_tab_container";

--- a/src/stylesheets/config_tab_container.scss
+++ b/src/stylesheets/config_tab_container.scss
@@ -28,9 +28,9 @@ $dangercolor: #D9534F;
       width: 73%;
       padding: 40px 50px;
 
-      ul:not(.input-list-ul) {
+      ul:not(.input-list-ul):not(.announcements-ul) {
         padding-left: 10px;
-        li:not(.panel) {
+        li:not(.panel):not(.announcement) {
           display: flex;
           flex-direction: row;
           justify-content: space-between;


### PR DESCRIPTION
Resolves https://jira.nypl.org/browse/SIMPLY-2739 and its subtasks.

Goes with https://github.com/NYPL-Simplified/circulation/tree/adjust-announcements-config-setting

Requirements doc: https://docs.google.com/document/d/1ngvqr7oN-VHMdnygDD9uAeVpa45LYq-JUTT5zY5-gJ4/edit?ts=5ec7f043&pli=1#heading=h.t2bf91puc1w

<img width="934" alt="Screen Shot 2020-06-26 at 2 55 50 PM" src="https://user-images.githubusercontent.com/42178216/85891468-283cda00-b7bd-11ea-998a-70704ed5ab88.png">

Note: while making sample announcements for the screenshot, I have just noticed a bug whereby the default end date does not update when you change the start date.  Will fix.  :woman_facepalming:
