### PR TITLE
Make basic info settings sys-admin-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changelog
 
+### v0.4.35
+
+#### Fixed
+
+- Revoked librarians' and library managers' privileges on the "Basic Information" section of the library edit form.
+
 ### v0.4.34
 
 #### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.4.34",
+  "version": "0.4.35",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/components/LibraryEditForm.tsx
+++ b/src/components/LibraryEditForm.tsx
@@ -61,7 +61,7 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
     }
 
     let categories = this.separateCategories(otherFields);
-    const requiresHigherThanLibrarian = 2;
+    const requiresSystemAdmin = 3;
     let basicInfoPanel = (
       <Panel
         id="library-basic-info"
@@ -82,7 +82,7 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
             value={this.props.item && this.props.item.name}
             description="The human-readable name of this library."
             error={this.props.error}
-            readOnly={this.props.adminLevel < requiresHigherThanLibrarian}
+            readOnly={this.props.adminLevel < requiresSystemAdmin}
           />
           <EditableInput
             elementType="input"
@@ -95,6 +95,7 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
             value={this.props.item && this.props.item.short_name}
             description="A short name of this library, to use when identifying it in scripts or URLs, e.g. 'NYPL'."
             error={this.props.error}
+            readOnly={this.props.adminLevel < requiresSystemAdmin}
           />
           { basicInfo.map(setting =>
             <ProtocolFormField

--- a/src/components/__tests__/LibraryEditForm-test.tsx
+++ b/src/components/__tests__/LibraryEditForm-test.tsx
@@ -12,7 +12,7 @@ import PairedMenus from "../PairedMenus";
 import InputList from "../InputList";
 import AnnouncementsSection from "../AnnouncementsSection";
 
-describe("LibraryEditForm", () => {
+describe.only("LibraryEditForm", () => {
   let wrapper;
   let save;
   let libraryData = {
@@ -201,16 +201,14 @@ describe("LibraryEditForm", () => {
       wrapper.setProps({ adminLevel: 2, data });
       fields = wrapper.find(EditableInput);
       fields.forEach(x => {
-        expect(x.prop("readOnly")).to.equal(x.prop("label") === "Level 3");
+        expect(x.prop("readOnly")).to.equal(["Name", "Short name", "Level 3"].includes(x.prop("label")));
       });
 
       // Librarian
       wrapper.setProps({ adminLevel: 1 });
       fields = wrapper.find(EditableInput);
       fields.forEach(x => {
-        expect(x.prop("readOnly")).to.equal(
-          ["Level 3", "Level 2", "Name"].includes(x.prop("label"))
-        );
+        expect(x.prop("readOnly")).to.equal(["Name", "Short name", "Level 3", "Level 2"].includes(x.prop("label")));
       });
     });
   });

--- a/src/components/__tests__/LibraryEditForm-test.tsx
+++ b/src/components/__tests__/LibraryEditForm-test.tsx
@@ -12,7 +12,7 @@ import PairedMenus from "../PairedMenus";
 import InputList from "../InputList";
 import AnnouncementsSection from "../AnnouncementsSection";
 
-describe.only("LibraryEditForm", () => {
+describe("LibraryEditForm", () => {
   let wrapper;
   let save;
   let libraryData = {


### PR DESCRIPTION
Resolves https://jira.nypl.org/browse/SIMPLY-3556 and https://jira.nypl.org/browse/SIMPLY-3557; it turns out that librarians and library managers weren't supposed to have access to the fields in the "Basic Information" section after all.  

(The "Name" and "Short Name" fields are configured in this branch; the other three fields in this section are taken care of on the back end, in https://github.com/NYPL-Simplified/circulation/pull/1566 and https://github.com/NYPL-Simplified/server_core/pull/1241)