### PR TITLE
Force date parsing function to use us-EN locale

### DIFF
--- a/src/components/AnnouncementForm.tsx
+++ b/src/components/AnnouncementForm.tsx
@@ -36,7 +36,7 @@ export default class AnnouncementForm extends React.Component<AnnouncementFormPr
     if (typeof date === "string" && date.indexOf("/") === -1) {
       return date;
     }
-    let [month, day, year] = typeof date === "string" ? date.split("/") : date.toLocaleDateString().split("/");
+    let [month, day, year] = typeof date === "string" ? date.split("/") : date.toLocaleDateString("en-US").split("/");
     return `${year}-${month.toString().length === 1 ? "0" + month : month}-${day.toString().length === 1 ? "0" + day : day}`;
   }
   updateContent(content: string) {


### PR DESCRIPTION
## Issue

When I go to load the settings page for the circulation manager I get: 

```
Uncaught TypeError: day is undefined AnnouncementForm.tsx:41
    formatDate AnnouncementForm.tsx:41
    getDefaultDates AnnouncementForm.tsx:32
    AnnouncementForm AnnouncementForm.tsx:25
```

Because of this error the circulation manager settings page just returns a white page. 

Loading this with a debugger `date.toLocaleDateString()` returns the date string in my locale (Canada 🇨🇦) which is `2020-08-26` which doesn't have the `/` that the code is trying to split on. 

There are other more subtle errors possible with this, for example if your locale is British English the [date format](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString) is day-month-year but uses the `/` separator.
```
// British English uses day-month-year order
console.log(date.toLocaleDateString('en-GB'));
// → "20/12/2012"
```

## Fix

This is a band-aid fix, it changes the call to `toLocaleDateString` to force the us-EN locale so that you get the date format you are expecting and the code doesn't error out. This stops the immediate error I am seeing so I'm able to use the CM settings pages again. 

I would however suggest that a review be done on this code with date internationalization in mind. It seems to assume US style date formatting in several places, which is likely to break for anyone in a non-US locale. It also [formats the dates it prints](https://github.com/NYPL-Simplified/circulation-web/blob/master/src/components/Announcement.tsx#L32) in a non-internationalized way, so some of the UI will display the locale date format and some won't. It would probably be better to format the date using the locale date format.

## Testing

To test this you can [change the language](https://support.mozilla.org/en-US/kb/use-firefox-another-language) in firefox to `English - Canadian`. Then load the admin interface and try to modify library settings. You should see the above error in the javascript console and the settings page won't load.


