### PR TITLE
Assign temporary ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v0.4.21
+#### Fixed
+- Fixed a bug involving editing unsaved announcements.
+
 ### v0.4.20
 #### Added
 - Implemented a new LibraryEditForm section so that admins can manage library-specific announcements.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.4.20",
+  "version": "0.4.21",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/components/AnnouncementForm.tsx
+++ b/src/components/AnnouncementForm.tsx
@@ -21,6 +21,7 @@ export default class AnnouncementForm extends React.Component<AnnouncementFormPr
   constructor(props: AnnouncementFormProps) {
     super(props);
     this.updateStartDate = this.updateStartDate.bind(this);
+    this.updateEndDate = this.updateEndDate.bind(this);
     let [start, finish] = this.getDefaultDates();
     this.state = {content: this.props.content || "", start: this.props.start || start, finish: this.props.finish || finish};
   }
@@ -92,7 +93,6 @@ export default class AnnouncementForm extends React.Component<AnnouncementFormPr
       } else if (wrongLength) {
         return true;
       }
-      this.updateEndDate = this.updateEndDate.bind(this);
       return false;
     };
     return (

--- a/src/components/AnnouncementForm.tsx
+++ b/src/components/AnnouncementForm.tsx
@@ -21,9 +21,8 @@ export default class AnnouncementForm extends React.Component<AnnouncementFormPr
   constructor(props: AnnouncementFormProps) {
     super(props);
     this.updateStartDate = this.updateStartDate.bind(this);
-    this.updateEndDate = this.updateEndDate.bind(this);
     let [start, finish] = this.getDefaultDates();
-    this.state = {content: "", start: start, finish: finish};
+    this.state = {content: this.props.content || "", start: this.props.start || start, finish: this.props.finish || finish};
   }
   getDefaultDates(): string[] {
     // By default, the start date is today's date and the end date is two months from today.
@@ -76,9 +75,9 @@ export default class AnnouncementForm extends React.Component<AnnouncementFormPr
       this.setState({content: "", start: start, finish: finish});
     }
   }
+
   componentWillReceiveProps(newProps: AnnouncementFormProps) {
     // Switch from creating a new announcement to editing an existing one.
-    // if (newProps.content !== this.props.content) {
     if (newProps.content?.length > 0) {
       const { content, start, finish } = newProps;
       this.setState({ content: content, start: this.formatDate(start), finish: this.formatDate(finish) });
@@ -93,6 +92,7 @@ export default class AnnouncementForm extends React.Component<AnnouncementFormPr
       } else if (wrongLength) {
         return true;
       }
+      this.updateEndDate = this.updateEndDate.bind(this);
       return false;
     };
     return (

--- a/src/components/AnnouncementsSection.tsx
+++ b/src/components/AnnouncementsSection.tsx
@@ -24,6 +24,14 @@ export default class AnnouncementsSection extends React.Component<AnnouncementsS
   }
   addAnnouncement(announcement: AnnouncementData) {
     let announcements = this.state.currentAnnouncements;
+    // If the announcement hasn't been saved yet, it does not have an ID; the ID is assigned by the server code.  But editing
+    // announcements involves finding them by their ID, so we give the new announcement a temporary ID just so that we'll be able
+    // to edit it.  The temporary ID gets blanked out before the announcement goes to the server, so the permanent ID will still get
+    // assigned on the back end.
+    if (!announcement.id) {
+      let tempId = ["temp_1", "temp_2", "temp_3"].find(x => !announcements.map(a => a.id).includes(x));
+      announcement.id = tempId;
+    }
     this.setState({ currentAnnouncements: announcements.concat(announcement), editing: null });
   }
   deleteAnnouncement(id: string) {
@@ -31,7 +39,7 @@ export default class AnnouncementsSection extends React.Component<AnnouncementsS
       this.setState({ currentAnnouncements: this.state.currentAnnouncements.filter(a => a.id !== id), editing: null});
     }
   }
-  editAnnouncement(id: string) {
+  editAnnouncement(id: string): void {
     let editing = this.state.currentAnnouncements.find(a => a.id === id);
     let currentAnnouncements = this.state.currentAnnouncements.filter(a => a.id !== id);
     if (this.state.editing && this.state.editing.id !== id) {
@@ -95,6 +103,9 @@ export default class AnnouncementsSection extends React.Component<AnnouncementsS
     );
   }
   getValue(): Array<AnnouncementData> {
-    return this.state.currentAnnouncements;
+    // If there are any new announcements, blank out their temporary IDs so that the server wil assign them permanent ones.
+    return this.state.currentAnnouncements.map(a =>
+      a.id.match(/temp_/) ? ({content: a.content, start: a.start, finish: a.finish} as AnnouncementData) : a
+    );
   }
 }

--- a/src/components/AnnouncementsSection.tsx
+++ b/src/components/AnnouncementsSection.tsx
@@ -72,6 +72,7 @@ export default class AnnouncementsSection extends React.Component<AnnouncementsS
     return (
       <ul className="announcements-ul">
         <h4>Scheduled Announcements:</h4>
+        <p>You can have a maximum of 3 announcements.</p>
         <hr />
         {
           Array.isArray(this.state.currentAnnouncements) && this.state.currentAnnouncements.sort(compareStartDate).map(a =>

--- a/src/components/__tests__/AnnouncementsSection-test.tsx
+++ b/src/components/__tests__/AnnouncementsSection-test.tsx
@@ -13,13 +13,13 @@ describe("AnnouncementsSection", () => {
       content: "First Announcement",
       start: "2020-05-12",
       finish: "2020-06-12",
-      id: 1
+      id: "perm_1"
     },
     {
       content: "Second Announcement",
       start: "2020-05-28",
       finish: "2020-06-28",
-      id: 2
+      id: "perm_2"
     }
   ];
   let setting = {
@@ -57,8 +57,8 @@ describe("AnnouncementsSection", () => {
     textarea.simulate("change");
     form.find("button").at(0).simulate("click");
     expect(wrapper.state().currentAnnouncements.length).to.equal(3);
+    expect(wrapper.state().currentAnnouncements[2].id).to.equal("temp_1");
     expect(wrapper.find(".announcement").length).to.equal(3);
-
   });
   it("edits an announcement", () => {
     expect(wrapper.state().editing).to.be.null;
@@ -85,5 +85,14 @@ describe("AnnouncementsSection", () => {
     expect(wrapper.find(".announcement").length).to.equal(1);
     expect(wrapper.find(".announcement").at(0).text()).to.contain("Second Announcement");
     confirmStub.restore();
+  });
+  it("removes any temporary IDs before submitting the list of announcements", () => {
+    wrapper.setState({
+      currentAnnouncements: announcements.concat({ content: "temp", start: "2020-05-28", finish: "2020-06-28", id: "temp_1"})
+    });
+    let list = wrapper.instance().getValue();
+    expect(list[0].id).to.equal("perm_1");
+    expect(list[1].id).to.equal("perm_2");
+    expect(list[2].id).to.be.undefined;
   });
 });

--- a/src/stylesheets/announcements.scss
+++ b/src/stylesheets/announcements.scss
@@ -3,8 +3,16 @@
     border: 1px solid $blue-dark;
     padding: 16px 16px 6px 16px;
     list-style: none;
+    > h4 {
+      margin-bottom: 1vh;
+    }
+    > p {
+      color: $red-dark;
+      margin-bottom: 0;
+    }
     > hr {
       border-color: $blue-dark;
+      margin-top: 1vh;
     }
     .announcement {
       display: flex;


### PR DESCRIPTION
Resolves https://jira.nypl.org/browse/SIMPLY-2895, a bug I found during QA.  

The bug: if you have unsaved announcements (i.e. you have created them but not submitted LibraryEditForm), then trying to edit an announcement causes the unsaved ones to disappear.

Explanation: the logic in `editAnnouncement` (in `AnnouncementsSection`) filters by ID in order to figure out which announcements to keep displaying in the list.  But the ID is assigned by the server.  So if your announcements aren't saved yet, they don't have IDs.

Workaround: I assigned temporary IDs to announcements when they're created.  The temporary IDs get blanked out when you submit the form.  This way, editing works as expected, and the announcements still get the server-generated permanent IDs when you save them.

