### PR TITLE
Stop hard-coding the name and short name fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changelog
 
+### v0.4.38
+
+#### Fixed
+
+- Stopped hard-coding the "name" and "short name" fields in the library create/edit form.
+
 ### v0.4.37
 
 #### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.4.37",
+  "version": "0.4.38",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/components/LibraryEditForm.tsx
+++ b/src/components/LibraryEditForm.tsx
@@ -62,6 +62,15 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
 
     let categories = this.separateCategories(otherFields);
     const requiresSystemAdmin = 3;
+    let ref = (setting) => {
+      if (setting.key === "name") {
+        return this.nameRef;
+      } else if (setting.key === "short name") {
+        return this.shortNameRef;
+      } else {
+        return this.settingRef;
+      }
+    };
     let basicInfoPanel = (
       <Panel
         id="library-basic-info"
@@ -71,39 +80,13 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
         content={
           <fieldset>
           <legend className="visuallyHidden">Basic Information</legend>
-          <EditableInput
-            elementType="input"
-            type="text"
-            disabled={this.props.disabled}
-            required={true}
-            name="name"
-            ref={this.nameRef}
-            label="Name"
-            value={this.props.item && this.props.item.name}
-            description="The human-readable name of this library."
-            error={this.props.error}
-            readOnly={this.props.adminLevel < requiresSystemAdmin}
-          />
-          <EditableInput
-            elementType="input"
-            type="text"
-            disabled={this.props.disabled}
-            required={true}
-            name="short_name"
-            ref={this.shortNameRef}
-            label="Short name"
-            value={this.props.item && this.props.item.short_name}
-            description="A short name of this library, to use when identifying it in scripts or URLs, e.g. 'NYPL'."
-            error={this.props.error}
-            readOnly={this.props.adminLevel < requiresSystemAdmin}
-          />
           { basicInfo.map(setting =>
             <ProtocolFormField
               key={setting.key}
-              ref={this.settingRef}
+              ref={ref(setting) as any}
               setting={setting}
               disabled={this.props.disabled}
-              value={this.props.item && this.props.item.settings && this.props.item.settings[setting.key]}
+              value={this.props.item && this.props.item[setting.key] || this.props.item?.settings && this.props.item.settings[setting.key]}
               default={findDefault(setting)}
               error={this.props.error}
               readOnly={this.adminNotAuthorized(setting)}

--- a/src/components/__tests__/LibraryEditForm-test.tsx
+++ b/src/components/__tests__/LibraryEditForm-test.tsx
@@ -27,6 +27,8 @@ describe("LibraryEditForm", () => {
     }
   };
   let settingFields = [
+    { key: "name", label: "Name", category: "Basic Information", level: 3 },
+    { key: "short_name", label: "Short Name", category: "Basic Information", level: 3 },
     { key: "privacy-policy", label: "Privacy Policy", category: "Links" },
     { key: "copyright", label: "Copyright", category: "Links" },
     { key: "logo", label: "Logo", category: "Client Interface Customization" },
@@ -104,10 +106,10 @@ describe("LibraryEditForm", () => {
 
     it("renders settings", () => {
       let privacyInput = protocolFormFieldByKey("privacy-policy");
-      expect(privacyInput.props().setting).to.equal(settingFields[0]);
+      expect(privacyInput.props().setting).to.equal(settingFields[2]);
       expect(privacyInput.props().value).not.to.be.ok;
       let copyrightInput = protocolFormFieldByKey("copyright");
-      expect(copyrightInput.props().setting).to.equal(settingFields[1]);
+      expect(copyrightInput.props().setting).to.equal(settingFields[3]);
       expect(copyrightInput.props().value).not.to.be.ok;
 
       wrapper.setProps({ item: libraryData });
@@ -118,10 +120,10 @@ describe("LibraryEditForm", () => {
     });
 
     it("does not render settings with the skip attribute", () => {
-      expect(wrapper.find(ProtocolFormField).length).to.equal(6);
+      expect(wrapper.find(ProtocolFormField).length).to.equal(8);
       let settings = wrapper.prop("data").settings.concat([{ key: "skip", label: "Skip this setting!", skip: true }]);
       wrapper.setProps({ data: {...wrapper.prop("data"), ...{settings}}});
-      expect(wrapper.find(ProtocolFormField).length).to.equal(6);
+      expect(wrapper.find(ProtocolFormField).length).to.equal(8);
       expect(protocolFormFieldByKey("skip").length).to.equal(0);
     });
 
@@ -218,21 +220,23 @@ describe("LibraryEditForm", () => {
 
       // System admin
       fields.forEach(x => {
-        expect(x.prop("readOnly")).to.be.false;
+        if (!["Name", "Short name"].includes(x.prop("label"))) {
+          expect(x.prop("readOnly")).to.be.false;
+        }
       });
 
       // Library manager
       wrapper.setProps({ adminLevel: 2, data });
       fields = wrapper.find(EditableInput);
       fields.forEach(x => {
-        expect(x.prop("readOnly")).to.equal(["Name", "Short name", "Level 3"].includes(x.prop("label")));
+        expect(x.prop("readOnly")).to.equal(["Name", "Short Name", "Level 3"].includes(x.prop("label")));
       });
 
       // Librarian
       wrapper.setProps({ adminLevel: 1 });
       fields = wrapper.find(EditableInput);
       fields.forEach(x => {
-        expect(x.prop("readOnly")).to.equal(["Name", "Short name", "Level 3", "Level 2"].includes(x.prop("label")));
+        expect(x.prop("readOnly")).to.equal(["Name", "Short Name", "Level 3", "Level 2"].includes(x.prop("label")));
       });
     });
   });


### PR DESCRIPTION
Resolves https://jira.nypl.org/browse/SIMPLY-3612; as described in [this spike]( https://github.com/NYPL-Simplified/circulation-web/pull/new/name-settings), it seems better to handle the `name` and `short_name` fields the same way as all the other fields, rather than hard-coding them.  Goes with [this core branch](https://github.com/NYPL-Simplified/server_core/pull/1250).