### PR TITLE
Input list fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changelog
 
+### v0.4.30
+
+#### Fixed
+
+- Fixed a bug whereby the InputList wasn't rendering default values from the server
+
 ### v0.4.29
 
 #### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.4.29",
+  "version": "0.4.30",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/components/InputList.tsx
+++ b/src/components/InputList.tsx
@@ -42,7 +42,6 @@ export default class InputList extends React.Component<
     super(props);
     let isMenu = props.setting.type === "menu";
     this.state = {
-      // listItems: (props.value as string[] || []),
       listItems:
         (props.value as string[]) || (props.setting.default as string[]) || [],
       newItem: "",

--- a/src/components/InputList.tsx
+++ b/src/components/InputList.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import * as React from "react";
 import WithRemoveButton from "./WithRemoveButton";
 import LanguageField from "./LanguageField";
@@ -8,7 +9,11 @@ import { Button } from "library-simplified-reusable-components";
 import { isEqual, formatString } from "../utils/sharedFunctions";
 
 export interface InputListProps {
-  createEditableInput: (setting: SettingData, customProps?: any, children?: JSX.Element[]) => JSX.Element;
+  createEditableInput: (
+    setting: SettingData,
+    customProps?: any,
+    children?: JSX.Element[]
+  ) => JSX.Element;
   labelAndDescription?: (setting: SettingData) => JSX.Element[];
   setting: SettingData | CustomListsSetting;
   disabled: boolean;
@@ -29,15 +34,19 @@ export interface InputListState {
   options?: JSX.Element[];
 }
 
-export default class InputList extends React.Component<InputListProps, InputListState> {
-
+export default class InputList extends React.Component<
+  InputListProps,
+  InputListState
+> {
   constructor(props: InputListProps) {
     super(props);
     let isMenu = props.setting.type === "menu";
     this.state = {
-      listItems: (props.value as string[] || []),
+      // listItems: (props.value as string[] || []),
+      listItems:
+        (props.value as string[]) || (props.setting.default as string[]) || [],
       newItem: "",
-      options: isMenu && this.filterMenu()
+      options: isMenu && this.filterMenu(),
     };
     this.updateNewItem = this.updateNewItem.bind(this);
     this.addListItem = this.addListItem.bind(this);
@@ -49,15 +58,24 @@ export default class InputList extends React.Component<InputListProps, InputList
 
   componentWillReceiveProps(newProps: InputListProps) {
     // Update the list of existing items with value from new props
-    if (this.state.listItems && newProps.value && !isEqual(this.state.listItems, newProps.value)) {
+    if (
+      this.state.listItems &&
+      newProps.value &&
+      !isEqual(this.state.listItems, newProps.value)
+    ) {
       this.setState({ listItems: newProps.value });
     }
   }
 
   componentDidUpdate(oldProps: InputListProps, oldState: InputListState) {
     // Remove already-selected items from the dropdown menu
-    if (oldState.listItems && this.state.listItems && !isEqual(oldState.listItems, this.state.listItems)) {
-      this.props.setting.format === "narrow" && this.setState({ options: this.filterMenu() });
+    if (
+      oldState.listItems &&
+      this.state.listItems &&
+      !isEqual(oldState.listItems, this.state.listItems)
+    ) {
+      this.props.setting.format === "narrow" &&
+        this.setState({ options: this.filterMenu() });
     }
   }
 
@@ -80,36 +98,38 @@ export default class InputList extends React.Component<InputListProps, InputList
     } else if (setting.type === "menu") {
       element = this.renderMenu(setting);
     } else {
-      element = (
-        this.props.createEditableInput(setting, {
-          value: null,
-          disabled: this.props.disabled,
-          onChange: this.updateNewItem,
-          ref: "addListItem",
-          label: null,
-          description: null
-        })
-      );
+      element = this.props.createEditableInput(setting, {
+        value: null,
+        disabled: this.props.disabled,
+        onChange: this.updateNewItem,
+        ref: "addListItem",
+        label: null,
+        description: null,
+      });
     }
     return (
       <div className="input-list">
-        { this.props.labelAndDescription && this.props.labelAndDescription(setting) }
-        { this.props.altValue && !hasListItems && <span>{this.props.altValue}</span> }
-        { this.props.title && hasListItems && <h4>{this.props.title}</h4> }
-        { hasListItems && this.renderList(this.state.listItems, setting) }
+        {this.props.labelAndDescription &&
+          this.props.labelAndDescription(setting)}
+        {this.props.altValue && !hasListItems && (
+          <span>{this.props.altValue}</span>
+        )}
+        {this.props.title && hasListItems && <h4>{this.props.title}</h4>}
+        {hasListItems && this.renderList(this.state.listItems, setting)}
         <div className="add-list-item-container">
-          <span className="add-list-item">
-            { element }
-          </span>
-          { showButton &&
+          <span className="add-list-item">{element}</span>
+          {showButton && (
             <Button
               type="button"
               className="add-list-item inline small bottom-align"
               callback={this.addListItem}
               content="Add"
-              disabled={this.props.disabled || (setting.type !== "menu" && !this.state.newItem.length)}
+              disabled={
+                this.props.disabled ||
+                (setting.type !== "menu" && !this.state.newItem.length)
+              }
             />
-          }
+          )}
         </div>
       </div>
     );
@@ -118,19 +138,24 @@ export default class InputList extends React.Component<InputListProps, InputList
   renderList(listItems, setting: SettingData) {
     return (
       <ul className="input-list-ul">
-        {
-          listItems.filter(listItem => listItem).map((listItem) => {
-            let value = typeof(listItem) === "string" ? listItem : Object.keys(listItem)[0];
+        {listItems
+          .filter((listItem) => listItem)
+          .map((listItem) => {
+            let value =
+              typeof listItem === "string"
+                ? listItem
+                : Object.keys(listItem)[0];
             return this.renderListItem(setting, value, listItem);
-          })
-        }
+          })}
       </ul>
     );
   }
 
   renderListItem(setting: SettingData, value: string, listItem) {
     let item: JSX.Element;
-    let label = setting.options ? setting.options.find(o => o.key === value)?.label : value;
+    let label = setting.options
+      ? setting.options.find((o) => o.key === value)?.label
+      : value;
     if (setting.format === "language-code") {
       item = (
         <LanguageField
@@ -142,23 +167,19 @@ export default class InputList extends React.Component<InputListProps, InputList
       );
     } else if (setting.urlBase) {
       // Use information stored in the parent component to render the list item as a link
-      item = (
-        <a href={setting.urlBase(listItem)}>{listItem}</a>
-      );
+      item = <a href={setting.urlBase(listItem)}>{listItem}</a>;
     } else {
-      item = (
-        this.props.createEditableInput(setting, {
-          type: "text",
-          description: null,
-          disabled: this.props.disabled,
-          value: label,
-          name: setting.type === "menu" ? `${setting.key}_${value}` : setting.key,
-          label: null,
-          extraContent: this.renderToolTip(listItem, setting.format),
-          optionalText: false,
-          readOnly: this.props.readOnly
-        })
-      );
+      item = this.props.createEditableInput(setting, {
+        type: "text",
+        description: null,
+        disabled: this.props.disabled,
+        value: label,
+        name: setting.type === "menu" ? `${setting.key}_${value}` : setting.key,
+        label: null,
+        extraContent: this.renderToolTip(listItem, setting.format),
+        optionalText: false,
+        readOnly: this.props.readOnly,
+      });
     }
     return (
       <li className="input-list-item" key={value}>
@@ -166,7 +187,7 @@ export default class InputList extends React.Component<InputListProps, InputList
           disabled={this.props.disabled}
           onRemove={() => this.removeListItem(listItem)}
         >
-          { item }
+          {item}
         </WithRemoveButton>
       </li>
     );
@@ -186,11 +207,11 @@ export default class InputList extends React.Component<InputListProps, InputList
           required: setting.required,
           ref: "addListItem",
           optionalText: !setting.required,
-          description: !setting.required ? "(Optional) " : ""
-        }, choices
+          description: !setting.required ? "(Optional) " : "",
+        },
+        choices
       );
-    }
-    else if (this.props.onEmpty) {
+    } else if (this.props.onEmpty) {
       // Optionally render a string telling the user that there are no more available choices.
       return this.props.onEmpty;
     }
@@ -198,13 +219,17 @@ export default class InputList extends React.Component<InputListProps, InputList
 
   renderToolTip(item: {} | string, format: string) {
     const icons = {
-      "geographic": <LocatorIcon />
+      geographic: <LocatorIcon />,
     };
 
-    if (typeof(item) === "object") {
+    if (typeof item === "object") {
       return (
         <span className="input-group-addon">
-          <ToolTip trigger={icons[format]} direction="point-right" text={Object.values(item)[0].toString()} />
+          <ToolTip
+            trigger={icons[format]}
+            direction="point-right"
+            text={Object.values(item)[0].toString()}
+          />
         </span>
       );
     }
@@ -219,39 +244,59 @@ export default class InputList extends React.Component<InputListProps, InputList
     // and crashing.
     if (!allOptions) {
       try {
-        allOptions = this.props.setting.options.map(o => <option key={o.key} value={o.key} aria-selected={false}>{o.label}</option>);
-      }
-      catch {
+        allOptions = this.props.setting.options.map((o) => (
+          <option key={o.key} value={o.key} aria-selected={false}>
+            {o.label}
+          </option>
+        ));
+      } catch {
         return;
       }
     }
     // Items that have already been selected, and should be eliminated from the menu.
-    let listItems = this.state ? this.state.listItems : (this.props.value || this.props.setting.default);
+    let listItems = this.state
+      ? this.state.listItems
+      : this.props.value || this.props.setting.default;
     // Items that haven't been selected yet.
-    let remainingOptions = listItems ? allOptions.filter(o => listItems.indexOf(o.props.value) < 0) : [];
+    let remainingOptions = listItems
+      ? allOptions.filter((o) => listItems.indexOf(o.props.value) < 0)
+      : [];
     return remainingOptions;
   }
 
   updateNewItem() {
-    let ref = this.props.setting.format === "language-code" ?
-      (this.refs["addListItem"] as any).refs["autocomplete"] :
-      (this.refs["addListItem"] as any);
-    this.setState({...this.state, ...{ newItem: ref.getValue() }});
+    let ref =
+      this.props.setting.format === "language-code"
+        ? (this.refs["addListItem"] as any).refs["autocomplete"]
+        : (this.refs["addListItem"] as any);
+    this.setState({ ...this.state, ...{ newItem: ref.getValue() } });
   }
 
   async removeListItem(listItem: string | {}) {
-    await this.setState({ listItems: this.state.listItems.filter(stateListItem => stateListItem !== listItem) });
+    await this.setState({
+      listItems: this.state.listItems.filter(
+        (stateListItem) => stateListItem !== listItem
+      ),
+    });
     this.props.onChange && this.props.onChange(this.state);
     // Actually save the changes instead of just manipulating the state
-    if (this.props.onSubmit) { await this.props.onSubmit(); }
+    if (this.props.onSubmit) {
+      await this.props.onSubmit();
+    }
   }
 
   async addListItem() {
-    let ref = this.props.setting.format === "language-code" ?
-      (this.refs["addListItem"] as any).refs["autocomplete"] :
-      (this.refs["addListItem"] as any);
-    const listItem = this.props.setting.capitalize ? this.capitalize(ref.getValue()) : ref.getValue();
-    await this.setState({ listItems: this.state.listItems.concat(listItem), newItem: "" });
+    let ref =
+      this.props.setting.format === "language-code"
+        ? (this.refs["addListItem"] as any).refs["autocomplete"]
+        : (this.refs["addListItem"] as any);
+    const listItem = this.props.setting.capitalize
+      ? this.capitalize(ref.getValue())
+      : ref.getValue();
+    await this.setState({
+      listItems: this.state.listItems.concat(listItem),
+      newItem: "",
+    });
     this.props.onChange && this.props.onChange(this.state);
     // Actually save the changes instead of just manipulating the state
     if (this.props.onSubmit) {
@@ -265,9 +310,14 @@ export default class InputList extends React.Component<InputListProps, InputList
   capitalize(value: string): string {
     // If it's a state/province abbreviation, the whole thing should be uppercase.  Otherwise, just capitalize
     // the first letter of each word.
-    return value.split(" ").map(x =>
-      x.length === 2 && this.props.setting.format === "geographic" ? x.toUpperCase() : formatString(x)
-    ).join(" ");
+    return value
+      .split(" ")
+      .map((x) =>
+        x.length === 2 && this.props.setting.format === "geographic"
+          ? x.toUpperCase()
+          : formatString(x)
+      )
+      .join(" ");
   }
 
   getValue() {

--- a/src/components/__tests__/InputList-test.tsx
+++ b/src/components/__tests__/InputList-test.tsx
@@ -16,12 +16,12 @@ describe("InputList", () => {
   let wrapper;
   let store;
   let context;
-  let value = ["Thing 1", "Thing 2"];
-  let setting = {
+  const value = ["Thing 1", "Thing 2"];
+  const setting = {
     key: "setting",
     label: "label",
     description: "description",
-    type: "list"
+    type: "list",
   };
   let parent;
   let createEditableInput;
@@ -41,23 +41,24 @@ describe("InputList", () => {
         value={value}
         setting={setting}
         disabled={false}
-      />
-    , { context });
+      />,
+      { context }
+    );
   });
 
   it("renders a label and description", () => {
     expect(labelAndDescription.callCount).to.equal(1);
     expect(labelAndDescription.args[0][0]).to.deep.equal(setting);
-    let label = wrapper.find("label");
+    const label = wrapper.find("label");
     expect(label.length).to.equal(1);
     expect(label.text()).to.equal("label");
 
-    let description = wrapper.find(".description").at(0);
+    const description = wrapper.find(".description").at(0);
     expect(description.text()).to.equal("description");
   });
 
   it("renders a list of items", () => {
-    let inputs = wrapper.find(".form-control");
+    const inputs = wrapper.find(".form-control");
     expect(inputs.length).to.equal(3);
     expect(inputs.at(0).prop("value")).to.equal("Thing 1");
     expect(inputs.at(0).prop("type")).to.equal("text");
@@ -75,10 +76,12 @@ describe("InputList", () => {
   });
 
   it("optionally renders links", () => {
-    let urlBase = (itemName) => { return `admin/web/${itemName}`; };
-    let settingWithUrlBase = {...setting, ...{urlBase}};
+    const urlBase = (itemName) => {
+      return `admin/web/${itemName}`;
+    };
+    const settingWithUrlBase = { ...setting, ...{ urlBase } };
     wrapper.setProps({ setting: settingWithUrlBase });
-    let links = wrapper.find("a");
+    const links = wrapper.find("a");
     expect(links.length).to.equal(2);
     links.forEach((l, idx) => {
       expect(l.text()).to.equal(`Thing ${idx + 1}`);
@@ -87,40 +90,48 @@ describe("InputList", () => {
   });
 
   it("renders WithRemoveButton elements", () => {
-    let withRemoveButtons = wrapper.find(WithRemoveButton);
+    const withRemoveButtons = wrapper.find(WithRemoveButton);
     expect(withRemoveButtons.length).to.equal(2);
     expect(withRemoveButtons.at(0).prop("disabled")).to.be.false;
-    expect(withRemoveButtons.at(0).find("input").prop("value")).to.equal("Thing 1");
+    expect(withRemoveButtons.at(0).find("input").prop("value")).to.equal(
+      "Thing 1"
+    );
     expect(withRemoveButtons.at(1).prop("disabled")).to.be.false;
-    expect(withRemoveButtons.at(1).find("input").prop("value")).to.equal("Thing 2");
+    expect(withRemoveButtons.at(1).find("input").prop("value")).to.equal(
+      "Thing 2"
+    );
   });
 
   it("renders a button for adding a list item", () => {
-    let addListItemContainer = wrapper.find(".add-list-item-container");
-    let addListItem = addListItemContainer.find("span.add-list-item");
+    const addListItemContainer = wrapper.find(".add-list-item-container");
+    const addListItem = addListItemContainer.find("span.add-list-item");
     expect(addListItem.length).to.equal(1);
     expect(addListItem.find("input").prop("value")).to.equal("");
     expect(addListItemContainer.find(WithRemoveButton).length).to.equal(0);
-    expect(addListItemContainer.find("button.add-list-item").text()).to.equal("Add");
+    expect(addListItemContainer.find("button.add-list-item").text()).to.equal(
+      "Add"
+    );
   });
 
   it("optionally renders a geographic tooltip with extra content", () => {
-    let valueWithObject = [{"Thing 3": "extra information!"}];
-    let geographicSetting = {...setting, ...{format: "geographic"}};
-    let spyToolTip = spy(wrapper.instance(), "renderToolTip");
+    const valueWithObject = [{ "Thing 3": "extra information!" }];
+    const geographicSetting = { ...setting, ...{ format: "geographic" } };
+    const spyToolTip = spy(wrapper.instance(), "renderToolTip");
 
     wrapper.setProps({ setting: geographicSetting, value: valueWithObject });
 
-    let withAddOn = wrapper.find(".with-add-on");
+    const withAddOn = wrapper.find(".with-add-on");
     expect(withAddOn.length).to.equal(1);
 
-    let addOn = withAddOn.find(".input-group-addon");
+    const addOn = withAddOn.find(".input-group-addon");
     expect(addOn.length).to.equal(1);
-    let toolTipElement = addOn.find(ToolTip);
+    const toolTipElement = addOn.find(ToolTip);
     expect(toolTipElement.length).to.equal(1);
     expect(toolTipElement.find("svg").hasClass("locatorIcon")).to.be.true;
     expect(toolTipElement.find(".tool-tip").hasClass("point-right")).to.be.true;
-    expect(toolTipElement.find(".tool-tip").text()).to.equal("extra information!");
+    expect(toolTipElement.find(".tool-tip").text()).to.equal(
+      "extra information!"
+    );
 
     expect(withAddOn.find("input").length).to.equal(1);
     expect(withAddOn.find("input").prop("value")).to.equal("Thing 3");
@@ -128,14 +139,18 @@ describe("InputList", () => {
   });
 
   it("renders an autocomplete field for languages", () => {
-    let valueWithObject = ["abc"];
-    let languageSetting = {...setting, ...{format: "language-code"}};
-    let languages = {
-      "eng": ["English"],
-      "spa": ["Spanish", "Castilian"]
+    const valueWithObject = ["abc"];
+    const languageSetting = { ...setting, ...{ format: "language-code" } };
+    const languages = {
+      eng: ["English"],
+      spa: ["Spanish", "Castilian"],
     };
-    wrapper.setProps({ setting: languageSetting, value: valueWithObject, additionalData: languages });
-    let languageField = wrapper.find(LanguageField);
+    wrapper.setProps({
+      setting: languageSetting,
+      value: valueWithObject,
+      additionalData: languages,
+    });
+    const languageField = wrapper.find(LanguageField);
     expect(languageField.length).to.equal(2);
 
     expect(languageField.at(0).prop("value")).to.equal("abc");
@@ -150,7 +165,7 @@ describe("InputList", () => {
   it("removes an item", () => {
     let removables = wrapper.find(WithRemoveButton);
     expect(removables.length).to.equal(2);
-    let button = removables.at(0).find(".remove-btn").hostNodes();
+    const button = removables.at(0).find(".remove-btn").hostNodes();
     button.simulate("click");
     removables = wrapper.find(WithRemoveButton);
     expect(removables.length).to.equal(1);
@@ -163,7 +178,7 @@ describe("InputList", () => {
     let blankInput = wrapper.find("span.add-list-item input");
     blankInput.getDOMNode().value = "Another thing...";
     blankInput.simulate("change");
-    let addButton = wrapper.find("button.add-list-item");
+    const addButton = wrapper.find("button.add-list-item");
     addButton.simulate("click");
     await new Promise((resolve) => setTimeout(resolve, 0));
 
@@ -175,22 +190,26 @@ describe("InputList", () => {
     expect(blankInput.prop("value")).to.equal("");
   });
 
-  it("adds and capitalizes an item", async() => {
-    wrapper.setProps({ setting: { ...wrapper.prop("setting"), ...{"capitalize": true} }});
+  it("adds and capitalizes an item", async () => {
+    wrapper.setProps({
+      setting: { ...wrapper.prop("setting"), ...{ capitalize: true } },
+    });
     let removables = wrapper.find(WithRemoveButton);
     expect(removables.length).to.equal(2);
 
     let blankInput = wrapper.find("span.add-list-item input");
     blankInput.getDOMNode().value = "new york";
     blankInput.simulate("change");
-    let addButton = wrapper.find("button.add-list-item");
+    const addButton = wrapper.find("button.add-list-item");
     addButton.simulate("click");
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     wrapper.update();
     removables = wrapper.find(WithRemoveButton);
     expect(removables.length).to.equal(3);
-    expect(removables.at(2).find(EditableInput).prop("value")).to.equal("New York");
+    expect(removables.at(2).find(EditableInput).prop("value")).to.equal(
+      "New York"
+    );
     expect(wrapper.state()["listItems"][2]).to.equal("New York");
 
     blankInput = wrapper.find("span.add-list-item input");
@@ -198,8 +217,10 @@ describe("InputList", () => {
   });
 
   it("capitalizes a string", () => {
-    wrapper.setProps({ setting: {...wrapper.prop("setting"), ...{"format": "geographic"}}});
-    let cap = wrapper.instance().capitalize;
+    wrapper.setProps({
+      setting: { ...wrapper.prop("setting"), ...{ format: "geographic" } },
+    });
+    const cap = wrapper.instance().capitalize;
     // Capitalizes one word
     expect(cap("california")).to.equal("California");
     // Capitalizes multiple words
@@ -211,22 +232,26 @@ describe("InputList", () => {
   });
 
   it("adds an autocompleted item", async () => {
-    let languageSetting = { ...setting, format: "language-code" };
+    const languageSetting = { ...setting, format: "language-code" };
     wrapper.setProps({ setting: languageSetting, value: ["abc"] });
 
     let removables = wrapper.find(WithRemoveButton);
     expect(removables.length).to.equal(1);
-    let autocomplete = wrapper.find("input[list='setting-autocomplete-list']").at(1);
+    let autocomplete = wrapper
+      .find("input[list='setting-autocomplete-list']")
+      .at(1);
     autocomplete.getDOMNode().value = "Another language";
     autocomplete.simulate("change");
-    let addButton = wrapper.find("button.add-list-item");
+    const addButton = wrapper.find("button.add-list-item");
     addButton.simulate("click");
     await new Promise((resolve) => setTimeout(resolve, 0));
     wrapper.update();
 
     removables = wrapper.find(WithRemoveButton);
     expect(removables.length).to.equal(2);
-    autocomplete = wrapper.find("input[list='setting-autocomplete-list']").at(2);
+    autocomplete = wrapper
+      .find("input[list='setting-autocomplete-list']")
+      .at(2);
     expect(autocomplete.prop("value")).to.equal("");
   });
 
@@ -241,7 +266,7 @@ describe("InputList", () => {
     removables = wrapper.find(WithRemoveButton);
     expect(removables.length).to.equal(2);
 
-    let empty = wrapper.find("span.add-list-item input");
+    const empty = wrapper.find("span.add-list-item input");
     empty.getDOMNode().value = "something new";
     empty.simulate("change");
     addButton = wrapper.find("button.add-list-item");
@@ -256,7 +281,7 @@ describe("InputList", () => {
   });
 
   it("optionally accepts an onChange prop", async () => {
-    let onChange = stub();
+    const onChange = stub();
     wrapper.setProps({ onChange });
     expect(onChange.callCount).to.equal(0);
     wrapper.instance().addListItem();
@@ -293,12 +318,17 @@ describe("InputList", () => {
     beforeEach(() => {
       options = [];
       while (options.length < 3) {
-        let optionName = `Option ${options.length + 1}`;
+        const optionName = `Option ${options.length + 1}`;
         options.push(
-          <option value={optionName} aria-selected={false}>{optionName}</option>
+          <option value={optionName} aria-selected={false}>
+            {optionName}
+          </option>
         );
       }
-      let menuSetting = {...setting, ...{type: "menu", menuOptions: options, description: null }};
+      const menuSetting = {
+        ...setting,
+        ...{ type: "menu", menuOptions: options, description: null },
+      };
       wrapper = mount(
         <InputList
           createEditableInput={createEditableInput}
@@ -306,13 +336,14 @@ describe("InputList", () => {
           value={value}
           setting={menuSetting}
           disabled={false}
-        />
-      , { context });
+        />,
+        { context }
+      );
     });
     it("renders a dropdown menu", () => {
-      let menu = wrapper.find("select");
+      const menu = wrapper.find("select");
       expect(menu.length).to.equal(1);
-      let menuOptions = menu.find("option");
+      const menuOptions = menu.find("option");
       expect(menuOptions.length).to.equal(3);
       menuOptions.forEach((o, idx) => {
         expect(o.text()).to.equal(`Option ${idx + 1}`);
@@ -322,56 +353,67 @@ describe("InputList", () => {
       let removables = wrapper.find(WithRemoveButton);
       expect(removables.length).to.equal(2);
       expect(wrapper.state()["listItems"].includes("Option 1")).to.be.false;
-      let menu = wrapper.find("select");
+      const menu = wrapper.find("select");
       expect(menu.getDOMNode().value).to.equal("Option 1");
-      let addButton = wrapper.find(Button).last();
+      const addButton = wrapper.find(Button).last();
       addButton.simulate("click");
       removables = wrapper.find(WithRemoveButton);
       expect(removables.length).to.equal(3);
-      expect(removables.last().find(EditableInput).prop("value")).to.equal("Option 1");
+      expect(removables.last().find(EditableInput).prop("value")).to.equal(
+        "Option 1"
+      );
       expect(wrapper.state()["listItems"].includes("Option 1")).to.be.true;
     });
     it("optionally eliminates already-selected options from the menu", () => {
       let options = wrapper.find("option");
       expect(options.length).to.equal(3);
-      expect(options.map(o => o.text()).includes("Option 1")).to.be.true;
+      expect(options.map((o) => o.text()).includes("Option 1")).to.be.true;
       wrapper.find(Button).last().simulate("click");
       options = wrapper.find("option");
       expect(options.length).to.equal(3);
-      expect(options.map(o => o.text()).includes("Option 1")).to.be.true;
+      expect(options.map((o) => o.text()).includes("Option 1")).to.be.true;
 
-      let narrowSetting = {...wrapper.prop("setting"), ...{ format: "narrow" }};
+      const narrowSetting = {
+        ...wrapper.prop("setting"),
+        ...{ format: "narrow" },
+      };
       wrapper.setProps({ setting: narrowSetting });
 
       wrapper.find(Button).last().simulate("click");
       options = wrapper.find("option");
       expect(options.length).to.equal(2);
-      expect(options.map(o => o.text()).includes("Option 1")).to.be.false;
+      expect(options.map((o) => o.text()).includes("Option 1")).to.be.false;
     });
     it("optionally renders a label", () => {
-      let settingWithLabel = {...wrapper.prop("setting"), ...{ menuTitle: "Custom Menu Title" }};
+      const settingWithLabel = {
+        ...wrapper.prop("setting"),
+        ...{ menuTitle: "Custom Menu Title" },
+      };
       wrapper.setProps({ setting: settingWithLabel });
-      let label = wrapper.find("select").closest("label");
+      const label = wrapper.find("select").closest("label");
       expect(label.text()).to.contain("Custom Menu Title");
     });
     it("optionally marks the menu as required", () => {
       let requiredText = wrapper.find(".required-field");
       expect(requiredText.length).to.equal(0);
-      let requiredSetting = {...wrapper.prop("setting"), ...{ menuTitle: "title", required: true }};
+      const requiredSetting = {
+        ...wrapper.prop("setting"),
+        ...{ menuTitle: "title", required: true },
+      };
       wrapper.setProps({ setting: requiredSetting });
       requiredText = wrapper.find(".required-field");
       expect(requiredText.length).to.equal(1);
       expect(requiredText.text()).to.equal("Required");
     });
     it("optionally renders an alternate value if there are no list items", () => {
-      let placeholder = (wrapper.find(".input-list > span"));
+      let placeholder = wrapper.find(".input-list > span");
       expect(placeholder.length).to.equal(0);
       wrapper.setProps({ altValue: "No list items!" });
-      placeholder = (wrapper.find(".input-list > span"));
+      placeholder = wrapper.find(".input-list > span");
       // There are still list items, so the placeholder isn't rendered yet.
       expect(placeholder.length).to.equal(0);
       wrapper.setProps({ value: [] });
-      placeholder = (wrapper.find(".input-list > span"));
+      placeholder = wrapper.find(".input-list > span");
       expect(placeholder.length).to.equal(1);
       expect(placeholder.text()).to.equal("No list items!");
     });
@@ -379,19 +421,25 @@ describe("InputList", () => {
       wrapper.setProps({
         value: ["Option 1", "Option 2", "Option 3"],
         onEmpty: "You've run out of options!",
-        setting: {...wrapper.prop("setting"), ...{ format: "narrow" } }
+        setting: { ...wrapper.prop("setting"), ...{ format: "narrow" } },
       });
       wrapper.update();
-      let menu = wrapper.find("select");
+      const menu = wrapper.find("select");
       expect(menu.length).to.equal(0);
-      let message = wrapper.find(".add-list-item-container span");
+      const message = wrapper.find(".add-list-item-container span");
       expect(message.text()).to.equal("You've run out of options!");
     });
     it("renders option elements if necessary", () => {
       // If the setting does not have a menuOptions property (e.g. because it has come from the server without being modified),
       // InputList will use its options property to generate the dropdown menu with basic default values.
-      let options = [{key: "key_1", label: "label_1"}, {key: "key_2", label: "label_2"}];
-      let setting = {...wrapper.prop("setting"), ...{options: options, menuOptions: null}};
+      const options = [
+        { key: "key_1", label: "label_1" },
+        { key: "key_2", label: "label_2" },
+      ];
+      const setting = {
+        ...wrapper.prop("setting"),
+        ...{ options: options, menuOptions: null },
+      };
       wrapper = mount(
         <InputList
           createEditableInput={createEditableInput}
@@ -399,14 +447,35 @@ describe("InputList", () => {
           value={value}
           setting={setting}
           disabled={false}
-        />
-      , { context });
-      let select = wrapper.find("select");
+        />,
+        { context }
+      );
+      const select = wrapper.find("select");
       expect(select.length).to.equal(1);
       expect(select.find("option").at(0).prop("value")).to.equal("key_1");
       expect(select.find("option").at(0).text()).to.equal("label_1");
       expect(select.find("option").at(1).prop("value")).to.equal("key_2");
       expect(select.find("option").at(1).text()).to.equal("label_2");
+    });
+    it("renders the default values", () => {
+      const setting = {
+        ...wrapper.prop("setting"),
+        ...{ default: ["Option 1", "Option 2"] },
+      };
+      wrapper = mount(
+        <InputList
+          createEditableInput={createEditableInput}
+          labelAndDescription={labelAndDescription}
+          value={null}
+          setting={setting}
+          disabled={false}
+        />,
+        { context }
+      );
+      const defaultItems = wrapper.find(EditableInput);
+      expect(defaultItems.length).to.equal(3);
+      expect(defaultItems.at(0).prop("value")).to.equal("Option 1");
+      expect(defaultItems.at(1).prop("value")).to.equal("Option 2");
     });
   });
 });


### PR DESCRIPTION
Resolves https://jira.nypl.org/browse/SIMPLY-3266

I was getting `eslint` errors about string refs being deprecated, but this is time-sensitive, so I temporarily disabled `eslint` for the relevant file, and will file a separate ticket for updating the refs.

Most of the changes showing up in this PR are just Prettier formatting things.  The actual changes are line 46 of `InputList.tsx` (defining the `listItems` state property as `(props.value as string[]) || (props.setting.default as string[]) || []`), and the new test ("renders the default values") at the end of `InputList-test.tsx`.
