### PR TITLE
List tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changelog
 
+### v0.4.41
+
+#### Added
+
+- Added a custom Mocha reporter so that a formatted list of suites and tests can be generated via the CLI.
+
 ### v0.4.40
 
 #### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.4.38",
+  "version": "0.4.40",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "simplified-circulation-web",
-      "version": "0.4.38",
+      "version": "0.4.40",
       "license": "Apache-2.0",
       "dependencies": {
         "@nypl/dgx-svg-icons": "0.3.4",
@@ -42,6 +42,7 @@
         "@typescript-eslint/parser": "^3.6.0",
         "chai": "4.2.0",
         "clean-webpack-plugin": "^2.0.1",
+        "colors-cli": "^1.0.27",
         "css-loader": "^2.1.1",
         "enzyme": "^3.9.0",
         "enzyme-adapter-react-16": "^1.12.1",
@@ -2484,6 +2485,15 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "node_modules/colors-cli": {
+      "version": "1.0.27",
+      "resolved": "https://registry.npmjs.org/colors-cli/-/colors-cli-1.0.27.tgz",
+      "integrity": "sha512-oyHDobdhzZDRHzVqOX+0owvXkS6recku25PUutP89BggJ3HikYTBpa7HZOoiAwhKFgHdyfJ+YNJyqxM4kBcEUg==",
+      "dev": true,
+      "bin": {
+        "colors": "bin/colors"
+      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -17103,6 +17113,12 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "colors-cli": {
+      "version": "1.0.27",
+      "resolved": "https://registry.npmjs.org/colors-cli/-/colors-cli-1.0.27.tgz",
+      "integrity": "sha512-oyHDobdhzZDRHzVqOX+0owvXkS6recku25PUutP89BggJ3HikYTBpa7HZOoiAwhKFgHdyfJ+YNJyqxM4kBcEUg==",
       "dev": true
     },
     "combined-stream": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.4.40",
+  "version": "0.4.41",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",
@@ -17,6 +17,7 @@
     "prepublish": "npm run prod",
     "lint": "tslint -c tslint.json src/*.ts src/*.tsx src/**/*.ts src/**/*.tsx src/**/**/*.ts src/**/**/*.tsx && sass-lint -c .sass-lint.yml -v -q",
     "test": "npm run lint && tsc && cp -r src/stylesheets lib && mocha --require lib/testHelper.js lib/__tests__/*.js lib/**/__tests__/*.js lib/**/**/__tests__/*.js",
+    "test-list": "mocha --require lib/testHelper.js lib/__tests__/*.js lib/**/__tests__/*.js lib/**/**/__tests__/*.js --reporter ./testReporter.js",
     "test-file": "npm run lint && tsc && cp -r src/stylesheets lib && mocha --require lib/testHelper.js",
     "test-browser": "npm run test-chrome && npm run test-firefox",
     "test-chrome": "node_modules/.bin/selenium-standalone install && nightwatch -e chrome",
@@ -60,6 +61,7 @@
     "@typescript-eslint/parser": "^3.6.0",
     "chai": "4.2.0",
     "clean-webpack-plugin": "^2.0.1",
+    "colors-cli": "^1.0.27",
     "css-loader": "^2.1.1",
     "enzyme": "^3.9.0",
     "enzyme-adapter-react-16": "^1.12.1",

--- a/testReporter.js
+++ b/testReporter.js
@@ -1,0 +1,28 @@
+var mocha = require('mocha');
+var sinon = require('sinon');
+var color = require('colors-cli/safe');
+module.exports = TestReporter;
+
+function TestReporter(runner) {
+  // This isn't the place for warnings about soon-to-be-deprecated React methods, etc; we just want a clean list.
+  console.warn = sinon.stub();
+  console.error = sinon.stub();
+
+  const {
+    EVENT_SUITE_BEGIN,
+    EVENT_TEST_BEGIN,
+    EVENT_SUITE_END
+  } = mocha.Runner.constants;
+
+  mocha.reporters.Base.call(this, runner);
+
+  runner.on(EVENT_SUITE_BEGIN, function(suite) {
+    console.group(color.x25.bold(suite.title));
+  });
+  runner.on(EVENT_TEST_BEGIN, function(test) {
+    console.log(test.title);
+  });
+  runner.on(EVENT_SUITE_END, function() {
+    console.groupEnd();
+  });
+}


### PR DESCRIPTION
Apparently we need to be able to give QA a list of the testable functionality for the admin interface; the best way to do that seems to be by giving them a list of our current tests.  I made a custom Mocha reporter so that, rather than someone having to put the list together manually, you can just run `npm run test-list` to generate a formatted, up-to-date list of tests, grouped by component, like so: 
<img width="664" alt="Screen Shot 2021-05-04 at 1 25 46 PM" src="https://user-images.githubusercontent.com/42178216/117047230-a1f7fb00-acdf-11eb-81ba-1c750ccbc170.png">
