### PR TITLE
Form submission bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changelog
 
+### v0.4.34
+
+#### Fixed
+
+- Fixed bug resulting in blank screen upon form submission
+
 ### v0.4.33
 
 #### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.4.33",
+  "version": "0.4.34",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/utils/sharedFunctions.ts
+++ b/src/utils/sharedFunctions.ts
@@ -33,9 +33,9 @@ export function clearForm(refs, useCurrent = false) {
           refs[key].current.props.onRemove();
         }
       } else {
-        refs[key].clear && refs[key].clear();
+        refs[key]?.clear && refs[key].clear();
         if (refs[key]?.props && refs[key].props.onRemove) {
-          refs[key]?.props.onRemove();
+          refs[key].props.onRemove();
         }
       }
     }

--- a/src/utils/sharedFunctions.ts
+++ b/src/utils/sharedFunctions.ts
@@ -3,13 +3,20 @@
 //  and ServiceEditForm.
 
 export function findDefault(setting) {
-  let defaultOptions = [];
-  setting.options && setting.default && setting.options.map(option => {
-    if (setting.default.indexOf(option.key) >= 0 || setting.default === option.key) {
-      defaultOptions.push(option);
-    }
-  });
-  if (defaultOptions.length > 0) { return defaultOptions; }
+  const defaultOptions = [];
+  setting.options &&
+    setting.default &&
+    setting.options.map((option) => {
+      if (
+        setting.default.indexOf(option.key) >= 0 ||
+        setting.default === option.key
+      ) {
+        defaultOptions.push(option);
+      }
+    });
+  if (defaultOptions.length > 0) {
+    return defaultOptions;
+  }
 }
 
 // Blank out the create form on successful submission, so that the user can go
@@ -17,33 +24,36 @@ export function findDefault(setting) {
 // LibraryEditForm, SitewideSettingEditForm, and ServiceEditForm.
 export function clearForm(refs, useCurrent = false) {
   if (refs) {
-    let keys = Object.keys(refs);
+    const keys = Object.keys(refs);
     for (let i = 0; i < keys.length; i++) {
-      let key = keys[i];
+      const key = keys[i];
       if (useCurrent) {
         refs[key].current?.clear && refs[key].current.clear();
         if (refs[key].current?.props && refs[key].current.props.onRemove) {
           refs[key].current.props.onRemove();
         }
-      }
-      else {
+      } else {
         refs[key].clear && refs[key].clear();
-        if (refs[key].props && refs[key].props.onRemove) {
-          refs[key].props.onRemove();
+        if (refs[key]?.props && refs[key].props.onRemove) {
+          refs[key]?.props.onRemove();
         }
       }
     }
   }
 }
 
-export function formatString(word: string, replacement?: string[], capitalize = true) {
+export function formatString(
+  word: string,
+  replacement?: string[],
+  capitalize = true
+) {
   if (capitalize) {
     word = word.substr(0, 1).toUpperCase() + word.substr(1);
   }
   if (replacement) {
     // If the replacement array contains more than one element, the last element will replace
     // all of the previous ones.  Otherwise, the one element will be replaced with a space.
-    let replaceWith = replacement.length > 1 ? replacement.pop() : " ";
+    const replaceWith = replacement.length > 1 ? replacement.pop() : " ";
     replacement.forEach((char) => {
       word = word.replace(new RegExp(char, "g"), replaceWith);
     });
@@ -53,5 +63,8 @@ export function formatString(word: string, replacement?: string[], capitalize = 
 
 /** Compares two arrays to see whether they contain the same items.  (The order of the items doesn't matter.) */
 export function isEqual(array1: Array<any>, array2: Array<any>): boolean {
-  return array1.length === array2.length && array1.every(x => array2.indexOf(x) >= 0);
+  return (
+    array1.length === array2.length &&
+    array1.every((x) => array2.indexOf(x) >= 0)
+  );
 }


### PR DESCRIPTION
Resolves https://jira.nypl.org/browse/SIMPLY-3507 -- a bug that was resulting in a blank screen (sometimes!) on submission of a create form, with the following error message:
<img width="1173" alt="Screen Shot 2021-02-04 at 4 31 46 PM" src="https://user-images.githubusercontent.com/42178216/108555875-136d0380-72c4-11eb-9ba4-c3b308f2fb05.png">

This fix is admittedly kind of hacky.  But the underlying problem seems to be that there are still a few components that haven't been updated to use the new refs API (because they're going to require some fundamental restructuring, not just a quick refactor, and I haven't had a chance to deal with that yet)...so, once I've done that, it will automatically provide a real fix (once everything is updated, it should all go through the first branch of the `if/else` statement; the lines I've just had to modify wouldn't be reachable anymore)...and I'm moving it up my priority list...but in the meantime, we need there to NOT be a blank screen when an admin submits a create form. 

Prettier has seen fit to mess with a whole bunch of things in this file, so it looks like there are a lot more changes than there actually are.  The real change is just the addition of question marks on lines 36 and 37 (checking that `refs[key]` exists). 