### PR TITLE
Display user's permissions level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changelog
 
+### v0.4.27
+
+#### Added
+
+- Displayed the current user's level of permissions in the account dropdown.
+
 ### v0.4.26
 
 #### Updated

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.4.25",
+  "version": "0.4.26",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.4.26",
+  "version": "0.4.27",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -75,6 +75,15 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
     });
   }
 
+  displayPermissions(isSystemAdmin: boolean, isLibraryManager: boolean) {
+    let permissions = isSystemAdmin
+      ? "system admin"
+      : isLibraryManager
+      ? "library manager"
+      : "librarian";
+    return <li className="permissions">Logged in as a {permissions}</li>;
+  }
+
   render(): JSX.Element {
     const currentPathname =
       (this.context.router &&
@@ -176,6 +185,7 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
                 />
                 {this.state.showAccountDropdown && (
                   <ul className="dropdown-menu">
+                    {this.displayPermissions(isSystemAdmin, isLibraryManager)}
                     {this.renderLinkItem(accountLink, currentPathname)}
                     <li>
                       <a href="/admin/sign_out">Sign out</a>

--- a/src/components/__tests__/Header-test.tsx
+++ b/src/components/__tests__/Header-test.tsx
@@ -263,14 +263,23 @@ describe("Header", () => {
       wrapper = mount(<Header />, { context: fullContext, childContextTypes });
 
       let toggle = wrapper.find(".account-dropdown-toggle").hostNodes();
-      let dropdownLinks = wrapper.find("ul.dropdown-menu a");
+      let dropdownItems = wrapper.find("ul.dropdown-menu li");
+      let dropdownLinks = wrapper.find("ul.dropdown-menu li a");
+      expect(dropdownItems.length).to.equal(0);
       expect(dropdownLinks.length).to.equal(0);
 
       toggle.simulate("click");
-      dropdownLinks = wrapper.find("ul.dropdown-menu li");
+      dropdownItems = wrapper.find("ul.dropdown-menu li");
+      dropdownLinks = wrapper.find("ul.dropdown-menu li a");
+      expect(dropdownItems.length).to.equal(3);
       expect(dropdownLinks.length).to.equal(2);
-      let changePassword = dropdownLinks.find(Link);
-      expect(changePassword.prop("to")).to.equal("/admin/web/account/");
+
+      let loggedInAs = dropdownItems.at(0);
+      expect(loggedInAs.text()).to.equal("Logged in as a librarian");
+      let changePassword = dropdownLinks.at(0);
+      expect(changePassword.parent().prop("to")).to.equal(
+        "/admin/web/account/"
+      );
       // The first anchor element is from the Link component.
       let signOut = dropdownLinks.find("a").at(1);
       expect(signOut.prop("href")).to.equal("/admin/sign_out");
@@ -279,5 +288,19 @@ describe("Header", () => {
       dropdownLinks = wrapper.find("ul.dropdown-menu li");
       expect(dropdownLinks.length).to.equal(0);
     });
+  });
+
+  it("displays the user's level of permissions", () => {
+    let permissions = (args) =>
+      wrapper
+        .instance()
+        .displayPermissions(...args)
+        .props.children.join("");
+    expect(permissions([true, true])).to.equal("Logged in as a system admin");
+    expect(permissions([true, false])).to.equal("Logged in as a system admin");
+    expect(permissions([false, true])).to.equal(
+      "Logged in as a library manager"
+    );
+    expect(permissions([false, false])).to.equal("Logged in as a librarian");
   });
 });

--- a/src/stylesheets/header.scss
+++ b/src/stylesheets/header.scss
@@ -50,6 +50,11 @@
       background-color: $dark-gray;
       left: auto;
       right: 0;
+      padding-bottom: 0;
+
+      .permissions, a {
+        padding: 5px;
+      }
 
       a {
         background-color: $dark;


### PR DESCRIPTION
Resolves https://jira.nypl.org/browse/SIMPLY-3192; shows user what they're currently logged in as.

<img width="218" alt="Screen Shot 2020-10-14 at 2 01 05 PM" src="https://user-images.githubusercontent.com/42178216/96185219-97267600-0f07-11eb-9c34-6e49b9daa8f3.png">
