### PR TITLE
Implement new refs API into...some components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changelog
 
+### v0.4.31
+
+#### Updated
+
+- Switched from string refs to the React 16 refs API for as many components as are currently compatible with it
+
 ### v0.4.30
 
 #### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.4.30",
+  "version": "0.4.31",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/components/Autocomplete.tsx
+++ b/src/components/Autocomplete.tsx
@@ -11,6 +11,7 @@ export interface AutocompleteProps {
 }
 
 export default class Autocomplete extends React.Component<AutocompleteProps, {}> {
+  private inputRef = React.createRef<EditableInput>();
   render(): JSX.Element {
     return (
       <div>
@@ -22,7 +23,7 @@ export default class Autocomplete extends React.Component<AutocompleteProps, {}>
           list={this.props.name + "-autocomplete-list"}
           label={this.props.label}
           value={this.props.value}
-          ref="input"
+          ref={this.inputRef}
           optionalText={false}
           onChange={this.props.onChange}
         />
@@ -39,10 +40,10 @@ export default class Autocomplete extends React.Component<AutocompleteProps, {}>
   }
 
   getValue() {
-    return (this.refs["input"] as any).getValue();
+    return this.inputRef.current.getValue();
   }
 
   clear() {
-    (this.refs["input"] as any).setState({ value: "" });
+    this.inputRef.current.setState({ value: "" });
   }
 }

--- a/src/components/BookCoverEditor.tsx
+++ b/src/components/BookCoverEditor.tsx
@@ -42,6 +42,13 @@ export interface BookCoverEditorProps extends BookCoverEditorStateProps, BookCov
 
 /** Tab on the book details page for uploading a new book cover. */
 export class BookCoverEditor extends React.Component<BookCoverEditorProps, {}> {
+  private formContainerRef = React.createRef<HTMLDivElement>();
+  private imageFormRef = React.createRef<Form>();
+  private coverUrlRef = React.createRef<EditableInput>();
+  private coverFileRef = React.createRef<EditableInput>();
+  private titlePositionRef = React.createRef<EditableInput>();
+  private rightsFormRef = React.createRef<Form>();
+  private rightStatusRef = React.createRef<EditableInput>();
   constructor(props) {
     super(props);
     this.refresh = this.refresh.bind(this);
@@ -76,7 +83,7 @@ export class BookCoverEditor extends React.Component<BookCoverEditorProps, {}> {
             alt="Current book cover"
             />
         </div>
-        <div ref="form-container" className="cover-edit-form">
+        <div ref={this.formContainerRef} className="cover-edit-form">
           <h3>Change cover:</h3>
           <Panel
             id="cover-metadata"
@@ -110,13 +117,13 @@ export class BookCoverEditor extends React.Component<BookCoverEditorProps, {}> {
   }
 
   renderCoverForm() {
-    let titlePositionRef = this.refs["title_position"] as any;
+    let titlePositionRef = this.titlePositionRef.current;
     let titlePositionValue = titlePositionRef && titlePositionRef.getValue();
     return (
       <div>
         <p>Cover must be at least 600px x 900px and in PNG, JPG, or GIF format.</p>
         <Form
-          ref="image-form"
+          ref={this.imageFormRef}
           className="edit-form"
           onSubmit={this.preview}
           buttonContent="Preview"
@@ -133,7 +140,7 @@ export class BookCoverEditor extends React.Component<BookCoverEditorProps, {}> {
                 disabled={this.props.isFetching}
                 name="cover_url"
                 label="URL for cover image"
-                ref="cover_url"
+                ref={this.coverUrlRef}
                 optionalText={false}
               />
               <EditableInput
@@ -143,7 +150,7 @@ export class BookCoverEditor extends React.Component<BookCoverEditorProps, {}> {
                 name="cover_file"
                 label="Or upload cover image"
                 accept="image/*"
-                ref="cover_file"
+                ref={this.coverFileRef}
                 optionalText={false}
               />
               <EditableInput
@@ -152,7 +159,7 @@ export class BookCoverEditor extends React.Component<BookCoverEditorProps, {}> {
                 name="title_position"
                 label="Title and Author Position"
                 value="none"
-                ref="title_position"
+                ref={this.titlePositionRef}
               >
                 <option value="none" aria-selected={titlePositionValue === "none"}>None</option>
                 <option value="top" aria-selected={titlePositionValue === "top"}>Top</option>
@@ -184,8 +191,8 @@ export class BookCoverEditor extends React.Component<BookCoverEditorProps, {}> {
   }
 
   preview(data: FormData) {
-    const file = (this.refs["cover_file"] as any).getValue();
-    const url = (this.refs["cover_url"] as any).getValue();
+    const file = this.coverFileRef.current.getValue();
+    const url = this.coverUrlRef.current.getValue();
     if (!file && !url && this.props.clearPreview) {
       this.props.clearPreview();
     }
@@ -197,11 +204,11 @@ export class BookCoverEditor extends React.Component<BookCoverEditorProps, {}> {
   renderRightsForm() {
     const copyrightStatusUri = "http://librarysimplified.org/terms/rights-status/in-copyright";
     const unknownStatusUri = "http://librarysimplified.org/terms/rights-status/unknown";
-    let rightStatusRef = this.refs["rights_status"] as any;
+    let rightStatusRef = this.rightStatusRef.current;
     let rightStatusValue = rightStatusRef && rightStatusRef.getValue();
     return (
       <Form
-        ref="rights-form"
+        ref={this.rightsFormRef}
         onSubmit={this.save}
         className="edit-form"
         withoutButton={true}
@@ -212,7 +219,7 @@ export class BookCoverEditor extends React.Component<BookCoverEditorProps, {}> {
               elementType="select"
               disabled={this.props.isFetching}
               name="rights_status"
-              ref="rights_status"
+              ref={this.rightStatusRef}
               label="License"
             >
               { Object.keys(this.props.rightsStatuses).map(uri => {
@@ -250,13 +257,13 @@ export class BookCoverEditor extends React.Component<BookCoverEditorProps, {}> {
 
     const editUrl = this.props.book && this.props.book.changeCoverLink && this.props.book.changeCoverLink.href;
 
-    const imageForm = (this.refs["image-form"] as HTMLFormElement).formRef.current;
+    const imageForm = this.imageFormRef.current.formRef.current;
     const imageFormData = new (window as any).FormData(imageForm);
     data.append("cover_file", imageFormData.get("cover_file"));
     data.append("cover_url", imageFormData.get("cover_url"));
     data.append("title_position", imageFormData.get("title_position"));
 
-    const rightsForm = (this.refs["rights-form"] as HTMLFormElement).formRef.current;
+    const rightsForm = this.rightsFormRef.current.formRef.current;
     const rightsFormData = new (window as any).FormData(rightsForm);
     data.append("rights_status", rightsFormData.get("rights_status"));
     data.append("rights_explanation", rightsFormData.get("rights_explanation"));

--- a/src/components/ChangePasswordForm.tsx
+++ b/src/components/ChangePasswordForm.tsx
@@ -31,6 +31,8 @@ export interface ChangePasswordState {
 }
 
 export class ChangePasswordForm extends React.Component<ChangePasswordFormProps, ChangePasswordState> {
+  private passwordRef = React.createRef<EditableInput>();
+  private confirmRef = React.createRef<EditableInput>();
   constructor(props) {
     super(props);
     this.state = { success: false, error: null };
@@ -47,7 +49,7 @@ export class ChangePasswordForm extends React.Component<ChangePasswordFormProps,
           disabled={this.props.isFetching}
           name="password"
           label="New Password"
-          ref="password"
+          ref={this.passwordRef}
           required={true}
         />
         <EditableInput
@@ -56,7 +58,7 @@ export class ChangePasswordForm extends React.Component<ChangePasswordFormProps,
           disabled={this.props.isFetching}
           name="confirm_password"
           label="Confirm New Password"
-          ref="confirm"
+          ref={this.confirmRef}
           required={true}
         />
       </fieldset>

--- a/src/components/ClassificationsForm.tsx
+++ b/src/components/ClassificationsForm.tsx
@@ -17,6 +17,13 @@ export interface ClassificationsFormProps {
 /** Form for editing a books classifications on the classifications tab of the
     book detail page. */
 export default class ClassificationsForm extends React.Component<ClassificationsFormProps, any> {
+  private errorMessageRef = React.createRef<Alert>();
+  private audienceRef = React.createRef<EditableInput>();
+  private targetAgeMinRef = React.createRef<EditableInput>();
+  private targetAgeMaxRef = React.createRef<EditableInput>();
+  private noFictionSelectedRef = React.createRef<EditableInput>();
+  private fictionRef = React.createRef<EditableInput>();
+  private nonfictionRef = React.createRef<EditableInput>();
   constructor(props) {
     super(props);
     this.state = {
@@ -48,7 +55,7 @@ export default class ClassificationsForm extends React.Component<Classifications
         <legend className="visuallyHidden">Classifications</legend>
 
         { error &&
-          <Alert bsStyle="danger" ref="errorMessage" tabIndex={-1}>
+          <Alert bsStyle="danger" ref={this.errorMessageRef} tabIndex={-1}>
             { Object.keys(error).map(err => {
               return (<p>{error[err]}</p>);
             })}
@@ -67,7 +74,7 @@ export default class ClassificationsForm extends React.Component<Classifications
                 disabled={this.props.disabled}
                 name="audience"
                 label="Audience"
-                ref="audience"
+                ref={this.audienceRef}
                 value={this.props.book.audience || "None"}
                 onChange={this.handleAudienceChange}
                 clientError={hasAudienceError}
@@ -89,7 +96,7 @@ export default class ClassificationsForm extends React.Component<Classifications
                   <div className="form-inline">
                     <EditableInput
                       elementType="input"
-                      ref="targetAgeMin"
+                      ref={this.targetAgeMinRef}
                       type="text"
                       disabled={this.props.disabled}
                       name="target_age_min"
@@ -99,7 +106,7 @@ export default class ClassificationsForm extends React.Component<Classifications
                     <span>&nbsp;&nbsp;-&nbsp;&nbsp;</span>
                     <EditableInput
                       elementType="input"
-                      ref="targetAgeMax"
+                      ref={this.targetAgeMaxRef}
                       type="text"
                       disabled={this.props.disabled}
                       name="target_age_max"
@@ -119,7 +126,7 @@ export default class ClassificationsForm extends React.Component<Classifications
                       name="fiction"
                       value="none"
                       label="None"
-                      ref="noFictionSelected"
+                      ref={this.noFictionSelectedRef}
                       checked={true}
                       onChange={this.handleFictionChange}
                       clientError={hasFictionError}
@@ -131,7 +138,7 @@ export default class ClassificationsForm extends React.Component<Classifications
                     name="fiction"
                     value="fiction"
                     label="Fiction"
-                    ref="fiction"
+                    ref={this.fictionRef}
                     checked={fiction !== undefined && fiction}
                     onChange={this.handleFictionChange}
                     clientError={hasFictionError}
@@ -142,7 +149,7 @@ export default class ClassificationsForm extends React.Component<Classifications
                     name="fiction"
                     value="nonfiction"
                     label="Nonfiction"
-                    ref="nonfiction"
+                    ref={this.nonfictionRef}
                     checked={fiction !== undefined && !fiction}
                     onChange={this.handleFictionChange}
                     clientError={hasFictionError}
@@ -264,8 +271,7 @@ export default class ClassificationsForm extends React.Component<Classifications
   }
 
   handleAudienceChange() {
-    let value = (this.refs as any).audience.getValue();
-
+    let value = this.audienceRef.current.getValue();
     if (this.validateAudience(value, this.state.genres)) {
       this.setState({ audience: value });
     } else {
@@ -274,7 +280,7 @@ export default class ClassificationsForm extends React.Component<Classifications
   }
 
   handleFictionChange() {
-    let value = (this.refs as any).fiction.getChecked();
+    let value = this.fictionRef.current.getChecked();
     let clearedType = value ? "Nonfiction" : "Fiction";
     let message = "Are you sure? This will clear any " +
                   clearedType +
@@ -316,8 +322,8 @@ export default class ClassificationsForm extends React.Component<Classifications
     if (error["audience"] || error["fiction"]) {
       this.setState({ error });
       setTimeout(() => {
-        if (this.refs["errorMessage"]) {
-          ReactDOM.findDOMNode<HTMLDivElement>(this.refs["errorMessage"]).focus();
+        if (this.errorMessageRef.current) {
+          ReactDOM.findDOMNode<HTMLDivElement>(this.errorMessageRef.current).focus();
         }
       }, 500);
       return;
@@ -325,8 +331,8 @@ export default class ClassificationsForm extends React.Component<Classifications
 
     data.append("audience", audience);
     if (this.shouldShowTargetAge()) {
-      data.append("target_age_min", (this.refs as any).targetAgeMin.getValue());
-      data.append("target_age_max", (this.refs as any).targetAgeMax.getValue());
+      data.append("target_age_min", this.targetAgeMinRef.current.getValue());
+      data.append("target_age_max", this.targetAgeMaxRef.current.getValue());
     }
     data.append("fiction", fiction ? "fiction" : "nonfiction");
     this.state.genres.forEach(genre => data.append("genres", genre));

--- a/src/components/ComplaintForm.tsx
+++ b/src/components/ComplaintForm.tsx
@@ -13,6 +13,7 @@ export interface ComplaintFormProps {
 
 /** Form for adding a new complaint to a book, from the complaints tab of the book detail page. */
 export default class ComplaintForm extends React.Component<ComplaintFormProps, any> {
+  private typeRef = React.createRef<EditableInput>();
   constructor(props) {
     super(props);
     this.state = { errors: [] };
@@ -52,7 +53,7 @@ export default class ComplaintForm extends React.Component<ComplaintFormProps, a
               <legend>Add Complaint</legend>
               <EditableInput
                 elementType="select"
-                ref="type"
+                ref={this.typeRef}
                 name="type"
                 placeholder=""
                 aria-label="Select a complaint type"
@@ -95,6 +96,6 @@ export default class ComplaintForm extends React.Component<ComplaintFormProps, a
   }
 
   clear() {
-    (this.refs["type"] as any).clear();
+    this.typeRef.current.clear();
   }
 }

--- a/src/components/CustomListsForBook.tsx
+++ b/src/components/CustomListsForBook.tsx
@@ -162,7 +162,7 @@ export class CustomListsForBook extends React.Component<CustomListsForBookProps,
     const url = this.listsUrl();
     let data = new (window as any).FormData();
     let lists = [];
-    listNames.map((name) => {
+    (listNames as string[]).map((name) => {
       let list = this.props.allCustomLists.find(x => x.name === name);
       lists.push(list);
     });

--- a/src/components/EditableConfigList.tsx
+++ b/src/components/EditableConfigList.tsx
@@ -81,6 +81,7 @@ export abstract class GenericEditableConfigList<T, U, V extends EditableConfigLi
   AdditionalContent?: new(props: AdditionalContentProps<T, U>) => React.Component<AdditionalContentProps<T, U>, any>;
   ExtraFormSection?: new(props: ExtraFormSectionProps<T, U>) => React.Component<ExtraFormSectionProps<T, U>, any>;
   extraFormKey?: string;
+  private editFormRef = React.createRef<any>();
 
   constructor(props) {
     super(props);
@@ -145,7 +146,7 @@ export abstract class GenericEditableConfigList<T, U, V extends EditableConfigLi
           <div>
             <h3>{headers["h3"]}</h3>
             <EditForm
-              ref="edit-form"
+              ref={this.editFormRef}
               data={this.props.data}
               additionalData={this.props.additionalData}
               disabled={this.props.isFetching}

--- a/src/components/EditableInput.tsx
+++ b/src/components/EditableInput.tsx
@@ -149,11 +149,11 @@ export default class EditableInput extends React.Component<EditableInputProps, E
   }
 
   getValue() {
-    return this.elementRef.current && this.elementRef.current.value;
+    return this.elementRef.current?.value;
   }
 
   getChecked() {
-    return this.elementRef.current && this.elementRef.current.checked;
+    return this.elementRef.current?.checked;
   }
 
   setValue(value) {

--- a/src/components/ErrorMessage.tsx
+++ b/src/components/ErrorMessage.tsx
@@ -12,6 +12,7 @@ export interface ErrorMessageProps {
 /** Shows a bootstrap error message at the top of the page when there's a bad
     response from the server. */
 export default class ErrorMessage extends React.Component<ErrorMessageProps, {}> {
+  private errorMessageRef = React.createRef<HTMLDivElement>();
   render(): JSX.Element {
     let status = this.props.error.status;
     let errorMessageHeader;
@@ -72,15 +73,15 @@ export default class ErrorMessage extends React.Component<ErrorMessageProps, {}>
     }
 
     return (
-      <div tabIndex={0} ref="errorMessage">
+      <div tabIndex={0} ref={this.errorMessageRef}>
         {alertElement}
       </div>
     );
   }
 
   componentDidMount() {
-    if (this.refs["errorMessage"]) {
-      ReactDOM.findDOMNode<HTMLDivElement>(this.refs["errorMessage"]).focus();
+    if (this.errorMessageRef.current) {
+      ReactDOM.findDOMNode<HTMLDivElement>(this.errorMessageRef.current).focus();
     }
   }
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -56,6 +56,7 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
     router: PropTypes.object.isRequired,
     admin: PropTypes.object.isRequired,
   };
+  private libraryRef = React.createRef<EditableInput>();
 
   constructor(props) {
     super(props);
@@ -132,7 +133,7 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
           {this.props.libraries && this.props.libraries.length > 0 && (
             <EditableInput
               elementType="select"
-              ref="library"
+              ref={this.libraryRef}
               value={currentLibrary}
               onChange={this.changeLibrary}
               aria-label="Select a library"
@@ -207,7 +208,7 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
   }
 
   changeLibrary() {
-    let library = (this.refs["library"] as any).getValue();
+    let library = this.libraryRef.current.getValue();
     if (library) {
       this.context.router.push(
         "/admin/web/collection/" + library + "%2Fgroups?max_cache_age=0"

--- a/src/components/IndividualAdminEditForm.tsx
+++ b/src/components/IndividualAdminEditForm.tsx
@@ -36,6 +36,13 @@ export default class IndividualAdminEditForm extends React.Component<IndividualA
     settingUp: PropTypes.bool.isRequired,
     admin: PropTypes.object.isRequired as React.Validator<Admin>
   };
+  private emailRef = React.createRef<EditableInput>();
+  private passwordRef = React.createRef<EditableInput>();
+  private systemRef = React.createRef<EditableInput>();
+  private managerAllRef = React.createRef<EditableInput>();
+  private librarianAllRef = React.createRef<EditableInput>();
+  private libraryManagerRef = React.createRef<EditableInput>();
+  private librarianRef = React.createRef<EditableInput>();
 
   constructor(props) {
     super(props);
@@ -55,7 +62,15 @@ export default class IndividualAdminEditForm extends React.Component<IndividualA
       this.setState({ admin: new Admin(nextProps.item.roles || []) });
     }
     if (nextProps.responseBody && !nextProps.fetchError) {
-      clearForm(this.refs);
+      [
+        this.emailRef,
+        this.passwordRef,
+        this.systemRef,
+        this.managerAllRef,
+        this.librarianAllRef,
+        this.libraryManagerRef,
+        this.librarianRef
+      ].forEach(ref => clearForm(ref));
     }
   }
 
@@ -101,7 +116,7 @@ export default class IndividualAdminEditForm extends React.Component<IndividualA
           readOnly={!!(this.props.item && this.props.item.email)}
           name="email"
           label="Email"
-          ref="email"
+          ref={this.emailRef}
           value={this.props.item && this.props.item.email}
           error={this.props.error}
           />
@@ -112,7 +127,7 @@ export default class IndividualAdminEditForm extends React.Component<IndividualA
             disabled={this.props.disabled}
             name="password"
             label="Password"
-            ref="password"
+            ref={this.passwordRef}
             required={this.context.settingUp}
             error={this.props.error}
             />
@@ -130,7 +145,7 @@ export default class IndividualAdminEditForm extends React.Component<IndividualA
           type="checkbox"
           disabled={this.isDisabled("system")}
           name="system"
-          ref="system"
+          ref={this.systemRef}
           label="System Admin"
           checked={this.isSelected("system")}
           onChange={() => this.handleRoleChange("system")}
@@ -145,7 +160,7 @@ export default class IndividualAdminEditForm extends React.Component<IndividualA
                    type="checkbox"
                    disabled={this.isDisabled("manager-all")}
                    name="manager-all"
-                   ref="manager-all"
+                   ref={this.managerAllRef}
                    label="Library Manager"
                    checked={this.isSelected("manager-all")}
                    onChange={() => this.handleRoleChange("manager-all")}
@@ -157,7 +172,7 @@ export default class IndividualAdminEditForm extends React.Component<IndividualA
                   type="checkbox"
                   disabled={this.isDisabled("librarian-all")}
                   name="librarian-all"
-                  ref="librarian-all"
+                  ref={this.librarianAllRef}
                   label="Librarian"
                   checked={this.isSelected("librarian-all")}
                   onChange={() => this.handleRoleChange("librarian-all")}
@@ -177,7 +192,7 @@ export default class IndividualAdminEditForm extends React.Component<IndividualA
                     type="checkbox"
                     disabled={this.isDisabled("manager", library.short_name)}
                     name={"manager-" + library.short_name}
-                    ref={"manager-" + library.short_name}
+                    ref={this.libraryManagerRef}
                     label=""
                     aria-label={`Library Manager for ${library.short_name}`}
                     checked={this.isSelected("manager", library.short_name)}
@@ -190,7 +205,7 @@ export default class IndividualAdminEditForm extends React.Component<IndividualA
                     type="checkbox"
                     disabled={this.isDisabled("librarian", library.short_name)}
                     name={"librarian-" + library.short_name}
-                    ref={"librarian-" + library.short_name}
+                    ref={this.librarianRef}
                     label=""
                     aria-label={`Librarian for ${library.short_name}`}
                     checked={this.isSelected("librarian", library.short_name)}

--- a/src/components/InputList.tsx
+++ b/src/components/InputList.tsx
@@ -38,6 +38,7 @@ export default class InputList extends React.Component<
   InputListProps,
   InputListState
 > {
+  private addListItemRef = React.createRef<LanguageField>();
   constructor(props: InputListProps) {
     super(props);
     let isMenu = props.setting.type === "menu";
@@ -88,7 +89,7 @@ export default class InputList extends React.Component<
       element = (
         <LanguageField
           disabled={this.props.disabled}
-          ref="addListItem"
+          ref={this.addListItemRef}
           name={setting.key}
           languages={this.props.additionalData}
           onChange={this.updateNewItem}
@@ -101,7 +102,7 @@ export default class InputList extends React.Component<
         value: null,
         disabled: this.props.disabled,
         onChange: this.updateNewItem,
-        ref: "addListItem",
+        ref: this.addListItemRef,
         label: null,
         description: null,
       });
@@ -204,7 +205,7 @@ export default class InputList extends React.Component<
           value: setting.key,
           label: setting.menuTitle,
           required: setting.required,
-          ref: "addListItem",
+          ref: this.addListItemRef,
           optionalText: !setting.required,
           description: !setting.required ? "(Optional) " : "",
         },
@@ -266,9 +267,9 @@ export default class InputList extends React.Component<
   updateNewItem() {
     let ref =
       this.props.setting.format === "language-code"
-        ? (this.refs["addListItem"] as any).refs["autocomplete"]
-        : (this.refs["addListItem"] as any);
-    this.setState({ ...this.state, ...{ newItem: ref.getValue() } });
+        ? this.addListItemRef.current.autocompleteRef.current
+        : this.addListItemRef.current;
+    this.setState({ ...this.state, ...{ newItem: (ref as any).getValue() } });
   }
 
   async removeListItem(listItem: string | {}) {
@@ -287,11 +288,11 @@ export default class InputList extends React.Component<
   async addListItem() {
     let ref =
       this.props.setting.format === "language-code"
-        ? (this.refs["addListItem"] as any).refs["autocomplete"]
-        : (this.refs["addListItem"] as any);
+        ? this.addListItemRef.current.autocompleteRef.current
+        : this.addListItemRef.current;
     const listItem = this.props.setting.capitalize
-      ? this.capitalize(ref.getValue())
-      : ref.getValue();
+      ? this.capitalize((ref as any).getValue())
+      : (ref as any).getValue();
     await this.setState({
       listItems: this.state.listItems.concat(listItem),
       newItem: "",
@@ -302,7 +303,7 @@ export default class InputList extends React.Component<
       await this.props.onSubmit();
     }
     if (this.props.setting.type !== "menu") {
-      ref.clear();
+      (ref as any).clear();
     }
   }
 

--- a/src/components/LaneEditor.tsx
+++ b/src/components/LaneEditor.tsx
@@ -28,6 +28,8 @@ export interface LaneEditorState {
 
 /** Right panel of the lanes page for editing a single lane. */
 export default class LaneEditor extends React.Component<LaneEditorProps, LaneEditorState> {
+  private laneNameRef = React.createRef<TextWithEditMode>();
+  private laneCustomListsRef = React.createRef<LaneCustomListsEditor>();
   constructor(props) {
     super(props);
     this.state = {
@@ -56,7 +58,7 @@ export default class LaneEditor extends React.Component<LaneEditorProps, LaneEdi
                 text={this.props.lane && this.props.lane.display_name}
                 placeholder="name"
                 onUpdate={this.changeName}
-                ref="laneName"
+                ref={this.laneNameRef}
                 aria-label="Enter a name for this lane"
               />
               { this.props.lane &&
@@ -104,7 +106,7 @@ export default class LaneEditor extends React.Component<LaneEditorProps, LaneEdi
             allCustomLists={this.props.customLists}
             customListIds={this.state.customListIds}
             onUpdate={this.changeCustomLists}
-            ref="laneCustomLists"
+            ref={this.laneCustomListsRef}
             />
         </div>
       </div>
@@ -203,9 +205,9 @@ export default class LaneEditor extends React.Component<LaneEditorProps, LaneEdi
     if (parent) {
       data.append("parent_id", parent.id);
     }
-    let name = (this.refs["laneName"] as TextWithEditMode).getText();
+    let name = this.laneNameRef.current.getText();
     data.append("display_name", name);
-    let listIds = (this.refs["laneCustomLists"] as LaneCustomListsEditor).getCustomListIds();
+    let listIds = this.laneCustomListsRef.current.getCustomListIds();
     data.append("custom_list_ids", JSON.stringify(listIds));
     data.append("inherit_parent_restrictions", this.state.inheritParentRestrictions);
     this.props.editLane(data).then(() => {
@@ -217,8 +219,8 @@ export default class LaneEditor extends React.Component<LaneEditorProps, LaneEdi
   }
 
   reset() {
-    (this.refs["laneName"] as TextWithEditMode).reset();
-    (this.refs["laneCustomLists"] as LaneCustomListsEditor).reset(this.props.lane.custom_list_ids);
+    this.laneNameRef.current.reset();
+    this.laneCustomListsRef.current.reset(this.props.lane.custom_list_ids);
     let inheritParentRestrictions = this.props.lane && this.props.lane.inherit_parent_restrictions;
     this.setState(Object.assign({}, this.state, { inheritParentRestrictions }));
   }

--- a/src/components/Lanes.tsx
+++ b/src/components/Lanes.tsx
@@ -56,6 +56,7 @@ export interface LanesState {
 /** Body of the lanes page, with all a library's lanes shown in a left sidebar and
     a lane editor on the right. */
 export class Lanes extends React.Component<LanesProps, LanesState> {
+  private resetRef = React.createRef<EditableInput>();
   static defaultProps = {
     editOrCreate: "create"
   };
@@ -167,7 +168,7 @@ export class Lanes extends React.Component<LanesProps, LanesState> {
   }
 
   checkReset() {
-    let inputValue = this.refs["reset"] && (this.refs["reset"] as EditableInput).getValue();
+    let inputValue = this.resetRef.current && this.resetRef.current.getValue();
     this.setState({...this.state, canReset: (inputValue === "RESET")});
   }
 
@@ -180,7 +181,7 @@ export class Lanes extends React.Component<LanesProps, LanesState> {
           <hr />
           <p>This cannot be undone.</p>
           <p>If you're sure you want to reset the lanes, type "RESET" below and click Reset.</p>
-          <EditableInput type="text" ref="reset" required={true} onChange={this.checkReset}/>
+          <EditableInput type="text" ref={this.resetRef} required={true} onChange={this.checkReset}/>
           <Button
             className="reset-button left-align danger"
             callback={this.resetLanes}

--- a/src/components/LanguageField.tsx
+++ b/src/components/LanguageField.tsx
@@ -12,7 +12,7 @@ export interface LanguageFieldProps {
 }
 
 export default class LanguageField extends React.Component<LanguageFieldProps, {}> {
-
+  autocompleteRef = React.createRef<Autocomplete>();
   render() {
     let value = (this.props.languages && this.props.languages[this.props.value] && this.props.languages[this.props.value][0]) || this.props.value;
     return (
@@ -22,7 +22,7 @@ export default class LanguageField extends React.Component<LanguageFieldProps, {
         name={this.props.name || "language"}
         value={value}
         label={this.props.label}
-        ref="autocomplete"
+        ref={this.autocompleteRef}
         onChange={this.props.onChange}
       />
     );

--- a/src/components/LibraryEditForm.tsx
+++ b/src/components/LibraryEditForm.tsx
@@ -23,6 +23,10 @@ export interface LibraryEditFormProps {
 /** Form for editing a library's configuration, on the libraries tab of the
     system configuration page. */
 export default class LibraryEditForm extends React.Component<LibraryEditFormProps, {}> {
+  private nameRef = React.createRef<EditableInput>();
+  private shortNameRef = React.createRef<EditableInput>();
+  private settingRef = React.createRef<ProtocolFormField>();
+  private announcementsRef = React.createRef<AnnouncementsSection>();
   constructor(props: LibraryEditFormProps) {
     super(props);
     this.submit = this.submit.bind(this);
@@ -30,7 +34,12 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
 
   componentWillReceiveProps(nextProps) {
     if (nextProps.responseBody && !nextProps.fetchError) {
-      clearForm(this.refs);
+      clearForm([
+        this.nameRef.current,
+        this.shortNameRef.current,
+        this.settingRef.current,
+        this.announcementsRef.current
+      ]);
     }
   }
 
@@ -60,7 +69,7 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
             disabled={this.props.disabled}
             required={true}
             name="name"
-            ref="name"
+            ref={this.nameRef}
             label="Name"
             value={this.props.item && this.props.item.name}
             description="The human-readable name of this library."
@@ -72,7 +81,7 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
             disabled={this.props.disabled}
             required={true}
             name="short_name"
-            ref="short_name"
+            ref={this.shortNameRef}
             label="Short name"
             value={this.props.item && this.props.item.short_name}
             description="A short name of this library, to use when identifying it in scripts or URLs, e.g. 'NYPL'."
@@ -81,7 +90,7 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
           { basicInfo.map(setting =>
             <ProtocolFormField
               key={setting.key}
-              ref={setting.key}
+              ref={this.settingRef}
               setting={setting}
               disabled={this.props.disabled}
               value={this.props.item && this.props.item.settings && this.props.item.settings[setting.key]}
@@ -135,7 +144,7 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
       <AnnouncementsSection
             setting={{...setting, ...{format: "date-range"}}}
             value={value && JSON.parse(value)}
-            ref="announcements"
+            ref={this.announcementsRef}
       />
     );
   }
@@ -179,7 +188,7 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
         return (
           <ProtocolFormField
             key={setting.key}
-            ref={setting.key}
+            ref={this.settingRef}
             setting={formatSetting(setting)}
             additionalData={this.props.additionalData}
             disabled={this.props.disabled}
@@ -200,7 +209,7 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
   }
 
   submit(data: FormData) {
-    let announcements = (this.refs["announcements"] as any).getValue();
+    let announcements = this.announcementsRef.current.getValue();
     let announcementList = [];
     announcements.forEach((a: AnnouncementData) => announcementList.push(a));
     data?.set("announcements", JSON.stringify(announcementList));

--- a/src/components/ManagePatronsForm.tsx
+++ b/src/components/ManagePatronsForm.tsx
@@ -30,6 +30,7 @@ export interface ManagePatronsFormProps extends ManagePatronsFormStateProps, Man
 
 
 export class ManagePatronsForm extends React.Component<ManagePatronsFormProps, {}> {
+  private identifierRef = React.createRef<EditableInput>();
   constructor(props) {
     super(props);
     this.submit = this.submit.bind(this);
@@ -52,7 +53,7 @@ export class ManagePatronsForm extends React.Component<ManagePatronsFormProps, {
           content={
             <EditableInput
               elementType="input"
-              ref="identifier"
+              ref={this.identifierRef}
               name="identifier"
               label="Identifier"
               className="form-control"

--- a/src/components/ProtocolFormField.tsx
+++ b/src/components/ProtocolFormField.tsx
@@ -24,6 +24,9 @@ export interface ProtocolFormFieldProps {
 /** Shows a form field for editing a single setting, based on setting information
     from the server. */
 export default class ProtocolFormField extends React.Component<ProtocolFormFieldProps, {}> {
+  private inputListRef = React.createRef<InputList>();
+  private colorPickerRef = React.createRef<ColorPicker>();
+  private elementRef = React.createRef<EditableInput>();
   constructor(props: ProtocolFormFieldProps) {
     super(props);
     this.randomize = this.randomize.bind(this);
@@ -86,7 +89,7 @@ export default class ProtocolFormField extends React.Component<ProtocolFormField
       description: setting.description,
       value: (this.props && this.props.value) || setting.default,
       error: this.props && this.props.error,
-      ref: "element",
+      ref: this.elementRef,
       onChange: this.props.onChange,
     };
     let props = extraProps[setting.type] ? {...basicProps, ...extraProps[setting.type]} : basicProps;
@@ -110,7 +113,7 @@ export default class ProtocolFormField extends React.Component<ProtocolFormField
       (this.props.value && [].concat.apply([], Object.values(this.props.value)));
     return (
       <InputList
-        ref="element"
+        ref={this.inputListRef}
         setting={setting}
         createEditableInput={this.createEditableInput}
         labelAndDescription={setting.label && this.labelAndDescription}
@@ -134,7 +137,7 @@ export default class ProtocolFormField extends React.Component<ProtocolFormField
         <ColorPicker
           value={String(this.props.value || setting.default)}
           setting={setting}
-          ref="element"
+          ref={this.colorPickerRef}
         />
       </div>
     );
@@ -162,21 +165,29 @@ export default class ProtocolFormField extends React.Component<ProtocolFormField
   }
 
   getValue() {
-    return (this.refs["element"] as any).getValue();
+    return this.findRef().getValue();
   }
 
   randomize() {
-    const element = (this.refs["element"] as any);
+    const element = this.findRef();
     const chars = "1234567890abcdefghijklmnopqrstuvwxyz!@#$%^&*()";
     let random = "";
     for (let i = 0; i < 32; i++) {
       random += chars.charAt(Math.floor(Math.random() * chars.length));
     }
-    element.setState({ value: random });
+    element?.setState({ value: random });
+  }
+
+  findRef() {
+    return (
+      this.inputListRef?.current ||
+      this.elementRef?.current ||
+      this.colorPickerRef?.current
+    ) as any;
   }
 
   clear() {
-    const element = (this.refs["element"] as any);
+    const element = this.findRef();
     if (element && element.clear) {
       element.clear();
     }

--- a/src/components/TextWithEditMode.tsx
+++ b/src/components/TextWithEditMode.tsx
@@ -19,6 +19,7 @@ export interface TextWithEditModeState {
 /** Renders text with a link to switch to edit mode and show an editable input instead.
     If the text isn't defined yet, it starts in edit mode. */
 export default class TextWithEditMode extends React.Component<TextWithEditModeProps, TextWithEditModeState> {
+  private textRef = React.createRef<EditableInput>();
   constructor(props) {
     super(props);
     this.state = {
@@ -41,7 +42,7 @@ export default class TextWithEditMode extends React.Component<TextWithEditModePr
               placeholder={this.props.placeholder}
               value={this.state.text}
               optionalText={false}
-              ref="text"
+              ref={this.textRef}
               aria-label={this.props["aria-label"]}
               onChange={(e) => this.setText(e)}
             />
@@ -78,7 +79,7 @@ export default class TextWithEditMode extends React.Component<TextWithEditModePr
   }
 
   updateText() {
-    const text = (this.refs["text"] as EditableInput).getValue();
+    const text = this.textRef.current.getValue();
     this.setState({ text, editMode: false });
     if (this.props.onUpdate) {
       this.props.onUpdate(text);
@@ -91,7 +92,7 @@ export default class TextWithEditMode extends React.Component<TextWithEditModePr
 
   getText() {
     if (this.state.editMode) {
-      let value = (this.refs["text"] as EditableInput).getValue();
+      let value = this.textRef.current.getValue();
       this.updateText();
       return value;
     } else {

--- a/src/utils/sharedFunctions.ts
+++ b/src/utils/sharedFunctions.ts
@@ -15,14 +15,22 @@ export function findDefault(setting) {
 // Blank out the create form on successful submission, so that the user can go
 // ahead and create another new thing.  Used by IndividualAdminEditForm,
 // LibraryEditForm, SitewideSettingEditForm, and ServiceEditForm.
-export function clearForm(refs) {
+export function clearForm(refs, useCurrent = false) {
   if (refs) {
     let keys = Object.keys(refs);
     for (let i = 0; i < keys.length; i++) {
       let key = keys[i];
-      refs[key].clear && refs[key].clear();
-      if (refs[key].props && refs[key].props.onRemove) {
-        refs[key].props.onRemove();
+      if (useCurrent) {
+        refs[key].current?.clear && refs[key].current.clear();
+        if (refs[key].current?.props && refs[key].current.props.onRemove) {
+          refs[key].current.props.onRemove();
+        }
+      }
+      else {
+        refs[key].clear && refs[key].clear();
+        if (refs[key].props && refs[key].props.onRemove) {
+          refs[key].props.onRemove();
+        }
       }
     }
   }


### PR DESCRIPTION
I updated the refs in as many of the components as I could.  Conspicuous exceptions:

1) The CustomLists components.  This is because that work has already been done and merged into the `customlists` branch, so there didn't seem to be a point in doing it twice.

2) `EditableInput`, `ServiceEditForm`, `SitewideSettingEditForm`, `LibraryRegistrationForm`.  I ran into major problems indicating that the refs usage in these components isn't compatible with the new refs API.  I'm not convinced refs are even the best way to get the data in all of the places in which these components use them, though; I think that, in several cases, switching over to props/state would be a much safer and less convoluted approach anyway, particularly given that the alternative seems to entail trying to strong-arm the new refs into doing something that they're not really intended to do.  But that's going to involve considerable investigation and refactoring, so (after MUCH FRUSTRATION), I decided it was out of the scope of this branch and am making a separate ticket for it.