### PR TITLE
Don't change navbar-brand styling on hover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changelog
 
+### v0.4.28
+
+#### Fixed
+
+- Fixed a CSS issue whereby text was erroneously styled to look like a link on hover.
+
 ### v0.4.27
 
 #### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.4.27",
+  "version": "0.4.28",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/stylesheets/header.scss
+++ b/src/stylesheets/header.scss
@@ -1,7 +1,7 @@
 .navbar-default {
   padding: 3px 0;
 
-  .navbar-brand {
+  .navbar-brand, .navbar-brand:hover {
     color: $pagecolorlight;
     font-size: 1.8em;
   }


### PR DESCRIPTION
Resolves https://jira.nypl.org/browse/SIMPLY-3194

Currently, when you go to dashboard/system config/troubleshooting, the "Admin" text all the way on the left in the header turns gray on hover (see screenshot) and looks confusingly link-y.  
<img width="339" alt="Screen Shot 2020-10-14 at 12 55 24 PM" src="https://user-images.githubusercontent.com/42178216/96497206-55a00e80-1218-11eb-9c33-b664d33243ec.png">
