### PR TITLE
Updates the README, adds a PR template

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,5 @@ deploy:
   keep-history: true
   github_token: $GITHUB_TOKEN
   on:
-    branch: master
+    branch: main
   local_dir: docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 #### (Prerelease) Updated
 
 - Updated the README.
-- Added a Github template.
+- Added a Github pull request template.
 
 ### v0.5.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Changelog
 
+#### (Prerelease) Updated
+
+- Updated the README.
+- Added a Github template.
+
 ### v0.5.1
 
 #### Fixed

--- a/README.md
+++ b/README.md
@@ -1,50 +1,64 @@
 # circulation-web
+
 Web front-end for the Circulation Manager administrative interface.
 
 [![npm version](https://badge.fury.io/js/simplified-circulation-web.svg)](https://badge.fury.io/js/simplified-circulation-web)
 
-[![Build Status](https://travis-ci.org/NYPL-Simplified/circulation-web.svg?branch=master)](https://travis-ci.org/NYPL-Simplified/circulation-web)
+[![Build Status](https://travis-ci.org/NYPL-Simplified/circulation-web.svg?branch=main)](https://travis-ci.org/NYPL-Simplified/circulation-web)
 
 ## Library Simplified Documentation
 
 To see screenshots, read in-depth documentation, and find out more about the project, check out the [Confluence](https://confluence.nypl.org/display/SIM/) site hosted by The New York Public Library.
 
-## Setup
+## Set Up
 
-This package is meant to be used with the Library Simplified [Circulation Manager](https://github.com/NYPL-Simplified/circulation).
+This package is meant to be used with the Library Simplified [Circulation Manager](https://github.com/NYPL-Simplified/circulation), and cannot be run in isolation. Please follow the Circulation Manager README instructions before setting up this repository.
 
-#### Use npm version
+#### Use NPM Version
 
 Suggested local folder setup:
+
 - `/[path to project folder]/circulation`
 
 To use the published version with your circulation manager, run `npm install` from `api/admin` in the `circulation` local installed repository.
 
-#### Use local development version
+#### Use Local Development Version
 
 Suggested local folder setup:
+
 - `/[path to project folder]/circulation`
 - `/[path to project folder]/circulation-web`
 
 If you're working on the administrative interface and want to test local changes, you can link your local clone of this repository to your local circulation manager. These steps will allow you to work on the front-end administrative interface and see updates while developing.
 
 1. Run `npm link` in this `circulation-web` repository,
-2. run `npm link simplified-circulation-web` from `api/admin` in the `circulation` repository,
-2. run the circulation manager using `python app.py` at the root in the `circulation` repository,
-3. run the web interface using `npm run dev` at the root of this `circulation-web` repository,
-4. visit `localhost:6500/admin/`
+2. run `npm link simplified-circulation-web` from `api/admin` in the `circulation` repository (which is where package.json is located),
+3. run the circulation manager using `python app.py` at the root in the `circulation` repository,
+4. run the web interface using `npm run dev` at the root of this `circulation-web` repository,
+5. run the Elasticsearch server using `./bin/elasticsearch` in the elasticsearch-[version] directory,
+6. visit `localhost:6500/admin/`.
 
-Webpack will take care of compiling and updating any new changes made locally for development. Just refresh the page to see updates without having to restart either the `circulation` or `circulation-web` servers.
+Webpack will take care of compiling and updating any new changes made locally for development. Just hard refresh the page (command + shift + R) to see updates without having to restart either the `circulation` or `circulation-web` servers.
 
 ## Web Catalog
 
-The Circulation Manager administrative interface relies on the [OPDS Web Catalog](https://github.com/NYPL-Simplified/opds-web-client) as its base React component and application. For more information, please check out the repository.
+The Circulation Manager administrative interface relies on the [OPDS Web Catalog](https://github.com/NYPL-Simplified/opds-web-client) as its base React component and application. For more information, please check out that repository.
 
-## Publishing
+## Publishing a New Release
 
-This package is [published to npm](https://www.npmjs.com/package/simplified-circulation-web).
+Before publishing a new release, update the version number in package.json and add the new version number + comments about what the new version includes to CHANGELOG.md. For new version numbers, you can refer to [Semantic Versioning](https://semver.org/) (major.minor.patch). Then, run `npm install` to update the package-lock.json file to include the new version.
 
-To publish a new version, you need to create an npm account and be a collaborator on the package. Then you can run `npm publish` from your local copy of the repository.
+Commit your changes, push them to Github, make a PR, and request your reviewer. Once approved, you may go back to your local repository, checkout the main branch, and `git pull`.
+
+This package is [published to npm](https://www.npmjs.com/package/simplified-circulation-web). To publish a new version, you need to create an npm account and be a collaborator on the package.
+
+If you're not already logged in to npm from your terminal, you'll have to do so at this point. Run `npm login` and enter your credentials when prompted.
+
+Then, you can run `npm publish` from your local copy of the repository.
+
+Afterwards, you should tag the release and add comments to Github. On the main branch, run `git tag -a v[version number] -m '[commit message]'`. Then run `git push origin v[version number]`.
+
+Go to the Github repository, click on "tags," find the tag you pushed, click on it and hit "edit." Add a release title, and a description. Then save by clicking, "Update Release."
 
 ## Accessibility
 
@@ -55,6 +69,7 @@ In order to run the app with `react-axe`, run `npm run dev-test-axe`. This will 
 ## Tests
 
 ### Unit Tests
+
 Like the codebase, all the unit tests are written in Typescript. Tests are written for all React components as well as redux and utility functions, and all can be found in their respective `__tests__` folders.
 
 To run the tests, perform `npm test`.
@@ -62,6 +77,7 @@ To run the tests, perform `npm test`.
 We use Travis CI for continuous integration. Any pull requests submitted must have tests and those tests must pass on Travis CI.
 
 ### Nightwatch
+
 There are end-to-end tests that run on Nightwatch. This selenium-based test runner allows us to include integration tests for logging into the admin and clicking through different pages.
 
 To set up credentials and run the tests, check out the [README](/tests/README.md) in `/tests/.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To see screenshots, read in-depth documentation, and find out more about the pro
 
 This package is meant to be used with the Library Simplified [Circulation Manager](https://github.com/NYPL-Simplified/circulation), and cannot be run in isolation. Please follow the Circulation Manager README instructions before setting up this repository.
 
-#### Use NPM Version
+#### Use npm Version
 
 Suggested local folder setup:
 
@@ -54,7 +54,7 @@ This package is [published to npm](https://www.npmjs.com/package/simplified-circ
 
 If you're not already logged in to npm from your terminal, you'll have to do so at this point. Run `npm login` and enter your credentials when prompted.
 
-Then, you can run `npm publish` from your local copy of the repository.
+Then, you can run `npm publish` from your local copy of the repository (ensure you are on the main branch before doing so).
 
 Afterwards, you should tag the release and add comments to Github. On the main branch, run `git tag -a v[version number] -m '[commit message]'`. Then run `git push origin v[version number]`.
 

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,22 @@
+## Description
+
+<!--- Describe your changes -->
+
+## Motivation and Context
+
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open issue, please link to the issue here. -->
+
+## How Has This Been Tested?
+
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to -->
+<!--- see how your change affects other areas of the code, etc. -->
+
+## Checklist:
+
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+
+- [ ] I have updated the documentation accordingly.
+- [ ] All new and existing tests passed.


### PR DESCRIPTION
Updates the README to include more granularity in set up instructions and publishing instructions.
Adds a PR template (same as the one for the circulation repo).
Updates .travis.yml to reference the main branch instead of the master (will be changing the name overall now).