### PR TITLE
Stop footer from floating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changelog
 
+### v0.4.37
+
+#### Fixed
+
+- Fixed CSS bug that caused the footer to sometimes float in the middle of the screen.
+
 ### v0.4.36
 
 #### Fixed

--- a/src/stylesheets/footer.scss
+++ b/src/stylesheets/footer.scss
@@ -6,6 +6,9 @@ footer {
   width: 100%;
   padding: 15px 0;
   z-index: 1;
+  position: absolute;
+  bottom: 0;
+  height: 56px; 
   p {
     margin: 2px 0;
     a, a:visited, a:link {

--- a/src/stylesheets/global.scss
+++ b/src/stylesheets/global.scss
@@ -65,3 +65,17 @@
     }
   }
 }
+
+#opds-catalog > div:first-child {
+  position: relative;
+  min-height: 100vh;
+  block-size: fit-content;
+  &:not(.config) main {
+    padding-bottom: 56px;
+    max-height: 78.5%;
+    block-size: fit-content;
+  }
+  &.config main {
+    block-size: fit-content;
+  }
+}

--- a/src/stylesheets/global.scss
+++ b/src/stylesheets/global.scss
@@ -66,7 +66,8 @@
   }
 }
 
-#opds-catalog > div:first-child {
+// body > div is the outer #opds-catalog div
+body > div > div:first-child {
   position: relative;
   min-height: 100vh;
   block-size: fit-content;

--- a/src/stylesheets/troubleshooting.scss
+++ b/src/stylesheets/troubleshooting.scss
@@ -127,7 +127,7 @@
     display: flex;
     flex-direction: column;
     width: 100%;
-    height: 100%;
+    height: 100vh;
     margin-bottom: 20px;
     > .tab-container {
       position: relative;


### PR DESCRIPTION
Resolves https://jira.nypl.org/browse/SIMPLY-3506

I initially noticed the floating footer problem in the context of the welcome page.
Before:
<img width="1200" alt="Screen Shot 2021-02-04 at 4 30 57 PM" src="https://user-images.githubusercontent.com/42178216/110032360-0d384780-7d06-11eb-9d84-46ce0a15af99.png">
After:
<img width="1194" alt="Screen Shot 2021-03-04 at 4 18 38 PM" src="https://user-images.githubusercontent.com/42178216/110032376-11646500-7d06-11eb-967d-828ea56cccbf.png">

But while I was working on it, I noticed that the footer was sometimes floaty on some of the other pages too, so this ended up being a more general fix.  
