### PR TITLE
Simply 3564/upgrade react methods

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -32,7 +32,14 @@
     "@typescript-eslint/no-explicit-any": 0,
     "no-useless-escape": 0,
     "@typescript-eslint/explicit-function-return-type": 0,
-    "react/prop-types": 0
+    "react/prop-types": 0,
+    "@typescript-eslint/camelcase": 0,
+    "react/no-string-refs": 0,
+    "jsx-a11y/label-has-associated-control": 0,
+    "react/jsx-key": 0,
+    "react/no-find-dom-node": 0,
+    "jsx-a11y/label-has-for": 0,
+    "react/no-unescaped-entities": 0
   },
   "settings": {
     "react": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## Changelog
 
-### v0.5.3
+### 08/06/2021
 
-#### Updated
+#### Updated (to be included in next version)
 
 - Prepended all deprecated React lifecycle methods (componentWillMount and componentWillReceiveProps) with UNSAFE\_.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 ## Changelog
 
+### v0.5.3
+
+#### Updated
+
+- Prepended all deprecated React lifecycle methods (componentWillMount and componentWillReceiveProps) with UNSAFE\_.
+
 ### v0.5.2
+
+#### Updated
 
 - Updated CI from Travis to GitHub Actions.
 - Updated the README.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.5.3",
+  "version": "0.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.5.3",
+  "version": "0.5.2",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/components/AccountPage.tsx
+++ b/src/components/AccountPage.tsx
@@ -20,7 +20,6 @@ export default class AccountPage extends React.Component<{}, {}> {
     csrfToken: PropTypes.string.isRequired,
   };
 
-
   render(): JSX.Element {
     return (
       <div className="account">
@@ -34,7 +33,7 @@ export default class AccountPage extends React.Component<{}, {}> {
     );
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     document.title = "Circulation Manager - Account";
   }
 }

--- a/src/components/AnnouncementForm.tsx
+++ b/src/components/AnnouncementForm.tsx
@@ -97,7 +97,7 @@ export default class AnnouncementForm extends React.Component<
     }
   }
 
-  componentWillReceiveProps(newProps: AnnouncementFormProps) {
+  UNSAFE_componentWillReceiveProps(newProps: AnnouncementFormProps) {
     // Switch from creating a new announcement to editing an existing one.
     if (newProps.content?.length > 0) {
       const { content, start, finish } = newProps;

--- a/src/components/BookCoverEditor.tsx
+++ b/src/components/BookCoverEditor.tsx
@@ -38,7 +38,10 @@ export interface BookCoverEditorOwnProps {
   refreshCatalog: () => Promise<any>;
 }
 
-export interface BookCoverEditorProps extends BookCoverEditorStateProps, BookCoverEditorDispatchProps, BookCoverEditorOwnProps {}
+export interface BookCoverEditorProps
+  extends BookCoverEditorStateProps,
+    BookCoverEditorDispatchProps,
+    BookCoverEditorOwnProps {}
 
 /** Tab on the book details page for uploading a new book cover. */
 export class BookCoverEditor extends React.Component<BookCoverEditorProps, {}> {
@@ -57,7 +60,7 @@ export class BookCoverEditor extends React.Component<BookCoverEditorProps, {}> {
     this.renderCoverForm = this.renderCoverForm.bind(this);
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     if (this.props.clearPreview) {
       this.props.clearPreview();
     }
@@ -67,33 +70,31 @@ export class BookCoverEditor extends React.Component<BookCoverEditorProps, {}> {
   }
 
   render(): JSX.Element {
-    return (this.props.book &&
-      <div>
-        <h2>
-          {this.props.book.title}
-        </h2>
-
-        <UpdatingLoader show={this.props.isFetching} />
-
+    return (
+      this.props.book && (
         <div>
-          <h3>Current cover:</h3>
-          <img
-            src={this.props.book.coverUrl}
-            className="book-cover current-cover"
-            alt="Current book cover"
+          <h2>{this.props.book.title}</h2>
+
+          <UpdatingLoader show={this.props.isFetching} />
+
+          <div>
+            <h3>Current cover:</h3>
+            <img
+              src={this.props.book.coverUrl}
+              className="book-cover current-cover"
+              alt="Current book cover"
             />
-        </div>
-        <div ref={this.formContainerRef} className="cover-edit-form">
-          <h3>Change cover:</h3>
-          <Panel
-            id="cover-metadata"
-            headerText="Cover Metadata"
-            openByDefault={true}
-            content={this.renderCoverForm()}
-            onEnter={this.save}
-          />
-          {
-            this.props.rightsStatuses &&
+          </div>
+          <div ref={this.formContainerRef} className="cover-edit-form">
+            <h3>Change cover:</h3>
+            <Panel
+              id="cover-metadata"
+              headerText="Cover Metadata"
+              openByDefault={true}
+              content={this.renderCoverForm()}
+              onEnter={this.save}
+            />
+            {this.props.rightsStatuses && (
               <Panel
                 id="rights"
                 headerText="Rights"
@@ -101,35 +102,40 @@ export class BookCoverEditor extends React.Component<BookCoverEditorProps, {}> {
                 onEnter={this.save}
                 content={this.renderRightsForm()}
               />
-          }
-          <Button
-            className="left-align"
-            content="Save this cover"
-            disabled={this.props.isFetching || !this.props.preview}
-            callback={this.save}
-          />
+            )}
+            <Button
+              className="left-align"
+              content="Save this cover"
+              disabled={this.props.isFetching || !this.props.preview}
+              callback={this.save}
+            />
+          </div>
+          {this.props.fetchError && (
+            <ErrorMessage error={this.props.fetchError} />
+          )}
         </div>
-        { this.props.fetchError &&
-          <ErrorMessage error={this.props.fetchError} />
-        }
-      </div>
+      )
     );
   }
 
   renderCoverForm() {
-    let titlePositionRef = this.titlePositionRef.current;
-    let titlePositionValue = titlePositionRef && titlePositionRef.getValue();
+    const titlePositionRef = this.titlePositionRef.current;
+    const titlePositionValue = titlePositionRef && titlePositionRef.getValue();
     return (
       <div>
-        <p>Cover must be at least 600px x 900px and in PNG, JPG, or GIF format.</p>
+        <p>
+          Cover must be at least 600px x 900px and in PNG, JPG, or GIF format.
+        </p>
         <Form
           ref={this.imageFormRef}
           className="edit-form"
           onSubmit={this.preview}
           buttonContent="Preview"
           buttonClass="top-align"
-          errorText={ this.props.previewFetchError &&
-            <ErrorMessage error={this.props.previewFetchError} />
+          errorText={
+            this.props.previewFetchError && (
+              <ErrorMessage error={this.props.previewFetchError} />
+            )
           }
           content={
             <fieldset key="cover-image">
@@ -161,27 +167,50 @@ export class BookCoverEditor extends React.Component<BookCoverEditorProps, {}> {
                 value="none"
                 ref={this.titlePositionRef}
               >
-                <option value="none" aria-selected={titlePositionValue === "none"}>None</option>
-                <option value="top" aria-selected={titlePositionValue === "top"}>Top</option>
-                <option value="center" aria-selected={titlePositionValue === "center"}>Center</option>
-                <option value="bottom" aria-selected={titlePositionValue === "bottom"}>Bottom</option>
+                <option
+                  value="none"
+                  aria-selected={titlePositionValue === "none"}
+                >
+                  None
+                </option>
+                <option
+                  value="top"
+                  aria-selected={titlePositionValue === "top"}
+                >
+                  Top
+                </option>
+                <option
+                  value="center"
+                  aria-selected={titlePositionValue === "center"}
+                >
+                  Center
+                </option>
+                <option
+                  value="bottom"
+                  aria-selected={titlePositionValue === "bottom"}
+                >
+                  Bottom
+                </option>
               </EditableInput>
             </fieldset>
           }
         />
 
-        <UpdatingLoader text="Updating Preview" show={this.props.isFetchingPreview} />
+        <UpdatingLoader
+          text="Updating Preview"
+          show={this.props.isFetchingPreview}
+        />
 
-        { this.props.preview &&
+        {this.props.preview && (
           <div>
             <h4>Preview:</h4>
             <img
               src={this.props.preview}
               className="book-cover preview-cover"
               alt="Preview of new cover"
-              />
+            />
           </div>
-        }
+        )}
       </div>
     );
   }
@@ -202,10 +231,12 @@ export class BookCoverEditor extends React.Component<BookCoverEditorProps, {}> {
   }
 
   renderRightsForm() {
-    const copyrightStatusUri = "http://librarysimplified.org/terms/rights-status/in-copyright";
-    const unknownStatusUri = "http://librarysimplified.org/terms/rights-status/unknown";
-    let rightStatusRef = this.rightStatusRef.current;
-    let rightStatusValue = rightStatusRef && rightStatusRef.getValue();
+    const copyrightStatusUri =
+      "http://librarysimplified.org/terms/rights-status/in-copyright";
+    const unknownStatusUri =
+      "http://librarysimplified.org/terms/rights-status/unknown";
+    const rightStatusRef = this.rightStatusRef.current;
+    const rightStatusValue = rightStatusRef && rightStatusRef.getValue();
     return (
       <Form
         ref={this.rightsFormRef}
@@ -222,29 +253,45 @@ export class BookCoverEditor extends React.Component<BookCoverEditorProps, {}> {
               ref={this.rightStatusRef}
               label="License"
             >
-              { Object.keys(this.props.rightsStatuses).map(uri => {
-                let status = this.props.rightsStatuses[uri];
+              {Object.keys(this.props.rightsStatuses).map((uri) => {
+                const status = this.props.rightsStatuses[uri];
                 if (status.allows_derivatives) {
                   return (
-                    <option value={uri} key={uri} aria-selected={rightStatusValue === uri}>{status.name}</option>
+                    <option
+                      value={uri}
+                      key={uri}
+                      aria-selected={rightStatusValue === uri}
+                    >
+                      {status.name}
+                    </option>
                   );
                 }
                 return null;
-              }
-            )}
-              <option value={copyrightStatusUri} aria-selected={rightStatusValue === copyrightStatusUri}>In Copyright</option>
-              <option value={unknownStatusUri} aria-selected={rightStatusValue === unknownStatusUri}>Other</option>
-          </EditableInput>
-          <EditableInput
-            elementType="textarea"
-            disabled={this.props.isFetching}
-            name="rights_explanation"
-            label="Explanation of rights"
-            optionalText={false}
-          />
-        </fieldset>
-      }
-    />);
+              })}
+              <option
+                value={copyrightStatusUri}
+                aria-selected={rightStatusValue === copyrightStatusUri}
+              >
+                In Copyright
+              </option>
+              <option
+                value={unknownStatusUri}
+                aria-selected={rightStatusValue === unknownStatusUri}
+              >
+                Other
+              </option>
+            </EditableInput>
+            <EditableInput
+              elementType="textarea"
+              disabled={this.props.isFetching}
+              name="rights_explanation"
+              label="Explanation of rights"
+              optionalText={false}
+            />
+          </fieldset>
+        }
+      />
+    );
   }
 
   refresh() {
@@ -255,7 +302,10 @@ export class BookCoverEditor extends React.Component<BookCoverEditorProps, {}> {
   save() {
     const data = new (window as any).FormData();
 
-    const editUrl = this.props.book && this.props.book.changeCoverLink && this.props.book.changeCoverLink.href;
+    const editUrl =
+      this.props.book &&
+      this.props.book.changeCoverLink &&
+      this.props.book.changeCoverLink.href;
 
     const imageForm = this.imageFormRef.current.formRef.current;
     const imageFormData = new (window as any).FormData(imageForm);
@@ -279,26 +329,39 @@ function mapStateToProps(state, ownProps) {
     bookAdminUrl: state.editor.book.url,
     preview: state.editor.bookCoverPreview.data,
     rightsStatuses: state.editor.rightsStatuses.data,
-    isFetching: state.editor.book.isFetching || state.editor.bookCover.isFetching || state.editor.rightsStatuses.isFetching || state.editor.bookCover.isEditing,
-    fetchError: state.editor.book.fetchError || state.editor.bookCover.fetchError || state.editor.rightsStatuses.fetchError,
+    isFetching:
+      state.editor.book.isFetching ||
+      state.editor.bookCover.isFetching ||
+      state.editor.rightsStatuses.isFetching ||
+      state.editor.bookCover.isEditing,
+    fetchError:
+      state.editor.book.fetchError ||
+      state.editor.bookCover.fetchError ||
+      state.editor.rightsStatuses.fetchError,
     isFetchingPreview: state.editor.bookCoverPreview.isFetching,
-    previewFetchError: state.editor.bookCoverPreview.fetchError
+    previewFetchError: state.editor.bookCoverPreview.fetchError,
   };
 }
 
 function mapDispatchToProps(dispatch, ownProps) {
-  let fetcher = new DataFetcher({ adapter: editorAdapter });
-  let actions = new ActionCreator(fetcher, ownProps.csrfToken);
+  const fetcher = new DataFetcher({ adapter: editorAdapter });
+  const actions = new ActionCreator(fetcher, ownProps.csrfToken);
   return {
     fetchBook: (url: string) => dispatch(actions.fetchBookAdmin(url)),
-    fetchPreview: (url: string, data: FormData) => dispatch(actions.fetchBookCoverPreview(url, data)),
+    fetchPreview: (url: string, data: FormData) =>
+      dispatch(actions.fetchBookCoverPreview(url, data)),
     clearPreview: () => dispatch(actions.clearBookCoverPreview()),
-    editCover: (url: string, data: FormData) => dispatch(actions.editBookCover(url, data)),
-    fetchRightsStatuses: () => dispatch(actions.fetchRightsStatuses())
+    editCover: (url: string, data: FormData) =>
+      dispatch(actions.editBookCover(url, data)),
+    fetchRightsStatuses: () => dispatch(actions.fetchRightsStatuses()),
   };
 }
 
-const ConnectedBookCoverEditor = connect<BookCoverEditorStateProps, BookCoverEditorDispatchProps, BookCoverEditorOwnProps>(
+const ConnectedBookCoverEditor = connect<
+  BookCoverEditorStateProps,
+  BookCoverEditorDispatchProps,
+  BookCoverEditorOwnProps
+>(
   mapStateToProps,
   mapDispatchToProps
 )(BookCoverEditor);

--- a/src/components/BookDetailsEditor.tsx
+++ b/src/components/BookDetailsEditor.tsx
@@ -38,10 +38,17 @@ export interface BookDetailsEditorOwnProps {
   refreshCatalog?: () => Promise<any>;
 }
 
-export interface BookDetailsEditorProps extends React.Props<BookDetailsEditor>, BookDetailsEditorStateProps, BookDetailsEditorDispatchProps, BookDetailsEditorOwnProps {}
+export interface BookDetailsEditorProps
+  extends React.Props<BookDetailsEditor>,
+    BookDetailsEditorStateProps,
+    BookDetailsEditorDispatchProps,
+    BookDetailsEditorOwnProps {}
 
 /** Tab for editing a book's metadata on the book details page. */
-export class BookDetailsEditor extends React.Component<BookDetailsEditorProps, {}> {
+export class BookDetailsEditor extends React.Component<
+  BookDetailsEditorProps,
+  {}
+> {
   constructor(props) {
     super(props);
     this.editBook = this.editBook.bind(this);
@@ -51,9 +58,9 @@ export class BookDetailsEditor extends React.Component<BookDetailsEditorProps, {
     this.refresh = this.refresh.bind(this);
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     if (this.props.bookUrl) {
-      let bookAdminUrl = this.props.bookUrl.replace("works", "admin/works");
+      const bookAdminUrl = this.props.bookUrl.replace("works", "admin/works");
       this.props.fetchBook(bookAdminUrl);
       this.props.fetchRoles();
       this.props.fetchMedia();
@@ -61,9 +68,9 @@ export class BookDetailsEditor extends React.Component<BookDetailsEditorProps, {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.bookUrl && nextProps.bookUrl !== this.props.bookUrl) {
-      let bookAdminUrl = nextProps.bookUrl.replace("works", "admin/works");
+      const bookAdminUrl = nextProps.bookUrl.replace("works", "admin/works");
       this.props.fetchBook(bookAdminUrl);
     }
   }
@@ -71,46 +78,47 @@ export class BookDetailsEditor extends React.Component<BookDetailsEditorProps, {
   render(): JSX.Element {
     return (
       <div className="book-details-editor">
-        { this.props.bookData && !this.props.fetchError && (<>
-            <h2>
-              {this.props.bookData.title}
-            </h2>
+        {this.props.bookData && !this.props.fetchError && (
+          <>
+            <h2>{this.props.bookData.title}</h2>
 
             <UpdatingLoader show={this.props.isFetching} />
 
-            { this.props.editError &&
+            {this.props.editError && (
               <ErrorMessage error={this.props.editError} />
-            }
+            )}
 
-            { (this.props.bookData.hideLink || this.props.bookData.restoreLink || this.props.bookData.refreshLink) &&
+            {(this.props.bookData.hideLink ||
+              this.props.bookData.restoreLink ||
+              this.props.bookData.refreshLink) && (
               <div className="form-group form-inline">
-                { this.props.bookData.hideLink &&
+                {this.props.bookData.hideLink && (
                   <Button
                     className="left-align"
                     disabled={this.props.isFetching}
                     content="Hide"
                     callback={this.hide}
                   />
-                }
-                { this.props.bookData.restoreLink &&
+                )}
+                {this.props.bookData.restoreLink && (
                   <Button
                     className="left-align"
                     disabled={this.props.isFetching}
                     content="Restore"
                     callback={this.restore}
                   />
-                }
-                { this.props.bookData.refreshLink &&
+                )}
+                {this.props.bookData.refreshLink && (
                   <Button
                     disabled={this.props.isFetching}
                     content="Refresh Metadata"
                     callback={this.refreshMetadata}
                   />
-                }
+                )}
               </div>
-            }
+            )}
 
-            { this.props.bookData.editLink &&
+            {this.props.bookData.editLink && (
               <BookEditForm
                 {...this.props.bookData}
                 roles={this.props.roles}
@@ -118,17 +126,17 @@ export class BookDetailsEditor extends React.Component<BookDetailsEditorProps, {
                 languages={this.props.languages}
                 disabled={this.props.isFetching}
                 editBook={this.props.editBook}
-                refresh={this.refresh} />
-            }
+                refresh={this.refresh}
+              />
+            )}
           </>
         )}
-        { this.props.fetchError &&
+        {this.props.fetchError && (
           <ErrorMessage error={this.props.fetchError} tryAgain={this.refresh} />
-        }
+        )}
       </div>
     );
   }
-
 
   hide() {
     return this.editBook(this.props.bookData.hideLink.href);
@@ -159,25 +167,37 @@ function mapStateToProps(state, ownProps) {
     roles: state.editor.roles.data,
     media: state.editor.media.data,
     languages: state.editor.languages.data,
-    isFetching: state.editor.book.isFetching || state.editor.roles.isFetching || state.editor.media.isFetching || state.editor.languages.isFetching,
-    fetchError: state.editor.book.fetchError || state.editor.roles.fetchError || state.editor.media.fetchError || state.editor.languages.fetchError,
-    editError: state.editor.book.editError
+    isFetching:
+      state.editor.book.isFetching ||
+      state.editor.roles.isFetching ||
+      state.editor.media.isFetching ||
+      state.editor.languages.isFetching,
+    fetchError:
+      state.editor.book.fetchError ||
+      state.editor.roles.fetchError ||
+      state.editor.media.fetchError ||
+      state.editor.languages.fetchError,
+    editError: state.editor.book.editError,
   };
 }
 
 function mapDispatchToProps(dispatch, ownProps) {
-  let fetcher = new DataFetcher({ adapter: editorAdapter });
-  let actions = new ActionCreator(fetcher, ownProps.csrfToken);
+  const fetcher = new DataFetcher({ adapter: editorAdapter });
+  const actions = new ActionCreator(fetcher, ownProps.csrfToken);
   return {
     editBook: (url, data) => dispatch(actions.editBook(url, data)),
     fetchBook: (url: string) => dispatch(actions.fetchBookAdmin(url)),
     fetchRoles: () => dispatch(actions.fetchRoles()),
     fetchMedia: () => dispatch(actions.fetchMedia()),
-    fetchLanguages: () => dispatch(actions.fetchLanguages())
+    fetchLanguages: () => dispatch(actions.fetchLanguages()),
   };
 }
 
-const ConnectedBookDetailsEditor = connect<BookDetailsEditorStateProps, BookDetailsEditorDispatchProps, BookDetailsEditorOwnProps>(
+const ConnectedBookDetailsEditor = connect<
+  BookDetailsEditorStateProps,
+  BookDetailsEditorDispatchProps,
+  BookDetailsEditorOwnProps
+>(
   mapStateToProps,
   mapDispatchToProps
 )(BookDetailsEditor);

--- a/src/components/BookDetailsTabContainer.tsx
+++ b/src/components/BookDetailsTabContainer.tsx
@@ -23,13 +23,14 @@ export interface BookDetailsTabContainerProps extends TabContainerProps {
 
 /** Wraps the book details component from OPDSWebClient with additional tabs
     for editing metadata, classifications, and complaints. */
-export class BookDetailsTabContainer extends TabContainer<BookDetailsTabContainerProps> {
-
+export class BookDetailsTabContainer extends TabContainer<
+  BookDetailsTabContainerProps
+> {
   componentWillUnmount() {
     this.props.clearBook();
   }
 
-  componentWillReceiveProps(newProps) {
+  UNSAFE_componentWillReceiveProps(newProps) {
     if (newProps.bookUrl !== this.props.bookUrl) {
       this.props.clearBook();
     }
@@ -37,14 +38,14 @@ export class BookDetailsTabContainer extends TabContainer<BookDetailsTabContaine
 
   tabs() {
     const tabs = {};
-    tabs["details"] = (<div>{this.props.children}</div>);
+    tabs["details"] = <div>{this.props.children}</div>;
     tabs["edit"] = (
       <BookDetailsEditor
         store={this.props.store}
         csrfToken={this.props.csrfToken}
         bookUrl={this.props.bookUrl}
         refreshCatalog={this.props.refreshCatalog}
-        />
+      />
     );
     tabs["classifications"] = (
       <Classifications
@@ -53,7 +54,7 @@ export class BookDetailsTabContainer extends TabContainer<BookDetailsTabContaine
         bookUrl={this.props.bookUrl}
         book={this.props.bookData}
         refreshCatalog={this.props.refreshCatalog}
-        />
+      />
     );
     if (this.props.bookData && this.props.bookData.changeCoverLink) {
       tabs["cover"] = (
@@ -63,7 +64,7 @@ export class BookDetailsTabContainer extends TabContainer<BookDetailsTabContaine
           bookUrl={this.props.bookUrl}
           book={this.props.bookData}
           refreshCatalog={this.props.refreshCatalog}
-          />
+        />
       );
     }
     tabs["complaints"] = (
@@ -73,7 +74,7 @@ export class BookDetailsTabContainer extends TabContainer<BookDetailsTabContaine
         bookUrl={this.props.bookUrl}
         book={this.props.bookData}
         refreshCatalog={this.props.refreshCatalog}
-        />
+      />
     );
     tabs["lists"] = (
       <CustomListsForBook
@@ -82,16 +83,21 @@ export class BookDetailsTabContainer extends TabContainer<BookDetailsTabContaine
         bookUrl={this.props.bookUrl}
         book={this.props.bookData}
         refreshCatalog={this.props.refreshCatalog}
-        library={this.props.library(this.props.collectionUrl, this.props.bookUrl)}
-        />
+        library={this.props.library(
+          this.props.collectionUrl,
+          this.props.bookUrl
+        )}
+      />
     );
     return tabs;
   }
 
   handleSelect(event) {
-    let tab = event.target.dataset.tabkey;
+    const tab = event.target.dataset.tabkey;
     if (this.context.router) {
-      this.context.router.push(this.context.pathFor(this.props.collectionUrl, this.props.bookUrl, tab));
+      this.context.router.push(
+        this.context.pathFor(this.props.collectionUrl, this.props.bookUrl, tab)
+      );
     }
   }
 
@@ -101,7 +107,10 @@ export class BookDetailsTabContainer extends TabContainer<BookDetailsTabContaine
 
   tabDisplayName(name) {
     let capitalized = name.charAt(0).toUpperCase() + name.slice(1);
-    if (name === "complaints" && typeof this.props.complaintsCount !== "undefined") {
+    if (
+      name === "complaints" &&
+      typeof this.props.complaintsCount !== "undefined"
+    ) {
       capitalized += " (" + this.props.complaintsCount + ")";
     }
     return capitalized;
@@ -112,28 +121,31 @@ function mapStateToProps(state, ownProps) {
   let complaintsCount;
 
   if (state.editor.complaints.data) {
-    complaintsCount = Object.keys(state.editor.complaints.data).reduce((result, type) => {
-      return result + state.editor.complaints.data[type];
-    }, 0);
+    complaintsCount = Object.keys(state.editor.complaints.data).reduce(
+      (result, type) => {
+        return result + state.editor.complaints.data[type];
+      },
+      0
+    );
   } else {
     complaintsCount = undefined;
   }
 
   return {
     complaintsCount: complaintsCount,
-    bookData: state.editor.book.data
+    bookData: state.editor.book.data,
   };
 }
 
 function mapDispatchToProps(dispatch) {
-  let fetcher = new DataFetcher({ adapter: editorAdapter });
-  let actions = new ActionCreator(fetcher);
+  const fetcher = new DataFetcher({ adapter: editorAdapter });
+  const actions = new ActionCreator(fetcher);
   return {
-    clearBook: () => dispatch(actions.clearBook())
+    clearBook: () => dispatch(actions.clearBook()),
   };
 }
 
-let connectOptions = { pure: true };
+const connectOptions = { pure: true };
 const ConnectedBookDetailsTabContainer = connect<any, any, any>(
   mapStateToProps,
   mapDispatchToProps,

--- a/src/components/CirculationEvents.tsx
+++ b/src/components/CirculationEvents.tsx
@@ -28,7 +28,10 @@ export interface CirculationEventsOwnProps {
   library?: string;
 }
 
-export interface CirculationEventsProps extends CirculationEventsStateProps, CirculationEventsDispatchProps, CirculationEventsOwnProps {}
+export interface CirculationEventsProps
+  extends CirculationEventsStateProps,
+    CirculationEventsDispatchProps,
+    CirculationEventsOwnProps {}
 
 export interface CirculationEventsState {
   showDownloadForm: boolean;
@@ -36,7 +39,10 @@ export interface CirculationEventsState {
 
 /** Shows a continuously updating list of the most recent circulation events, and
     a button to download a CSV of circulation events for a particular date. */
-export class CirculationEvents extends React.Component<CirculationEventsProps, CirculationEventsState> {
+export class CirculationEvents extends React.Component<
+  CirculationEventsProps,
+  CirculationEventsState
+> {
   timer: any;
   context: { showCircEventsDownload: boolean };
   _isMounted: boolean;
@@ -51,7 +57,7 @@ export class CirculationEvents extends React.Component<CirculationEventsProps, C
   }
 
   static contextTypes: React.ValidationMap<any> = {
-    showCircEventsDownload: PropTypes.bool
+    showCircEventsDownload: PropTypes.bool,
   };
 
   render(): JSX.Element {
@@ -60,9 +66,13 @@ export class CirculationEvents extends React.Component<CirculationEventsProps, C
       <div className="circulation-events">
         <h2>Circulation Events</h2>
 
-        { this.context.showCircEventsDownload &&
-            <Button callback={this.showDownloadForm} content="Download CSV" className="left-align"/>
-        }
+        {this.context.showCircEventsDownload && (
+          <Button
+            callback={this.showDownloadForm}
+            content="Download CSV"
+            className="left-align"
+          />
+        )}
 
         <CirculationEventsDownloadForm
           show={this.state.showDownloadForm}
@@ -70,45 +80,39 @@ export class CirculationEvents extends React.Component<CirculationEventsProps, C
           library={library}
         />
 
-        { fetchError &&
-          <ErrorMessage error={fetchError} />
-        }
+        {fetchError && <ErrorMessage error={fetchError} />}
 
-        { (!isLoaded && !library) &&
-          <LoadingIndicator />
-        }
+        {!isLoaded && !library && <LoadingIndicator />}
 
-        {
-          !library && (
-              <table className="table table-striped">
-                <thead>
-                  <tr>
-                    <th>Book</th>
-                    <th>Event</th>
-                    <th>Time</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  { events.map(event =>
-                    <tr key={event.id}>
-                      <td>
-                        <CatalogLink bookUrl={event.book.url}>
-                          {event.book.title}
-                        </CatalogLink>
-                      </td>
-                      <td>{this.formatType(event.type)}</td>
-                      <td>{this.formatTime(event.time)}</td>
-                    </tr>
-                  ) }
-                </tbody>
-              </table>
-            )
-        }
+        {!library && (
+          <table className="table table-striped">
+            <thead>
+              <tr>
+                <th>Book</th>
+                <th>Event</th>
+                <th>Time</th>
+              </tr>
+            </thead>
+            <tbody>
+              {events.map((event) => (
+                <tr key={event.id}>
+                  <td>
+                    <CatalogLink bookUrl={event.book.url}>
+                      {event.book.title}
+                    </CatalogLink>
+                  </td>
+                  <td>{this.formatType(event.type)}</td>
+                  <td>{this.formatTime(event.time)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
       </div>
     );
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this._isMounted = true;
     if (!this.props.library) {
       this.fetchAndQueue();
@@ -138,13 +142,13 @@ export class CirculationEvents extends React.Component<CirculationEventsProps, C
   }
 
   formatTime(str) {
-    let date = new Date(str);
-    let options = {
+    const date = new Date(str);
+    const options = {
       weekday: "short",
       month: "short",
       day: "numeric",
       hour: "numeric",
-      minute: "numeric"
+      minute: "numeric",
     };
     return date.toLocaleString("en-US", options);
   }
@@ -162,18 +166,22 @@ function mapStateToProps(state, ownProps) {
   return {
     events: state.editor.circulationEvents.data || [],
     fetchError: state.editor.circulationEvents.fetchError,
-    isLoaded: state.editor.circulationEvents.isLoaded
+    isLoaded: state.editor.circulationEvents.isLoaded,
   };
 }
 
 function mapDispatchToProps(dispatch) {
-  let actions = new ActionCreator();
+  const actions = new ActionCreator();
   return {
-    fetchCirculationEvents: () => dispatch(actions.fetchCirculationEvents())
+    fetchCirculationEvents: () => dispatch(actions.fetchCirculationEvents()),
   };
 }
 
-const ConnectedCirculationEvents = connect<CirculationEventsStateProps, CirculationEventsDispatchProps, CirculationEventsOwnProps>(
+const ConnectedCirculationEvents = connect<
+  CirculationEventsStateProps,
+  CirculationEventsDispatchProps,
+  CirculationEventsOwnProps
+>(
   mapStateToProps,
   mapDispatchToProps
 )(CirculationEvents);

--- a/src/components/Classifications.tsx
+++ b/src/components/Classifications.tsx
@@ -6,7 +6,7 @@ import DataFetcher from "opds-web-client/lib/DataFetcher";
 import ActionCreator from "../actions";
 import ErrorMessage from "./ErrorMessage";
 import ClassificationsForm from "./ClassificationsForm";
-import ClassificationsTable  from "./ClassificationsTable";
+import ClassificationsTable from "./ClassificationsTable";
 import { BookData, GenreTree, ClassificationData } from "../interfaces";
 import { FetchErrorData } from "opds-web-client/lib/interfaces";
 import { State } from "../reducers/index";
@@ -38,7 +38,10 @@ export interface ClassificationsOwnProps {
   refreshCatalog: () => Promise<any>;
 }
 
-export interface ClassificationsProps extends ClassificationsStateProps, ClassificationsDispatchProps, ClassificationsOwnProps {}
+export interface ClassificationsProps
+  extends ClassificationsStateProps,
+    ClassificationsDispatchProps,
+    ClassificationsOwnProps {}
 
 /** Tab on the book details page with a table of a book's current classifications and
     a form for editing them. */
@@ -52,36 +55,37 @@ export class Classifications extends React.Component<ClassificationsProps, {}> {
   render(): JSX.Element {
     return (
       <div className="classifications">
-        { this.props.book &&
+        {this.props.book && (
           <>
-            <h2>
-              {this.props.book.title}
-            </h2>
+            <h2>{this.props.book.title}</h2>
             <UpdatingLoader show={this.props.isFetching} />
           </>
-        }
+        )}
 
-        { this.props.fetchError &&
+        {this.props.fetchError && (
           <ErrorMessage error={this.props.fetchError} />
-        }
+        )}
 
-        { this.props.book && this.props.genreTree &&
+        {this.props.book && this.props.genreTree && (
           <ClassificationsForm
             book={this.props.book}
             genreTree={this.props.genreTree}
             disabled={this.props.isFetching}
             editClassifications={this.editClassifications}
-            />
-        }
+          />
+        )}
 
-        { this.props.classifications && this.props.classifications.length > 0 &&
-          <ClassificationsTable classifications={this.props.classifications} />
-        }
+        {this.props.classifications &&
+          this.props.classifications.length > 0 && (
+            <ClassificationsTable
+              classifications={this.props.classifications}
+            />
+          )}
       </div>
     );
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     if (this.props.bookUrl) {
       this.props.fetchGenreTree("/admin/genres");
       this.props.fetchClassifications(this.classificationsUrl());
@@ -89,11 +93,16 @@ export class Classifications extends React.Component<ClassificationsProps, {}> {
   }
 
   classificationsUrl() {
-    return this.props.bookUrl.replace("works", "admin/works") + "/classifications";
+    return (
+      this.props.bookUrl.replace("works", "admin/works") + "/classifications"
+    );
   }
 
   editClassificationsUrl() {
-    return this.props.bookUrl.replace("works", "admin/works") + "/edit_classifications";
+    return (
+      this.props.bookUrl.replace("works", "admin/works") +
+      "/edit_classifications"
+    );
   }
 
   refresh() {
@@ -103,9 +112,11 @@ export class Classifications extends React.Component<ClassificationsProps, {}> {
   }
 
   editClassifications(data: FormData) {
-    return this.props.editClassifications(this.editClassificationsUrl(), data).then(response => {
-      this.refresh();
-    });
+    return this.props
+      .editClassifications(this.editClassificationsUrl(), data)
+      .then((response) => {
+        this.refresh();
+      });
   }
 }
 
@@ -114,26 +125,33 @@ function mapStateToProps(state, ownProps) {
     bookAdminUrl: state.editor.book.url,
     genreTree: state.editor.classifications.genreTree,
     classifications: state.editor.classifications.classifications,
-    isFetching: state.editor.classifications.isFetchingGenreTree ||
-                state.editor.classifications.isEditingClassifications ||
-                state.editor.classifications.isFetchingClassifications ||
-                state.editor.book.isFetching,
-    fetchError: state.editor.classifications.fetchError
+    isFetching:
+      state.editor.classifications.isFetchingGenreTree ||
+      state.editor.classifications.isEditingClassifications ||
+      state.editor.classifications.isFetchingClassifications ||
+      state.editor.book.isFetching,
+    fetchError: state.editor.classifications.fetchError,
   };
 }
 
 function mapDispatchToProps(dispatch, ownProps) {
-  let fetcher = new DataFetcher({ adapter: editorAdapter });
-  let actions = new ActionCreator(fetcher, ownProps.csrfToken);
+  const fetcher = new DataFetcher({ adapter: editorAdapter });
+  const actions = new ActionCreator(fetcher, ownProps.csrfToken);
   return {
     fetchBook: (url: string) => dispatch(actions.fetchBookAdmin(url)),
     fetchGenreTree: (url: string) => dispatch(actions.fetchGenreTree(url)),
-    fetchClassifications: (url: string) => dispatch(actions.fetchClassifications(url)),
-    editClassifications: (url: string, data: FormData) => dispatch(actions.editClassifications(url, data))
+    fetchClassifications: (url: string) =>
+      dispatch(actions.fetchClassifications(url)),
+    editClassifications: (url: string, data: FormData) =>
+      dispatch(actions.editClassifications(url, data)),
   };
 }
 
-const ConnectedClassifications = connect<ClassificationsStateProps, ClassificationsDispatchProps, ClassificationsOwnProps>(
+const ConnectedClassifications = connect<
+  ClassificationsStateProps,
+  ClassificationsDispatchProps,
+  ClassificationsOwnProps
+>(
   mapStateToProps,
   mapDispatchToProps
 )(Classifications);

--- a/src/components/ClassificationsForm.tsx
+++ b/src/components/ClassificationsForm.tsx
@@ -16,7 +16,10 @@ export interface ClassificationsFormProps {
 
 /** Form for editing a books classifications on the classifications tab of the
     book detail page. */
-export default class ClassificationsForm extends React.Component<ClassificationsFormProps, any> {
+export default class ClassificationsForm extends React.Component<
+  ClassificationsFormProps,
+  any
+> {
   private errorMessageRef = React.createRef<Alert>();
   private audienceRef = React.createRef<EditableInput>();
   private targetAgeMinRef = React.createRef<EditableInput>();
@@ -27,7 +30,8 @@ export default class ClassificationsForm extends React.Component<Classifications
   constructor(props) {
     super(props);
     this.state = {
-      audience: props.book && props.book.audience ? props.book.audience : "None",
+      audience:
+        props.book && props.book.audience ? props.book.audience : "None",
       fiction: props.book ? props.book.fiction : undefined,
       genres: [],
       error: null,
@@ -40,27 +44,24 @@ export default class ClassificationsForm extends React.Component<Classifications
   }
 
   render(): JSX.Element {
-    const {
-      audience,
-      fiction,
-      error,
-      genres
-    } = this.state;
-    let genreOptions = this.genreOptions();
-    const hasAudienceError = (audience === "None") || (error && error["audience"]);
-    const hasFictionError = (fiction === undefined) || (error && error["fiction"]);
+    const { audience, fiction, error, genres } = this.state;
+    const genreOptions = this.genreOptions();
+    const hasAudienceError =
+      audience === "None" || (error && error["audience"]);
+    const hasFictionError =
+      fiction === undefined || (error && error["fiction"]);
 
     return (
       <fieldset className="classifications-form">
         <legend className="visuallyHidden">Classifications</legend>
 
-        { error &&
+        {error && (
           <Alert bsStyle="danger" ref={this.errorMessageRef} tabIndex={-1}>
-            { Object.keys(error).map(err => {
-              return (<p>{error[err]}</p>);
+            {Object.keys(error).map((err) => {
+              return <p>{error[err]}</p>;
             })}
           </Alert>
-        }
+        )}
 
         <Panel
           id="classifications"
@@ -79,18 +80,47 @@ export default class ClassificationsForm extends React.Component<Classifications
                 onChange={this.handleAudienceChange}
                 clientError={hasAudienceError}
               >
-                { (!audience || audience === "None") &&
-                  <option value="None" aria-selected={audience === "None"}>None</option>
-                }
-                <option value="Children" aria-selected={audience === "Children"}>Children</option>
-                <option value="Young Adult" aria-selected={audience === "Young Adult"}>Young Adult</option>
-                <option value="Adult" aria-selected={audience === "Adult"}>Adult</option>
-                <option value="Adults Only" aria-selected={audience === "Adults Only"}>Adults Only</option>
-                <option value="All Ages" aria-selected={audience === "All Ages"}>All Ages</option>
-                <option value="Research" aria-selected={audience === "Research"}>Research</option>
+                {(!audience || audience === "None") && (
+                  <option value="None" aria-selected={audience === "None"}>
+                    None
+                  </option>
+                )}
+                <option
+                  value="Children"
+                  aria-selected={audience === "Children"}
+                >
+                  Children
+                </option>
+                <option
+                  value="Young Adult"
+                  aria-selected={audience === "Young Adult"}
+                >
+                  Young Adult
+                </option>
+                <option value="Adult" aria-selected={audience === "Adult"}>
+                  Adult
+                </option>
+                <option
+                  value="Adults Only"
+                  aria-selected={audience === "Adults Only"}
+                >
+                  Adults Only
+                </option>
+                <option
+                  value="All Ages"
+                  aria-selected={audience === "All Ages"}
+                >
+                  All Ages
+                </option>
+                <option
+                  value="Research"
+                  aria-selected={audience === "Research"}
+                >
+                  Research
+                </option>
               </EditableInput>
 
-              { this.shouldShowTargetAge() &&
+              {this.shouldShowTargetAge() && (
                 <div className="form-group target-age">
                   <p>Target Age Range</p>
                   <div className="form-inline">
@@ -102,7 +132,7 @@ export default class ClassificationsForm extends React.Component<Classifications
                       name="target_age_min"
                       aria-label="Enter a minimum target age"
                       value={this.props.book.targetAgeRange[0]}
-                      />
+                    />
                     <span>&nbsp;&nbsp;-&nbsp;&nbsp;</span>
                     <EditableInput
                       elementType="input"
@@ -112,14 +142,14 @@ export default class ClassificationsForm extends React.Component<Classifications
                       name="target_age_max"
                       aria-label="Enter a maximum target age"
                       value={this.props.book.targetAgeRange[1]}
-                      />
+                    />
                   </div>
                 </div>
-              }
+              )}
               <div className="form-group fiction-radio-input">
                 <p>Fiction Classification</p>
                 <div className="form-inline">
-                  { fiction === undefined &&
+                  {fiction === undefined && (
                     <EditableInput
                       type="radio"
                       disabled={this.props.disabled}
@@ -131,7 +161,7 @@ export default class ClassificationsForm extends React.Component<Classifications
                       onChange={this.handleFictionChange}
                       clientError={hasFictionError}
                     />
-                  }
+                  )}
                   <EditableInput
                     type="radio"
                     disabled={this.props.disabled}
@@ -142,7 +172,7 @@ export default class ClassificationsForm extends React.Component<Classifications
                     checked={fiction !== undefined && fiction}
                     onChange={this.handleFictionChange}
                     clientError={hasFictionError}
-                    />
+                  />
                   <EditableInput
                     type="radio"
                     disabled={this.props.disabled}
@@ -153,20 +183,20 @@ export default class ClassificationsForm extends React.Component<Classifications
                     checked={fiction !== undefined && !fiction}
                     onChange={this.handleFictionChange}
                     clientError={hasFictionError}
-                    />
-                  </div>
+                  />
+                </div>
               </div>
               <div className="form-group genre-group-form">
                 <p>Genres</p>
-                { genres.sort().map(category =>
+                {genres.sort().map((category) => (
                   <WithRemoveButton
                     key={category}
                     disabled={this.props.disabled}
                     onRemove={() => this.removeGenre(category)}
-                    >
+                  >
                     {this.fullGenre(category)}
                   </WithRemoveButton>
-                ) }
+                ))}
 
                 <p className="add-genre-form-title">Add Genre</p>
                 <GenreForm
@@ -174,7 +204,7 @@ export default class ClassificationsForm extends React.Component<Classifications
                   genreOptions={genreOptions}
                   bookGenres={genres}
                   addGenre={this.addGenre}
-                  />
+                />
               </div>
             </div>
           }
@@ -184,15 +214,15 @@ export default class ClassificationsForm extends React.Component<Classifications
     );
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     if (this.props.book) {
       this.setState({ audience: this.props.book.audience || "None" });
-      this.setState({ fiction: this.props.book.fiction  });
+      this.setState({ fiction: this.props.book.fiction });
       this.setState({ genres: this.bookGenres(this.props.book) });
     }
   }
 
-  componentWillReceiveProps(newProps) {
+  UNSAFE_componentWillReceiveProps(newProps) {
     if (this.bookChanged(newProps.book)) {
       this.setState({ audience: newProps.book.audience });
       this.setState({ fiction: newProps.book.fiction });
@@ -201,11 +231,13 @@ export default class ClassificationsForm extends React.Component<Classifications
   }
 
   bookChanged(newBook: BookData): boolean {
-    return newBook.audience !== this.props.book.audience ||
-           newBook.targetAgeRange[0] !== this.props.book.targetAgeRange[0] ||
-           newBook.targetAgeRange[1] !== this.props.book.targetAgeRange[1] ||
-           newBook.fiction !== this.props.book.fiction ||
-           newBook.categories.sort() !== this.props.book.categories.sort();
+    return (
+      newBook.audience !== this.props.book.audience ||
+      newBook.targetAgeRange[0] !== this.props.book.targetAgeRange[0] ||
+      newBook.targetAgeRange[1] !== this.props.book.targetAgeRange[1] ||
+      newBook.fiction !== this.props.book.fiction ||
+      newBook.categories.sort() !== this.props.book.categories.sort()
+    );
   }
 
   bookGenres(book: BookData) {
@@ -213,25 +245,29 @@ export default class ClassificationsForm extends React.Component<Classifications
       return [];
     }
 
-    return book.categories.filter(category => {
-      return !!this.props.genreTree["Fiction"][category] ||
-             !!this.props.genreTree["Nonfiction"][category];
+    return book.categories.filter((category) => {
+      return (
+        !!this.props.genreTree["Fiction"][category] ||
+        !!this.props.genreTree["Nonfiction"][category]
+      );
     });
   }
 
   shouldShowTargetAge() {
-    return this.state.audience === "Children" ||
-           this.state.audience === "Young Adult";
+    return (
+      this.state.audience === "Children" ||
+      this.state.audience === "Young Adult"
+    );
   }
 
-  filterGenres(genres: string[], fiction: boolean = true) {
-    let top = fiction ? "Fiction" : "Nonfiction";
+  filterGenres(genres: string[], fiction = true) {
+    const top = fiction ? "Fiction" : "Nonfiction";
 
     if (!this.props.genreTree[top]) {
       return [];
     }
 
-    return genres.filter(genre => this.props.genreTree[top][genre]);
+    return genres.filter((genre) => this.props.genreTree[top][genre]);
   }
 
   genreOptions() {
@@ -239,19 +275,20 @@ export default class ClassificationsForm extends React.Component<Classifications
       return [];
     }
 
-    let top = this.state.fiction ? "Fiction" : "Nonfiction";
+    const top = this.state.fiction ? "Fiction" : "Nonfiction";
 
     if (!this.props.genreTree[top]) {
       return [];
     }
 
-    return Object.keys(this.props.genreTree[top])
-                 .map(key => this.props.genreTree[top][key]);
+    return Object.keys(this.props.genreTree[top]).map(
+      (key) => this.props.genreTree[top][key]
+    );
   }
 
   fullGenre(category) {
     for (const top of ["Fiction", "Nonfiction"]) {
-      let genre = this.props.genreTree[top][category];
+      const genre = this.props.genreTree[top][category];
       if (genre) {
         return genre.parents.concat([genre.name]).join(" > ");
       }
@@ -271,7 +308,7 @@ export default class ClassificationsForm extends React.Component<Classifications
   }
 
   handleAudienceChange() {
-    let value = this.audienceRef.current.getValue();
+    const value = this.audienceRef.current.getValue();
     if (this.validateAudience(value, this.state.genres)) {
       this.setState({ audience: value });
     } else {
@@ -280,16 +317,17 @@ export default class ClassificationsForm extends React.Component<Classifications
   }
 
   handleFictionChange() {
-    let value = this.fictionRef.current.getChecked();
-    let clearedType = value ? "Nonfiction" : "Fiction";
-    let message = "Are you sure? This will clear any " +
-                  clearedType +
-                  " genres you have chosen!";
+    const value = this.fictionRef.current.getChecked();
+    const clearedType = value ? "Nonfiction" : "Fiction";
+    const message =
+      "Are you sure? This will clear any " +
+      clearedType +
+      " genres you have chosen!";
 
     if (this.state.genres.length === 0 || window.confirm(message)) {
       this.setState({
         fiction: value,
-        genres: this.filterGenres(this.state.genres, value)
+        genres: this.filterGenres(this.state.genres, value),
       });
     }
   }
@@ -302,17 +340,14 @@ export default class ClassificationsForm extends React.Component<Classifications
 
   removeGenre(genreToRemove) {
     this.setState({
-      genres: this.state.genres.filter(genre => genre !== genreToRemove)
+      genres: this.state.genres.filter((genre) => genre !== genreToRemove),
     });
   }
 
   submit() {
-    const {
-      audience,
-      fiction,
-    } = this.state;
-    let data = new (window as any).FormData();
-    let error = {};
+    const { audience, fiction } = this.state;
+    const data = new (window as any).FormData();
+    const error = {};
     if (!audience || audience === "None") {
       error["audience"] = "No Audience classification selected.";
     }
@@ -323,7 +358,9 @@ export default class ClassificationsForm extends React.Component<Classifications
       this.setState({ error });
       setTimeout(() => {
         if (this.errorMessageRef.current) {
-          ReactDOM.findDOMNode<HTMLDivElement>(this.errorMessageRef.current).focus();
+          ReactDOM.findDOMNode<HTMLDivElement>(
+            this.errorMessageRef.current
+          ).focus();
         }
       }, 500);
       return;
@@ -335,7 +372,7 @@ export default class ClassificationsForm extends React.Component<Classifications
       data.append("target_age_max", this.targetAgeMaxRef.current.getValue());
     }
     data.append("fiction", fiction ? "fiction" : "nonfiction");
-    this.state.genres.forEach(genre => data.append("genres", genre));
+    this.state.genres.forEach((genre) => data.append("genres", genre));
     this.setState({ error: null });
     return this.props.editClassifications(data);
   }

--- a/src/components/Collections.tsx
+++ b/src/components/Collections.tsx
@@ -1,24 +1,42 @@
 import * as React from "react";
-import { GenericEditableConfigList, EditableConfigListStateProps, EditableConfigListDispatchProps, EditableConfigListOwnProps } from "./EditableConfigList";
+import {
+  GenericEditableConfigList,
+  EditableConfigListStateProps,
+  EditableConfigListDispatchProps,
+  EditableConfigListOwnProps,
+} from "./EditableConfigList";
 import { connect } from "react-redux";
 import * as PropTypes from "prop-types";
 import ActionCreator from "../actions";
-import { CollectionsData, CollectionData, LibraryData, LibraryRegistrationsData, ServiceData } from "../interfaces";
+import {
+  CollectionsData,
+  CollectionData,
+  LibraryData,
+  LibraryRegistrationsData,
+  ServiceData,
+} from "../interfaces";
 import ServiceWithRegistrationsEditForm from "./ServiceWithRegistrationsEditForm";
 import TrashIcon from "./icons/TrashIcon";
 
-export interface CollectionsStateProps extends EditableConfigListStateProps<CollectionsData> {
+export interface CollectionsStateProps
+  extends EditableConfigListStateProps<CollectionsData> {
   isFetchingLibraryRegistrations?: boolean;
 }
 
-export interface CollectionsDispatchProps extends EditableConfigListDispatchProps<CollectionsData> {
+export interface CollectionsDispatchProps
+  extends EditableConfigListDispatchProps<CollectionsData> {
   registerLibrary: (data: FormData) => Promise<void>;
   fetchLibraryRegistrations?: () => Promise<LibraryRegistrationsData>;
 }
 
-export interface CollectionsProps extends CollectionsStateProps, CollectionsDispatchProps, EditableConfigListOwnProps {}
+export interface CollectionsProps
+  extends CollectionsStateProps,
+    CollectionsDispatchProps,
+    EditableConfigListOwnProps {}
 
-class CollectionEditForm extends ServiceWithRegistrationsEditForm<CollectionsData> {}
+class CollectionEditForm extends ServiceWithRegistrationsEditForm<
+  CollectionsData
+> {}
 
 /**
  * Right panel for collections on the system configuration page.
@@ -30,7 +48,11 @@ class CollectionEditForm extends ServiceWithRegistrationsEditForm<CollectionsDat
  * <Collections />
  * ```
  */
-export class Collections extends GenericEditableConfigList<CollectionsData, CollectionData, CollectionsProps> {
+export class Collections extends GenericEditableConfigList<
+  CollectionsData,
+  CollectionData,
+  CollectionsProps
+> {
   EditForm = CollectionEditForm;
   listDataKey = "collections";
   itemTypeName = "collection";
@@ -56,23 +78,25 @@ export class Collections extends GenericEditableConfigList<CollectionsData, Coll
             }
           });
         }
-      }
+      },
     };
   }
 
-  componentWillMount() {
-    super.componentWillMount();
+  UNSAFE_componentWillMount() {
+    super.UNSAFE_componentWillMount();
     if (this.props.fetchLibraryRegistrations) {
       this.props.fetchLibraryRegistrations();
     }
   }
 
-  renderLinks(): {[key: string]: JSX.Element} {
-    let linkBase = "/admin/web/troubleshooting/self-tests/collections";
-    let linkElement = <a href={linkBase}>the troubleshooting page</a>;
+  renderLinks(): { [key: string]: JSX.Element } {
+    const linkBase = "/admin/web/troubleshooting/self-tests/collections";
+    const linkElement = <a href={linkBase}>the troubleshooting page</a>;
     return {
-      "info": <>Self-tests for the collections have been moved to {linkElement}</>,
-      "footer": <>Problems with your collections?  Please visit {linkElement}.</>
+      info: (
+        <>Self-tests for the collections have been moved to {linkElement}</>
+      ),
+      footer: <>Problems with your collections? Please visit {linkElement}.</>,
     };
   }
 
@@ -82,8 +106,10 @@ export class Collections extends GenericEditableConfigList<CollectionsData, Coll
         <li className="deleted-collection" key={index}>
           <TrashIcon />
           <h4>{this.label(item)}</h4>
-          <p>This collection cannot be edited and is currently being deleted.
-            The deletion process is gradual and this collection will be removed once it is complete.
+          <p>
+            This collection cannot be edited and is currently being deleted. The
+            deletion process is gradual and this collection will be removed once
+            it is complete.
           </p>
         </li>
       );
@@ -92,10 +118,13 @@ export class Collections extends GenericEditableConfigList<CollectionsData, Coll
   }
 
   async delete(item: CollectionData): Promise<void> {
-    const deleteInfo = "This action cannot be undone. Deletion will not happen " +
+    const deleteInfo =
+      "This action cannot be undone. Deletion will not happen " +
       "immediately but gradually. Until the collection is completely deleted, " +
       "it will remain in the list and will be uneditable.";
-    if (window.confirm(`Set "${this.label(item)}" for deletion? ${deleteInfo}`)) {
+    if (
+      window.confirm(`Set "${this.label(item)}" for deletion? ${deleteInfo}`)
+    ) {
       await this.props.deleteItem(item[this.identifierKey]);
       this.props.fetchData();
     }
@@ -103,40 +132,62 @@ export class Collections extends GenericEditableConfigList<CollectionsData, Coll
 }
 
 function mapStateToProps(state, ownProps) {
-  const data = Object.assign({}, state.editor.collections && state.editor.collections.data || {});
+  const data = Object.assign(
+    {},
+    (state.editor.collections && state.editor.collections.data) || {}
+  );
   if (state.editor.libraries && state.editor.libraries.data) {
     data.allLibraries = state.editor.libraries.data.libraries;
   }
-  if (state.editor.collectionLibraryRegistrations && state.editor.collectionLibraryRegistrations.data) {
-    data.libraryRegistrations = state.editor.collectionLibraryRegistrations.data.library_registrations;
+  if (
+    state.editor.collectionLibraryRegistrations &&
+    state.editor.collectionLibraryRegistrations.data
+  ) {
+    data.libraryRegistrations =
+      state.editor.collectionLibraryRegistrations.data.library_registrations;
   }
   // fetchError = an error involving loading the list of collections; formError = an error upon
   // submission of the create/edit form (including upon submitting a change to a library's registration).
   return {
     data: data,
-    responseBody: state.editor.collections && state.editor.collections.successMessage,
+    responseBody:
+      state.editor.collections && state.editor.collections.successMessage,
     fetchError: state.editor.collections.fetchError,
-    formError: state.editor.collections.formError || (state.editor.collectionLibraryRegistrations && state.editor.collectionLibraryRegistrations.fetchError) || (state.editor.registerLibraryWithCollection && state.editor.registerLibraryWithCollection.fetchError),
-    isFetching: state.editor.collections.isFetching || state.editor.collections.isEditing,
-    isFetchingLibraryRegistrations: state.editor.collectionLibraryRegistrations && state.editor.collectionLibraryRegistrations.isFetching
+    formError:
+      state.editor.collections.formError ||
+      (state.editor.collectionLibraryRegistrations &&
+        state.editor.collectionLibraryRegistrations.fetchError) ||
+      (state.editor.registerLibraryWithCollection &&
+        state.editor.registerLibraryWithCollection.fetchError),
+    isFetching:
+      state.editor.collections.isFetching || state.editor.collections.isEditing,
+    isFetchingLibraryRegistrations:
+      state.editor.collectionLibraryRegistrations &&
+      state.editor.collectionLibraryRegistrations.isFetching,
   };
 }
 
-
 function mapDispatchToProps(dispatch, ownProps) {
-  let actions = new ActionCreator(null, ownProps.csrfToken);
+  const actions = new ActionCreator(null, ownProps.csrfToken);
   return {
     fetchData: () => dispatch(actions.fetchCollections()),
     editItem: (data: FormData) => dispatch(actions.editCollection(data)),
-    deleteItem: (identifier: string | number) => dispatch(actions.deleteCollection(identifier)),
-    registerLibrary: (data: FormData) => dispatch(actions.registerLibraryWithCollection(data)),
-    fetchLibraryRegistrations: () => dispatch(actions.fetchCollectionLibraryRegistrations())
+    deleteItem: (identifier: string | number) =>
+      dispatch(actions.deleteCollection(identifier)),
+    registerLibrary: (data: FormData) =>
+      dispatch(actions.registerLibraryWithCollection(data)),
+    fetchLibraryRegistrations: () =>
+      dispatch(actions.fetchCollectionLibraryRegistrations()),
   };
 }
 
-const ConnectedCollections = connect<EditableConfigListStateProps<CollectionsData>, EditableConfigListDispatchProps<CollectionsData>, EditableConfigListOwnProps>(
+const ConnectedCollections = connect<
+  EditableConfigListStateProps<CollectionsData>,
+  EditableConfigListDispatchProps<CollectionsData>,
+  EditableConfigListOwnProps
+>(
   mapStateToProps,
-  mapDispatchToProps,
+  mapDispatchToProps
 )(Collections);
 
 export default ConnectedCollections;

--- a/src/components/Complaints.tsx
+++ b/src/components/Complaints.tsx
@@ -32,7 +32,10 @@ export interface ComplaintsOwnProps {
   refreshCatalog: () => Promise<any>;
 }
 
-export interface ComplaintsProps extends ComplaintsStateProps, ComplaintsDispatchProps, ComplaintsOwnProps {}
+export interface ComplaintsProps
+  extends ComplaintsStateProps,
+    ComplaintsDispatchProps,
+    ComplaintsOwnProps {}
 
 /** Tab on the book details page that shows existing complaints and lets an admin resolve
     complaints or add new complaints. */
@@ -46,21 +49,20 @@ export class Complaints extends React.Component<ComplaintsProps, {}> {
   render(): JSX.Element {
     return (
       <div className="complaints">
-        { this.props.book &&
+        {this.props.book && (
           <div>
-            <h2>
-              {this.props.book.title}
-            </h2>
+            <h2>{this.props.book.title}</h2>
             <UpdatingLoader show={this.props.isFetching} />
           </div>
-        }
+        )}
 
-        { this.props.fetchError &&
+        {this.props.fetchError && (
           <ErrorMessage error={this.props.fetchError} tryAgain={this.refresh} />
-        }
+        )}
 
         <h3>Complaints</h3>
-        { this.props.complaints && Object.keys(this.props.complaints).length > 0 ?
+        {this.props.complaints &&
+        Object.keys(this.props.complaints).length > 0 ? (
           <table className="table">
             <thead>
               <tr>
@@ -70,10 +72,14 @@ export class Complaints extends React.Component<ComplaintsProps, {}> {
               </tr>
             </thead>
             <tbody>
-              { Object.keys(this.props.complaints).map(type =>
+              {Object.keys(this.props.complaints).map((type) => (
                 <tr key={type} className="complaint">
-                  <td className="complaint-type">{this.readableComplaintType(type)}</td>
-                  <td className="complaint-count">{this.props.complaints[type]}</td>
+                  <td className="complaint-type">
+                    {this.readableComplaintType(type)}
+                  </td>
+                  <td className="complaint-count">
+                    {this.props.complaints[type]}
+                  </td>
                   <td className="complaint-resolve">
                     <Button
                       className="btn-sm top-align"
@@ -83,26 +89,30 @@ export class Complaints extends React.Component<ComplaintsProps, {}> {
                     />
                   </td>
                 </tr>
-              ) }
+              ))}
             </tbody>
-          </table> :
-          <div><strong>None found.</strong></div>
-        }
+          </table>
+        ) : (
+          <div>
+            <strong>None found.</strong>
+          </div>
+        )}
 
         <br />
 
-        { this.props.book && this.props.book.issuesLink &&
+        {this.props.book && this.props.book.issuesLink && (
           <ComplaintForm
             disabled={this.props.isFetching}
             complaintUrl={this.props.book.issuesLink.href}
             postComplaint={this.props.postComplaint}
-            refreshComplaints={this.refresh} />
-        }
+            refreshComplaints={this.refresh}
+          />
+        )}
       </div>
     );
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     if (this.props.bookUrl) {
       this.props.fetchComplaints(this.complaintsUrl());
     }
@@ -113,11 +123,13 @@ export class Complaints extends React.Component<ComplaintsProps, {}> {
   }
 
   resolveComplaintsUrl() {
-    return this.props.bookUrl.replace("works", "admin/works") + "/resolve_complaints";
+    return (
+      this.props.bookUrl.replace("works", "admin/works") + "/resolve_complaints"
+    );
   }
 
   readableComplaintType(type: string) {
-    let match = type.match(/\/terms\/problem\/(.+)$/);
+    const match = type.match(/\/terms\/problem\/(.+)$/);
     if (match) {
       return formatString(match[1], ["-"]);
     } else {
@@ -131,10 +143,12 @@ export class Complaints extends React.Component<ComplaintsProps, {}> {
   }
 
   resolve(type: string) {
-    let readableType = this.readableComplaintType(type);
-    if (window.confirm(`Resolve all "${readableType}" complaints for this book?`)) {
-      let url = this.resolveComplaintsUrl();
-      let data = new (window as any).FormData();
+    const readableType = this.readableComplaintType(type);
+    if (
+      window.confirm(`Resolve all "${readableType}" complaints for this book?`)
+    ) {
+      const url = this.resolveComplaintsUrl();
+      const data = new (window as any).FormData();
       data.append("type", type);
       return this.props.resolveComplaints(url, data).then(this.refresh);
     }
@@ -145,21 +159,26 @@ function mapStateToProps(state, ownProps) {
   return {
     complaints: state.editor.complaints.data,
     isFetching: state.editor.complaints.isFetching,
-    fetchError: state.editor.complaints.fetchError
+    fetchError: state.editor.complaints.fetchError,
   };
 }
 
 function mapDispatchToProps(dispatch, ownProps) {
-  let fetcher = new DataFetcher();
-  let actions = new ActionCreator(fetcher, ownProps.csrfToken);
+  const fetcher = new DataFetcher();
+  const actions = new ActionCreator(fetcher, ownProps.csrfToken);
   return {
     fetchComplaints: (url) => dispatch(actions.fetchComplaints(url)),
     postComplaint: (url, data) => dispatch(actions.postComplaint(url, data)),
-    resolveComplaints: (url, data) => dispatch(actions.resolveComplaints(url, data))
+    resolveComplaints: (url, data) =>
+      dispatch(actions.resolveComplaints(url, data)),
   };
 }
 
-const ConnectedComplaints = connect<ComplaintsStateProps, ComplaintsDispatchProps, ComplaintsOwnProps>(
+const ConnectedComplaints = connect<
+  ComplaintsStateProps,
+  ComplaintsDispatchProps,
+  ComplaintsOwnProps
+>(
   mapStateToProps,
   mapDispatchToProps
 )(Complaints);

--- a/src/components/ConfigPage.tsx
+++ b/src/components/ConfigPage.tsx
@@ -26,7 +26,7 @@ export default class ConfigPage extends React.Component<ConfigPageProps, {}> {
 
   static contextTypes: React.ValidationMap<ConfigPageContext> = {
     editorStore: PropTypes.object.isRequired as React.Validator<Store>,
-    csrfToken: PropTypes.string.isRequired
+    csrfToken: PropTypes.string.isRequired,
   };
 
   render(): JSX.Element {
@@ -48,7 +48,7 @@ export default class ConfigPage extends React.Component<ConfigPageProps, {}> {
     );
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     document.title = "Circulation Manager - Configuration";
   }
 }

--- a/src/components/CustomListEditor.tsx
+++ b/src/components/CustomListEditor.tsx
@@ -1,5 +1,9 @@
 import * as React from "react";
-import { LanguagesData, LibraryData, CollectionData as AdminCollectionData } from "../interfaces";
+import {
+  LanguagesData,
+  LibraryData,
+  CollectionData as AdminCollectionData,
+} from "../interfaces";
 import { CollectionData, BookData } from "opds-web-client/lib/interfaces";
 import TextWithEditMode from "./TextWithEditMode";
 import EditableInput from "./EditableInput";
@@ -37,7 +41,10 @@ export interface CustomListEditorState {
 }
 
 /** Right panel of the lists page for editing a single list. */
-export default class CustomListEditor extends React.Component<CustomListEditorProps, CustomListEditorState> {
+export default class CustomListEditor extends React.Component<
+  CustomListEditorProps,
+  CustomListEditorState
+> {
   static listener;
   constructor(props) {
     super(props);
@@ -45,7 +52,7 @@ export default class CustomListEditor extends React.Component<CustomListEditorPr
       title: this.props.list && this.props.list.title,
       entries: (this.props.list && this.props.list.books) || [],
       collections: this.props.listCollections || [],
-      entryPointSelected: "all"
+      entryPointSelected: "all",
     };
 
     this.changeTitle = this.changeTitle.bind(this);
@@ -59,14 +66,15 @@ export default class CustomListEditor extends React.Component<CustomListEditorPr
 
   render(): JSX.Element {
     const listId = this.props.listId;
-    const listTitle = this.props.list && this.props.list.title ? this.props.list.title : "";
+    const listTitle =
+      this.props.list && this.props.list.title ? this.props.list.title : "";
     const nextPageUrl = this.props.list && this.props.list.nextPageUrl;
     const crawlable = `${listTitle ? `lists/${listTitle}/` : ""}crawlable`;
     const opdsFeedUrl = `${this.props.library?.short_name}/${crawlable}`;
     const hasChanges = this.hasChanges();
     // The "save this list" button should be disabled if there are no changes
     // or if the list's title is empty.
-    let disableSave = this.isTitleEmpty() || !hasChanges;
+    const disableSave = this.isTitleEmpty() || !hasChanges;
     return (
       <div className="custom-list-editor">
         <div className="custom-list-editor-header">
@@ -82,9 +90,7 @@ export default class CustomListEditor extends React.Component<CustomListEditorPr
                 disableIfBlank={true}
               />
             </fieldset>
-            { listId &&
-              <h4>ID-{listId}</h4>
-            }
+            {listId && <h4>ID-{listId}</h4>}
           </div>
           <div className="save-or-cancel-list">
             <Button
@@ -92,42 +98,46 @@ export default class CustomListEditor extends React.Component<CustomListEditorPr
               disabled={disableSave}
               content="Save this list"
             />
-            { hasChanges &&
+            {hasChanges && (
               <Button
                 className="inverted"
                 callback={this.reset}
                 content="Cancel Changes"
               />
-            }
+            )}
           </div>
         </div>
         <div className="custom-list-editor-body">
           <section>
-            { this.props.collections && this.props.collections.length > 0 &&
+            {this.props.collections && this.props.collections.length > 0 && (
               <div className="custom-list-filters">
                 <Panel
                   headerText="Add from collections"
                   id="add-from-collections"
                   content={
                     <div className="collections">
-                      <div>Automatically add new books from these collections to this list:</div>
-                      { this.props.collections.map(collection =>
-                          <EditableInput
-                            key={collection.id}
-                            type="checkbox"
-                            name="collection"
-                            checked={this.hasCollection(collection)}
-                            label={collection.name}
-                            value={String(collection.id)}
-                            onChange={() => { this.changeCollection(collection); }}
-                            />
-                        )
-                      }
+                      <div>
+                        Automatically add new books from these collections to
+                        this list:
+                      </div>
+                      {this.props.collections.map((collection) => (
+                        <EditableInput
+                          key={collection.id}
+                          type="checkbox"
+                          name="collection"
+                          checked={this.hasCollection(collection)}
+                          label={collection.name}
+                          value={String(collection.id)}
+                          onChange={() => {
+                            this.changeCollection(collection);
+                          }}
+                        />
+                      ))}
                     </div>
                   }
                 />
               </div>
-            }
+            )}
             <CustomListSearch
               search={this.search}
               entryPoints={this.props.entryPoints}
@@ -145,7 +155,9 @@ export default class CustomListEditor extends React.Component<CustomListEditorPr
             loadMoreEntries={this.props.loadMoreEntries}
             onUpdate={this.changeEntries}
             isFetchingMoreSearchResults={this.props.isFetchingMoreSearchResults}
-            isFetchingMoreCustomListEntries={this.props.isFetchingMoreCustomListEntries}
+            isFetchingMoreCustomListEntries={
+              this.props.isFetchingMoreCustomListEntries
+            }
             ref="listEntries"
             opdsFeedUrl={opdsFeedUrl}
             entryCount={this.props.entryCount}
@@ -157,7 +169,7 @@ export default class CustomListEditor extends React.Component<CustomListEditorPr
   }
 
   componentDidMount() {
-    CustomListEditor.listener = browserHistory.listen( location =>  {
+    CustomListEditor.listener = browserHistory.listen((location) => {
       this.setState({ title: "", entries: [], collections: [] });
     });
   }
@@ -165,36 +177,48 @@ export default class CustomListEditor extends React.Component<CustomListEditorPr
     CustomListEditor.listener();
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     // Note: This gets called after performing a search, at which point the
     // state of the component can already have updates that need to be taken
     // into account.
     if (!nextProps.list && !this.props.list) {
       // This is no current or previous list, so this is a new list.
-      this.setState({ title: "", entries: [], collections: []});
-    } else if (nextProps.list && (nextProps.listId !== this.props.listId)) {
+      this.setState({ title: "", entries: [], collections: [] });
+    } else if (nextProps.list && nextProps.listId !== this.props.listId) {
       // Update the state with the next list to edit.
       this.setState({
         title: nextProps.list && nextProps.list.title,
         entries: (nextProps.list && nextProps.list.books) || [],
-        collections: (nextProps.list && nextProps.listCollections) || []
+        collections: (nextProps.list && nextProps.listCollections) || [],
       });
-    } else if (nextProps.list && nextProps.list.books && nextProps.list.books.length !== this.state.entries.length) {
+    } else if (
+      nextProps.list &&
+      nextProps.list.books &&
+      nextProps.list.books.length !== this.state.entries.length
+    ) {
       let collections = this.state.collections;
-      if ((!this.props.list || !this.props.listCollections) && nextProps.list && nextProps.listCollections) {
+      if (
+        (!this.props.list || !this.props.listCollections) &&
+        nextProps.list &&
+        nextProps.listCollections
+      ) {
         collections = nextProps.listCollections;
       }
-      let title = this.state.title ? this.state.title : nextProps.list.title;
+      const title = this.state.title ? this.state.title : nextProps.list.title;
       this.setState({
         title,
         entries: nextProps.list.books,
-        collections: collections
+        collections: collections,
       });
-    } else if ((!this.props.list || !this.props.listCollections) && nextProps.list && nextProps.listCollections) {
+    } else if (
+      (!this.props.list || !this.props.listCollections) &&
+      nextProps.list &&
+      nextProps.listCollections
+    ) {
       this.setState({
         title: this.state.title,
         entries: this.state.entries,
-        collections: nextProps.listCollections
+        collections: nextProps.listCollections,
       });
     }
   }
@@ -203,14 +227,21 @@ export default class CustomListEditor extends React.Component<CustomListEditorPr
     if (this.props.list?.title) {
       return false;
     } else {
-      return (!this.state.title || this.state.title === "list title" || this.state.title === "");
+      return (
+        !this.state.title ||
+        this.state.title === "list title" ||
+        this.state.title === ""
+      );
     }
   }
 
   hasChanges(): boolean {
-    let titleChanged = (this.props.list && this.props.list.title !== this.state.title);
-    let entriesChanged = this.props.list && !!this.props.list.books &&
-      (this.props.list.books.length !== this.state.entries.length);
+    let titleChanged =
+      this.props.list && this.props.list.title !== this.state.title;
+    let entriesChanged =
+      this.props.list &&
+      !!this.props.list.books &&
+      this.props.list.books.length !== this.state.entries.length;
     // If the current list is new then this.props.list will be undefined, but
     // the state for the entries or title can be populated so there's a need to check.
     if (!this.props.list) {
@@ -219,8 +250,10 @@ export default class CustomListEditor extends React.Component<CustomListEditorPr
     }
 
     if (!entriesChanged) {
-      let propsIds = ((this.props.list && this.props.list.books) || []).map(entry => entry.id).sort();
-      let stateIds = this.state.entries?.map(entry => entry.id).sort();
+      const propsIds = ((this.props.list && this.props.list.books) || [])
+        .map((entry) => entry.id)
+        .sort();
+      const stateIds = this.state.entries?.map((entry) => entry.id).sort();
       for (let i = 0; i < propsIds.length; i++) {
         if (propsIds[i] !== stateIds[i]) {
           entriesChanged = true;
@@ -229,11 +262,18 @@ export default class CustomListEditor extends React.Component<CustomListEditorPr
       }
     }
     let collectionsChanged = false;
-    if (this.props.listCollections && this.props.listCollections.length !== this.state.collections.length) {
+    if (
+      this.props.listCollections &&
+      this.props.listCollections.length !== this.state.collections.length
+    ) {
       collectionsChanged = true;
     } else {
-      let propsIds = (this.props.listCollections || []).map(collection => collection.id).sort();
-      let stateIds = this.state.collections.map(collection => collection.id).sort();
+      const propsIds = (this.props.listCollections || [])
+        .map((collection) => collection.id)
+        .sort();
+      const stateIds = this.state.collections
+        .map((collection) => collection.id)
+        .sort();
       for (let i = 0; i < propsIds.length; i++) {
         if (propsIds[i] !== stateIds[i]) {
           collectionsChanged = true;
@@ -241,16 +281,24 @@ export default class CustomListEditor extends React.Component<CustomListEditorPr
         }
       }
     }
-    let hasChanges = titleChanged || entriesChanged || collectionsChanged;
+    const hasChanges = titleChanged || entriesChanged || collectionsChanged;
     return hasChanges;
   }
 
   changeTitle(title: string) {
-    this.setState({ title, entries: this.state.entries, collections: this.state.collections });
+    this.setState({
+      title,
+      entries: this.state.entries,
+      collections: this.state.collections,
+    });
   }
 
   changeEntries(entries: Entry[]) {
-    this.setState({ entries, title: this.state.title, collections: this.state.collections });
+    this.setState({
+      entries,
+      title: this.state.title,
+      collections: this.state.collections,
+    });
   }
 
   hasCollection(collection: AdminCollectionData) {
@@ -266,12 +314,18 @@ export default class CustomListEditor extends React.Component<CustomListEditorPr
     const hasCollection = this.hasCollection(collection);
     let newCollections;
     if (hasCollection) {
-      newCollections = this.state.collections.filter(stateCollection => stateCollection.id !== collection.id);
+      newCollections = this.state.collections.filter(
+        (stateCollection) => stateCollection.id !== collection.id
+      );
     } else {
       newCollections = this.state.collections.slice(0);
       newCollections.push(collection);
     }
-    this.setState({ title: this.state.title, entries: this.state.entries, collections: newCollections });
+    this.setState({
+      title: this.state.title,
+      entries: this.state.entries,
+      collections: newCollections,
+    });
   }
 
   changeEntryPoint(entryPointSelected: string) {
@@ -288,24 +342,36 @@ export default class CustomListEditor extends React.Component<CustomListEditorPr
     if (this.props.list) {
       data.append("id", this.props.listId);
     }
-    let title = (this.refs["listTitle"] as TextWithEditMode).getText();
+    const title = (this.refs["listTitle"] as TextWithEditMode).getText();
     data.append("name", title);
-    let entries = (this.refs["listEntries"] as CustomListEntriesEditor).getEntries();
+    const entries = (this.refs[
+      "listEntries"
+    ] as CustomListEntriesEditor).getEntries();
     data.append("entries", JSON.stringify(entries));
-    let deletedEntries = (this.refs["listEntries"] as CustomListEntriesEditor).getDeleted();
+    const deletedEntries = (this.refs[
+      "listEntries"
+    ] as CustomListEntriesEditor).getDeleted();
     data.append("deletedEntries", JSON.stringify(deletedEntries));
-    let collections = this.state.collections.map(collection => collection.id);
+    const collections = this.state.collections.map(
+      (collection) => collection.id
+    );
     data.append("collections", JSON.stringify(collections));
 
-    this.props.editCustomList(data, this.props.listId && String(this.props.listId)).then(() => {
-      (this.refs["listEntries"] as CustomListEntriesEditor).clearState();
-      this.setState({ title: this.state.title, entries });
+    this.props
+      .editCustomList(data, this.props.listId && String(this.props.listId))
+      .then(() => {
+        (this.refs["listEntries"] as CustomListEntriesEditor).clearState();
+        this.setState({ title: this.state.title, entries });
 
-      // If a new list was created, go to the new list's edit page.
-      if (!this.props.list && this.props.responseBody) {
-        window.location.href = "/admin/web/lists/" + this.props.library.short_name + "/edit/" + this.props.responseBody;
-      }
-    });
+        // If a new list was created, go to the new list's edit page.
+        if (!this.props.list && this.props.responseBody) {
+          window.location.href =
+            "/admin/web/lists/" +
+            this.props.library.short_name +
+            "/edit/" +
+            this.props.responseBody;
+        }
+      });
   }
 
   reset() {
@@ -315,7 +381,7 @@ export default class CustomListEditor extends React.Component<CustomListEditorPr
       this.setState({
         title: this.state.title,
         entries: this.state.entries,
-        collections: (this.props.listCollections) || [],
+        collections: this.props.listCollections || [],
         entryPointSelected: "all",
       });
     }, 200);
@@ -334,24 +400,28 @@ export default class CustomListEditor extends React.Component<CustomListEditorPr
 
   getEntryPointsElms(entryPoints) {
     const entryPointsElms = [];
-    !entryPoints.includes("All") && entryPointsElms.push(
-      <EditableInput
-        key="all"
-        type="radio"
-        name="entry-points-selection"
-        checked={"all" === this.state.entryPointSelected}
-        label="All"
-        value="all"
-        onChange={() => this.changeEntryPoint("all")}
-      />
-    );
-    entryPoints.forEach(entryPoint =>
+    !entryPoints.includes("All") &&
+      entryPointsElms.push(
+        <EditableInput
+          key="all"
+          type="radio"
+          name="entry-points-selection"
+          checked={"all" === this.state.entryPointSelected}
+          label="All"
+          value="all"
+          onChange={() => this.changeEntryPoint("all")}
+        />
+      );
+    entryPoints.forEach((entryPoint) =>
       entryPointsElms.push(
         <EditableInput
           key={entryPoint}
           type="radio"
           name="entry-points-selection"
-          checked={entryPoint === this.state.entryPointSelected || entryPoint.toLowerCase() === this.state.entryPointSelected}
+          checked={
+            entryPoint === this.state.entryPointSelected ||
+            entryPoint.toLowerCase() === this.state.entryPointSelected
+          }
           label={entryPoint}
           value={entryPoint}
           onChange={() => this.changeEntryPoint(entryPoint)}

--- a/src/components/CustomListEntriesEditor.tsx
+++ b/src/components/CustomListEntriesEditor.tsx
@@ -302,7 +302,7 @@ export default class CustomListEntriesEditor extends React.Component<
     );
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     let deleted = this.state.deleted;
     let added = this.state.added;
     let totalVisibleEntries = this.state.totalVisibleEntries;

--- a/src/components/CustomLists.tsx
+++ b/src/components/CustomLists.tsx
@@ -171,7 +171,7 @@ export class CustomLists extends React.Component<
     return <CustomListEditor {...{ ...editorProps, ...extraProps }} />;
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     if (this.props.fetchCustomLists) {
       this.props.fetchCustomLists();
     }
@@ -188,7 +188,7 @@ export class CustomLists extends React.Component<
     this.props.fetchLanguages();
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     // If we've fetched lists but we're not on the edit or create page,
     // redirect to the edit page for the first list, or the create page
     // if there are no lists.

--- a/src/components/CustomListsForBook.tsx
+++ b/src/components/CustomListsForBook.tsx
@@ -5,9 +5,7 @@ import DataFetcher from "opds-web-client/lib/DataFetcher";
 import ActionCreator from "../actions";
 import ErrorMessage from "./ErrorMessage";
 import ProtocolFormField from "./ProtocolFormField";
-import {
-  BookData, CustomListData, CustomListsData
-} from "../interfaces";
+import { BookData, CustomListData, CustomListsData } from "../interfaces";
 import { FetchErrorData } from "opds-web-client/lib/interfaces";
 import { State } from "../reducers/index";
 import { Link } from "react-router";
@@ -34,7 +32,10 @@ export interface CustomListsForBookOwnProps {
   refreshCatalog: () => Promise<any>;
 }
 
-export interface CustomListsForBookProps extends CustomListsForBookStateProps, CustomListsForBookDispatchProps, CustomListsForBookOwnProps {}
+export interface CustomListsForBookProps
+  extends CustomListsForBookStateProps,
+    CustomListsForBookDispatchProps,
+    CustomListsForBookOwnProps {}
 
 export interface CustomListsForBookState {
   customLists?: CustomListData[];
@@ -42,13 +43,16 @@ export interface CustomListsForBookState {
 
 /** Tab on the book details page that shows custom lists a book is on and lets
     an admin add the book to lists or remove the book from lists. */
-export class CustomListsForBook extends React.Component<CustomListsForBookProps, CustomListsForBookState> {
+export class CustomListsForBook extends React.Component<
+  CustomListsForBookProps,
+  CustomListsForBookState
+> {
   private addListRef = React.createRef<ProtocolFormField>();
 
   constructor(props: CustomListsForBookProps) {
     super(props);
     this.state = {
-      customLists: this.props.customListsForBook
+      customLists: this.props.customListsForBook,
     };
     this.refresh = this.refresh.bind(this);
     this.save = this.save.bind(this);
@@ -58,13 +62,11 @@ export class CustomListsForBook extends React.Component<CustomListsForBookProps,
   render(): JSX.Element {
     return (
       <div className="custom-list-for-book">
-        { this.props.book &&
-          <h2>{this.props.book.title}</h2>
-        }
-          <h3>Lists:</h3>
-        { this.props.fetchError &&
+        {this.props.book && <h2>{this.props.book.title}</h2>}
+        <h3>Lists:</h3>
+        {this.props.fetchError && (
           <ErrorMessage error={this.props.fetchError} tryAgain={this.refresh} />
-        }
+        )}
         <div className="edit-form">
           {this.renderInputList()}
           {this.renderLink()}
@@ -75,25 +77,36 @@ export class CustomListsForBook extends React.Component<CustomListsForBookProps,
 
   makeOption(list: CustomListData): JSX.Element {
     // Dropdown menu of the lists to which the book can still be added
-    return <option value={list.name} key={list.id} aria-selected={false}>{list.name}</option>;
+    return (
+      <option value={list.name} key={list.id} aria-selected={false}>
+        {list.name}
+      </option>
+    );
   }
 
   renderLink(): JSX.Element {
     // Link to the form for creating a new list
-    return(
+    return (
       <div key="list-creator-link">
-        <Link to={{
-          pathname: `/admin/web/lists/${this.props.library}/create`,
-          state: { bookTitle: this.props.book && this.props.book.title }
-        }}>Create a new list</Link>
-        <p>(The book title will be automatically copied and searched on the list creator page.)</p>
+        <Link
+          to={{
+            pathname: `/admin/web/lists/${this.props.library}/create`,
+            state: { bookTitle: this.props.book && this.props.book.title },
+          }}
+        >
+          Create a new list
+        </Link>
+        <p>
+          (The book title will be automatically copied and searched on the list
+          creator page.)
+        </p>
       </div>
     );
   }
 
   renderInputList(): JSX.Element {
     // The list of lists the book is already on, and the dropdown for adding it to others
-    let allLists = this.props.allCustomLists || [];
+    const allLists = this.props.allCustomLists || [];
     if (allLists.length > 0) {
       return (
         <ProtocolFormField
@@ -107,32 +120,39 @@ export class CustomListsForBook extends React.Component<CustomListsForBookProps,
             label: null,
             custom_lists: this.state.customLists,
             required: false,
-            menuOptions: allLists.filter(l => l.name).map(l => this.makeOption(l)),
-            urlBase: this.makeURL
+            menuOptions: allLists
+              .filter((l) => l.name)
+              .map((l) => this.makeOption(l)),
+            urlBase: this.makeURL,
           }}
           title="Current Lists"
           disabled={this.props.isFetching}
-          value={this.props.customListsForBook && this.props.customListsForBook.map(l => l.name)}
+          value={
+            this.props.customListsForBook &&
+            this.props.customListsForBook.map((l) => l.name)
+          }
           altValue="This book is not currently on any lists."
           onSubmit={this.save}
           onEmpty="This book has been added to all the available lists."
         />
       );
     } else {
-        // Don't show the dropdown if no lists exist.
-        return <p>There are no available lists.</p>;
+      // Don't show the dropdown if no lists exist.
+      return <p>There are no available lists.</p>;
     }
   }
 
   makeURL(listName: string): string {
     // Each item in the list of lists links to its list edit form
-    let list = (this.props.allCustomLists || []).find(l => l.name === listName);
+    const list = (this.props.allCustomLists || []).find(
+      (l) => l.name === listName
+    );
     if (list) {
       return `/admin/web/lists/${this.props.library}/edit/${list.id}`;
     }
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     if (this.props.bookUrl) {
       this.props.fetchCustomListsForBook(this.listsUrl());
       if (!this.props.allCustomLists) {
@@ -141,7 +161,7 @@ export class CustomListsForBook extends React.Component<CustomListsForBookProps,
     }
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (this.props.bookUrl !== nextProps.bookUrl) {
       this.setState({ customLists: nextProps.customListsForBook });
     }
@@ -160,10 +180,10 @@ export class CustomListsForBook extends React.Component<CustomListsForBookProps,
   save() {
     const listNames = (this.addListRef.current as ProtocolFormField).getValue();
     const url = this.listsUrl();
-    let data = new (window as any).FormData();
-    let lists = [];
+    const data = new (window as any).FormData();
+    const lists = [];
     (listNames as string[]).map((name) => {
-      let list = this.props.allCustomLists.find(x => x.name === name);
+      const list = this.props.allCustomLists.find((x) => x.name === name);
       lists.push(list);
     });
     data.append("lists", JSON.stringify(lists));
@@ -173,24 +193,35 @@ export class CustomListsForBook extends React.Component<CustomListsForBookProps,
 
 function mapStateToProps(state, ownProps) {
   return {
-    allCustomLists: state.editor.customLists.data && state.editor.customLists.data.custom_lists,
-    customListsForBook: state.editor.customListsForBook.data && state.editor.customListsForBook.data.custom_lists,
+    allCustomLists:
+      state.editor.customLists.data &&
+      state.editor.customLists.data.custom_lists,
+    customListsForBook:
+      state.editor.customListsForBook.data &&
+      state.editor.customListsForBook.data.custom_lists,
     isFetching: state.editor.customListsForBook.isFetching,
-    fetchError: state.editor.customListsForBook.fetchError
+    fetchError: state.editor.customListsForBook.fetchError,
   };
 }
 
 function mapDispatchToProps(dispatch, ownProps) {
-  let fetcher = new DataFetcher();
-  let actions = new ActionCreator(fetcher, ownProps.csrfToken);
+  const fetcher = new DataFetcher();
+  const actions = new ActionCreator(fetcher, ownProps.csrfToken);
   return {
-    fetchAllCustomLists: () => dispatch(actions.fetchCustomLists(ownProps.library)),
-    fetchCustomListsForBook: (url) => dispatch(actions.fetchCustomListsForBook(url)),
-    editCustomListsForBook: (url, data) => dispatch(actions.editCustomListsForBook(url, data))
+    fetchAllCustomLists: () =>
+      dispatch(actions.fetchCustomLists(ownProps.library)),
+    fetchCustomListsForBook: (url) =>
+      dispatch(actions.fetchCustomListsForBook(url)),
+    editCustomListsForBook: (url, data) =>
+      dispatch(actions.editCustomListsForBook(url, data)),
   };
 }
 
-const ConnectedCustomListsForBook = connect<CustomListsForBookStateProps, CustomListsForBookDispatchProps, CustomListsForBookOwnProps>(
+const ConnectedCustomListsForBook = connect<
+  CustomListsForBookStateProps,
+  CustomListsForBookDispatchProps,
+  CustomListsForBookOwnProps
+>(
   mapStateToProps,
   mapDispatchToProps
 )(CustomListsForBook);

--- a/src/components/DashboardPage.tsx
+++ b/src/components/DashboardPage.tsx
@@ -19,20 +19,23 @@ export interface DashboardPageContext {
 
 /** Page that shows high-level statistics about patrons and collections
     and a list of the most recent circulation events. */
-export default class DashboardPage extends React.Component<DashboardPageProps, {}> {
+export default class DashboardPage extends React.Component<
+  DashboardPageProps,
+  {}
+> {
   context: DashboardPageContext;
 
   static contextTypes: React.ValidationMap<DashboardPageContext> = {
-    editorStore: PropTypes.object.isRequired as React.Validator<Store>
+    editorStore: PropTypes.object.isRequired as React.Validator<Store>,
   };
 
   static childContextTypes: React.ValidationMap<{}> = {
-    library: PropTypes.func
+    library: PropTypes.func,
   };
 
   getChildContext() {
     return {
-      library: () => this.props.params.library
+      library: () => this.props.params.library,
     };
   }
 
@@ -43,14 +46,17 @@ export default class DashboardPage extends React.Component<DashboardPageProps, {
         <Header />
         <main className="body">
           <Stats store={this.context.editorStore} library={library} />
-          <CirculationEvents store={this.context.editorStore} library={library} />
+          <CirculationEvents
+            store={this.context.editorStore}
+            library={library}
+          />
         </main>
         <Footer />
       </div>
     );
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     document.title = "Circulation Manager - Dashboard";
   }
 }

--- a/src/components/DiagnosticsTabContainer.tsx
+++ b/src/components/DiagnosticsTabContainer.tsx
@@ -41,7 +41,7 @@ export class DiagnosticsTabContainer extends TabContainer<
     other: "Other",
   };
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.props.fetchDiagnostics();
   }
 

--- a/src/components/DiscoveryServices.tsx
+++ b/src/components/DiscoveryServices.tsx
@@ -1,28 +1,49 @@
 import * as React from "react";
-import { GenericEditableConfigList, EditableConfigListStateProps, EditableConfigListDispatchProps, EditableConfigListOwnProps } from "./EditableConfigList";
+import {
+  GenericEditableConfigList,
+  EditableConfigListStateProps,
+  EditableConfigListDispatchProps,
+  EditableConfigListOwnProps,
+} from "./EditableConfigList";
 import { connect } from "react-redux";
 import * as PropTypes from "prop-types";
 import ActionCreator from "../actions";
-import { DiscoveryServicesData, DiscoveryServiceData, LibraryData, LibraryRegistrationsData } from "../interfaces";
+import {
+  DiscoveryServicesData,
+  DiscoveryServiceData,
+  LibraryData,
+  LibraryRegistrationsData,
+} from "../interfaces";
 import ServiceWithRegistrationsEditForm from "./ServiceWithRegistrationsEditForm";
 
-export interface DiscoveryServicesStateProps extends EditableConfigListStateProps<DiscoveryServicesData> {
+export interface DiscoveryServicesStateProps
+  extends EditableConfigListStateProps<DiscoveryServicesData> {
   isFetchingLibraryRegistrations?: boolean;
 }
 
-export interface DiscoveryServicesDispatchProps extends EditableConfigListDispatchProps<DiscoveryServicesData> {
+export interface DiscoveryServicesDispatchProps
+  extends EditableConfigListDispatchProps<DiscoveryServicesData> {
   registerLibrary: (data: FormData) => Promise<void>;
   fetchLibraryRegistrations?: () => Promise<LibraryRegistrationsData>;
 }
 
-export interface DiscoveryServicesProps extends DiscoveryServicesStateProps, DiscoveryServicesDispatchProps, EditableConfigListOwnProps {}
+export interface DiscoveryServicesProps
+  extends DiscoveryServicesStateProps,
+    DiscoveryServicesDispatchProps,
+    EditableConfigListOwnProps {}
 
-class DiscoveryServiceEditForm extends ServiceWithRegistrationsEditForm<DiscoveryServicesData> {}
+class DiscoveryServiceEditForm extends ServiceWithRegistrationsEditForm<
+  DiscoveryServicesData
+> {}
 
 /** Right panel for discovery services on the system configuration page.
     Shows a list of current discovery services and allows creating a new
     service or editing or deleting an existing service. */
-export class DiscoveryServices extends GenericEditableConfigList<DiscoveryServicesData, DiscoveryServiceData, DiscoveryServicesProps> {
+export class DiscoveryServices extends GenericEditableConfigList<
+  DiscoveryServicesData,
+  DiscoveryServiceData,
+  DiscoveryServicesProps
+> {
   EditForm = DiscoveryServiceEditForm;
   listDataKey = "discovery_services";
   itemTypeName = "discovery service";
@@ -31,7 +52,7 @@ export class DiscoveryServices extends GenericEditableConfigList<DiscoveryServic
   labelKey = "name";
 
   static childContextTypes: React.ValidationMap<any> = {
-    registerLibrary: PropTypes.func
+    registerLibrary: PropTypes.func,
   };
 
   getChildContext() {
@@ -48,12 +69,12 @@ export class DiscoveryServices extends GenericEditableConfigList<DiscoveryServic
             }
           });
         }
-      }
+      },
     };
   }
 
-  componentWillMount() {
-    super.componentWillMount();
+  UNSAFE_componentWillMount() {
+    super.UNSAFE_componentWillMount();
     if (this.props.fetchLibraryRegistrations) {
       this.props.fetchLibraryRegistrations();
     }
@@ -61,37 +82,63 @@ export class DiscoveryServices extends GenericEditableConfigList<DiscoveryServic
 }
 
 function mapStateToProps(state, ownProps) {
-  const data = Object.assign({}, state.editor.discoveryServices && state.editor.discoveryServices.data || {});
+  const data = Object.assign(
+    {},
+    (state.editor.discoveryServices && state.editor.discoveryServices.data) ||
+      {}
+  );
   if (state.editor.libraries && state.editor.libraries.data) {
     data.allLibraries = state.editor.libraries.data.libraries;
   }
-  if (state.editor.discoveryServiceLibraryRegistrations && state.editor.discoveryServiceLibraryRegistrations.data) {
-    data.libraryRegistrations = state.editor.discoveryServiceLibraryRegistrations.data.library_registrations;
+  if (
+    state.editor.discoveryServiceLibraryRegistrations &&
+    state.editor.discoveryServiceLibraryRegistrations.data
+  ) {
+    data.libraryRegistrations =
+      state.editor.discoveryServiceLibraryRegistrations.data.library_registrations;
   }
   // fetchError = an error involving loading the list of discovery services; formError = an error upon
   // submission of the create/edit form (including upon submitting a change to a library's registration).
   return {
     data: data,
-    responseBody: state.editor.discoveryServices && state.editor.discoveryServices.successMessage,
+    responseBody:
+      state.editor.discoveryServices &&
+      state.editor.discoveryServices.successMessage,
     fetchError: state.editor.discoveryServices.fetchError,
-    formError: state.editor.discoveryServices.formError || (state.editor.registerLibraryWithDiscoveryService && state.editor.registerLibraryWithDiscoveryService.fetchError),
-    isFetching: state.editor.discoveryServices.isFetching || state.editor.discoveryServices.isEditing || (state.editor.registerLibraryWithDiscoveryService && state.editor.registerLibraryWithDiscoveryService.isFetching),
-    isFetchingLibraryRegistrations: state.editor.discoveryServiceLibraryRegistrations && state.editor.discoveryServiceLibraryRegistrations.isFetching
+    formError:
+      state.editor.discoveryServices.formError ||
+      (state.editor.registerLibraryWithDiscoveryService &&
+        state.editor.registerLibraryWithDiscoveryService.fetchError),
+    isFetching:
+      state.editor.discoveryServices.isFetching ||
+      state.editor.discoveryServices.isEditing ||
+      (state.editor.registerLibraryWithDiscoveryService &&
+        state.editor.registerLibraryWithDiscoveryService.isFetching),
+    isFetchingLibraryRegistrations:
+      state.editor.discoveryServiceLibraryRegistrations &&
+      state.editor.discoveryServiceLibraryRegistrations.isFetching,
   };
 }
 
 function mapDispatchToProps(dispatch, ownProps) {
-  let actions = new ActionCreator(null, ownProps.csrfToken);
+  const actions = new ActionCreator(null, ownProps.csrfToken);
   return {
     fetchData: () => dispatch(actions.fetchDiscoveryServices()),
     editItem: (data: FormData) => dispatch(actions.editDiscoveryService(data)),
-    deleteItem: (identifier: string | number) => dispatch(actions.deleteDiscoveryService(identifier)),
-    registerLibrary: (data: FormData) => dispatch(actions.registerLibraryWithDiscoveryService(data)),
-    fetchLibraryRegistrations: () => dispatch(actions.fetchDiscoveryServiceLibraryRegistrations())
+    deleteItem: (identifier: string | number) =>
+      dispatch(actions.deleteDiscoveryService(identifier)),
+    registerLibrary: (data: FormData) =>
+      dispatch(actions.registerLibraryWithDiscoveryService(data)),
+    fetchLibraryRegistrations: () =>
+      dispatch(actions.fetchDiscoveryServiceLibraryRegistrations()),
   };
 }
 
-const ConnectedDiscoveryServices = connect<DiscoveryServicesStateProps, DiscoveryServicesDispatchProps, EditableConfigListOwnProps>(
+const ConnectedDiscoveryServices = connect<
+  DiscoveryServicesStateProps,
+  DiscoveryServicesDispatchProps,
+  EditableConfigListOwnProps
+>(
   mapStateToProps,
   mapDispatchToProps
 )(DiscoveryServices);

--- a/src/components/EditableConfigList.tsx
+++ b/src/components/EditableConfigList.tsx
@@ -132,7 +132,7 @@ export abstract class GenericEditableConfigList<
     const ExtraFormSection = this.ExtraFormSection;
     const itemToEdit = this.itemToEdit();
     return (
-      <div className={this.getAdditionalContentClassName()}>
+      <div className={this.getClassName()}>
         <h2>{headers["h2"]}</h2>
         {canListAllData && this.links && this.links["info"] && (
           <Alert bsStyle="info">{this.links["info"]}</Alert>
@@ -278,7 +278,7 @@ export abstract class GenericEditableConfigList<
     return { h2, h3 };
   }
 
-  getAdditionalContentClassName() {
+  getClassName(): string {
     const className = this.AdditionalContent ? "has-additional-content" : "";
     return className;
   }

--- a/src/components/EditableConfigList.tsx
+++ b/src/components/EditableConfigList.tsx
@@ -36,7 +36,10 @@ export interface EditableConfigListOwnProps {
   settingUp?: boolean;
 }
 
-export interface EditableConfigListProps<T> extends EditableConfigListStateProps<T>, EditableConfigListDispatchProps<T>, EditableConfigListOwnProps {}
+export interface EditableConfigListProps<T>
+  extends EditableConfigListStateProps<T>,
+    EditableConfigListDispatchProps<T>,
+    EditableConfigListOwnProps {}
 
 export interface EditFormProps<T, U> {
   item?: U;
@@ -73,12 +76,19 @@ export interface ExtraFormSectionProps<T, U> {
 
     GenericEditableConfigList allows subclasses to define additional props. Subclasses of
     EditableConfigList cannot change the props and do not have to specify a type for them. */
-export abstract class GenericEditableConfigList<T, U, V extends EditableConfigListProps<T>> extends React.Component<V, {}> {
+export abstract class GenericEditableConfigList<
+  T,
+  U,
+  V extends EditableConfigListProps<T>
+> extends React.Component<V, {}> {
   context: { admin: Admin };
   static contextTypes = {
-    admin: PropTypes.object.isRequired
+    admin: PropTypes.object.isRequired,
   };
-  abstract EditForm: new(props: EditFormProps<T, U>) => React.Component<EditFormProps<T, U>, any>;
+  abstract EditForm: new (props: EditFormProps<T, U>) => React.Component<
+    EditFormProps<T, U>,
+    any
+  >;
   abstract listDataKey: string;
   abstract itemTypeName: string;
   abstract urlBase: string;
@@ -86,9 +96,13 @@ export abstract class GenericEditableConfigList<T, U, V extends EditableConfigLi
   abstract labelKey: string;
   adminLevel?: number;
   limitOne = false;
-  links?: {[key: string]: JSX.Element};
-  AdditionalContent?: new(props: AdditionalContentProps<T, U>) => React.Component<AdditionalContentProps<T, U>, any>;
-  ExtraFormSection?: new(props: ExtraFormSectionProps<T, U>) => React.Component<ExtraFormSectionProps<T, U>, any>;
+  links?: { [key: string]: JSX.Element };
+  AdditionalContent?: new (
+    props: AdditionalContentProps<T, U>
+  ) => React.Component<AdditionalContentProps<T, U>, any>;
+  ExtraFormSection?: new (
+    props: ExtraFormSectionProps<T, U>
+  ) => React.Component<ExtraFormSectionProps<T, U>, any>;
   extraFormKey?: string;
   private editFormRef = React.createRef<any>();
 
@@ -100,7 +114,7 @@ export abstract class GenericEditableConfigList<T, U, V extends EditableConfigLi
     this.renderLi = this.renderLi.bind(this);
   }
 
-   componentWillMount() {
+  UNSAFE_componentWillMount() {
     if (this.props.fetchData) {
       this.props.fetchData();
     }
@@ -109,49 +123,50 @@ export abstract class GenericEditableConfigList<T, U, V extends EditableConfigLi
   render(): JSX.Element {
     const headers = this.getHeaders();
     // If not in edit or create mode and there is data, display the list.
-    const canListAllData = !this.props.isFetching && !this.props.editOrCreate &&
-      this.props.data && this.props.data[this.listDataKey];
-    let EditForm = this.EditForm;
-    let ExtraFormSection = this.ExtraFormSection;
-    let itemToEdit = this.itemToEdit();
+    const canListAllData =
+      !this.props.isFetching &&
+      !this.props.editOrCreate &&
+      this.props.data &&
+      this.props.data[this.listDataKey];
+    const EditForm = this.EditForm;
+    const ExtraFormSection = this.ExtraFormSection;
+    const itemToEdit = this.itemToEdit();
     return (
       <div className={this.getClassName()}>
         <h2>{headers["h2"]}</h2>
-        { canListAllData && this.links && this.links["info"] &&
+        {canListAllData && this.links && this.links["info"] && (
           <Alert bsStyle="info">{this.links["info"]}</Alert>
-        }
-        { this.props.responseBody && this.props.editOrCreate &&
-          <Alert bsStyle="success">
-            {this.successMessage()}
-          </Alert>
-        }
-        { this.props.fetchError && !this.props.editOrCreate &&
+        )}
+        {this.props.responseBody && this.props.editOrCreate && (
+          <Alert bsStyle="success">{this.successMessage()}</Alert>
+        )}
+        {this.props.fetchError && !this.props.editOrCreate && (
           <ErrorMessage error={this.props.fetchError} />
-        }
-        { this.props.formError && this.props.editOrCreate &&
+        )}
+        {this.props.formError && this.props.editOrCreate && (
           <ErrorMessage error={this.props.formError} />
-        }
-        { this.props.isFetching &&
-          <LoadingIndicator />
-        }
-        { canListAllData &&
+        )}
+        {this.props.isFetching && <LoadingIndicator />}
+        {canListAllData && (
           <div>
-            { (!this.limitOne || this.props.data[this.listDataKey].length === 0) &&
-              this.canCreate() &&
+            {(!this.limitOne ||
+              this.props.data[this.listDataKey].length === 0) &&
+              this.canCreate() && (
                 <a
                   className="btn btn-default create-item"
                   href={this.urlBase + "create"}
-                  >Create new {this.itemTypeName}
+                >
+                  Create new {this.itemTypeName}
                 </a>
-            }
+              )}
             <ul>
-              { this.props.data[this.listDataKey].map((item, index) =>
-                  this.renderLi(item, index))
-              }
+              {this.props.data[this.listDataKey].map((item, index) =>
+                this.renderLi(item, index)
+              )}
             </ul>
           </div>
-        }
-        { (this.props.editOrCreate === "create") &&
+        )}
+        {this.props.editOrCreate === "create" && (
           <div>
             <h3>{headers["h3"]}</h3>
             <EditForm
@@ -169,9 +184,9 @@ export abstract class GenericEditableConfigList<T, U, V extends EditableConfigLi
               adminLevel={this.getAdminLevel()}
             />
           </div>
-        }
+        )}
 
-        { itemToEdit &&
+        {itemToEdit && (
           <div>
             <h3>Edit {this.label(itemToEdit)}</h3>
             <EditForm
@@ -189,14 +204,14 @@ export abstract class GenericEditableConfigList<T, U, V extends EditableConfigLi
               adminLevel={this.getAdminLevel()}
             />
           </div>
-        }
-        { this.links && this.links["footer"] && <p>{this.links["footer"]}</p> }
+        )}
+        {this.links && this.links["footer"] && <p>{this.links["footer"]}</p>}
       </div>
     );
   }
 
   renderLi(item, index): JSX.Element {
-    let AdditionalContent = this.AdditionalContent || null;
+    const AdditionalContent = this.AdditionalContent || null;
 
     return (
       <li key={index}>
@@ -204,30 +219,39 @@ export abstract class GenericEditableConfigList<T, U, V extends EditableConfigLi
           className="btn small edit-item"
           href={this.urlBase + "edit/" + item[this.identifierKey]}
         >
-        { this.canEdit(item) ?
-          <span>Edit <PencilIcon /></span> :
-          <span>View <VisibleIcon /></span>
-        }
+          {this.canEdit(item) ? (
+            <span>
+              Edit <PencilIcon />
+            </span>
+          ) : (
+            <span>
+              View <VisibleIcon />
+            </span>
+          )}
         </a>
 
         <h3>{this.label(item)}</h3>
 
-        {this.canDelete() &&
+        {this.canDelete() && (
           <Button
             className="danger delete-item small"
-            callback={() => this.delete(item) }
-            content={<span>Delete<TrashIcon /></span>}
+            callback={() => this.delete(item)}
+            content={
+              <span>
+                Delete
+                <TrashIcon />
+              </span>
+            }
           />
-        }
-        {
-          AdditionalContent &&
+        )}
+        {AdditionalContent && (
           <AdditionalContent
             type={this.itemTypeName}
             item={item}
             store={this.props.store}
             csrfToken={this.props.csrfToken}
           />
-        }
+        )}
       </li>
     );
   }
@@ -249,18 +273,20 @@ export abstract class GenericEditableConfigList<T, U, V extends EditableConfigLi
   }
 
   getHeaders() {
-    let h2 = `${this.getItemType()} configuration`;
-    let h3 = `Create a new ${this.itemTypeName}`;
+    const h2 = `${this.getItemType()} configuration`;
+    const h3 = `Create a new ${this.itemTypeName}`;
     return { h2, h3 };
   }
 
   getClassName() {
-    let className = this.AdditionalContent ? "has-additional-content" : "";
+    const className = this.AdditionalContent ? "has-additional-content" : "";
     return className;
   }
 
   getItemType() {
-    return this.itemTypeName.slice(0, 1).toUpperCase() + this.itemTypeName.slice(1);
+    return (
+      this.itemTypeName.slice(0, 1).toUpperCase() + this.itemTypeName.slice(1)
+    );
   }
 
   formatItemType() {
@@ -277,14 +303,18 @@ export abstract class GenericEditableConfigList<T, U, V extends EditableConfigLi
     if (this.props.editOrCreate === "create") {
       verb = "Successfully created ";
       return (
-        <span>{verb}
+        <span>
+          {verb}
           <a href={this.getLink()}>a new {this.formatItemType()}</a>
         </span>
       );
     } else {
       verb = "Successfully edited this ";
       return (
-        <span>{verb}{this.formatItemType()}</span>
+        <span>
+          {verb}
+          {this.formatItemType()}
+        </span>
       );
     }
   }
@@ -311,14 +341,14 @@ export abstract class GenericEditableConfigList<T, U, V extends EditableConfigLi
    * that inherit GenericEditableConfigList.
    */
   canDelete() {
-    return (this.getAdminLevel() === 3);
+    return this.getAdminLevel() === 3;
   }
 
   canEdit(item) {
     // The server has the option to assign the item a level from 1 to 3, indicating what level of permissions
     // the admin needs to have in order to be able to modify the item.
     // (Currently, this is just being used to prevent librarians from modifying local analytics configurations.)
-    return (!item.level || item.level <= this.getAdminLevel());
+    return !item.level || item.level <= this.getAdminLevel();
   }
 
   save(data: FormData) {
@@ -341,7 +371,11 @@ export abstract class GenericEditableConfigList<T, U, V extends EditableConfigLi
   }
 
   itemToEdit(): U | null {
-    if (this.props.editOrCreate === "edit" && this.props.data && this.props.data[this.listDataKey]) {
+    if (
+      this.props.editOrCreate === "edit" &&
+      this.props.data &&
+      this.props.data[this.listDataKey]
+    ) {
       for (const item of this.props.data[this.listDataKey]) {
         if (String(item[this.identifierKey]) === this.props.identifier) {
           return item;
@@ -352,13 +386,16 @@ export abstract class GenericEditableConfigList<T, U, V extends EditableConfigLi
   }
 
   async delete(item: U): Promise<void> {
-    if (window.confirm("Delete \"" + this.label(item) + "\"?")) {
+    if (window.confirm('Delete "' + this.label(item) + '"?')) {
       await this.props.deleteItem(item[this.identifierKey]);
       this.props.fetchData();
     }
   }
 }
 
-export abstract class EditableConfigList<T, U> extends GenericEditableConfigList<T, U, EditableConfigListProps<T>> {}
+export abstract class EditableConfigList<
+  T,
+  U
+> extends GenericEditableConfigList<T, U, EditableConfigListProps<T>> {}
 
 export default EditableConfigList;

--- a/src/components/EditableConfigList.tsx
+++ b/src/components/EditableConfigList.tsx
@@ -132,7 +132,7 @@ export abstract class GenericEditableConfigList<
     const ExtraFormSection = this.ExtraFormSection;
     const itemToEdit = this.itemToEdit();
     return (
-      <div className={this.getClassName()}>
+      <div className={this.getAdditionalContentClassName()}>
         <h2>{headers["h2"]}</h2>
         {canListAllData && this.links && this.links["info"] && (
           <Alert bsStyle="info">{this.links["info"]}</Alert>
@@ -278,7 +278,7 @@ export abstract class GenericEditableConfigList<
     return { h2, h3 };
   }
 
-  getClassName() {
+  getAdditionalContentClassName() {
     const className = this.AdditionalContent ? "has-additional-content" : "";
     return className;
   }
@@ -386,7 +386,7 @@ export abstract class GenericEditableConfigList<
   }
 
   async delete(item: U): Promise<void> {
-    if (window.confirm('Delete "' + this.label(item) + '"?')) {
+    if (window.confirm(`Delete "` + this.label(item) + `"?`)) {
       await this.props.deleteItem(item[this.identifierKey]);
       this.props.fetchData();
     }

--- a/src/components/EditableInput.tsx
+++ b/src/components/EditableInput.tsx
@@ -26,54 +26,70 @@ export interface EditableInputState {
     because if the element gets its value from a prop, the user won't be able to make any changes.
     This component keeps an updated value in its state. This also handles rendering an optional
     label and description for the input. */
-export default class EditableInput extends React.Component<EditableInputProps, EditableInputState> {
+export default class EditableInput extends React.Component<
+  EditableInputProps,
+  EditableInputState
+> {
   private elementRef = React.createRef<HTMLInputElement>();
   static defaultProps = {
     optionalText: true,
-    readOnly: false
+    readOnly: false,
   };
 
   constructor(props) {
     super(props);
     this.state = {
       value: props.value || "",
-      checked: props.checked || false
+      checked: props.checked || false,
     };
     this.handleChange = this.handleChange.bind(this);
   }
 
   render() {
     const {
-      type, elementType, optionalText, required, description, clientError, error,
-      label, extraContent,
+      type,
+      elementType,
+      optionalText,
+      required,
+      description,
+      clientError,
+      error,
+      label,
+      extraContent,
     } = this.props;
     const checkboxOrRadioOrSelect = !!(
-      type === "checkbox" || type === "radio" || elementType === "select"
+      type === "checkbox" ||
+      type === "radio" ||
+      elementType === "select"
     );
-    const optionalTextStr = (optionalText && !required && !checkboxOrRadioOrSelect)
-      ? "(Optional) " : "";
+    const optionalTextStr =
+      optionalText && !required && !checkboxOrRadioOrSelect
+        ? "(Optional) "
+        : "";
     const descriptionText = description ? description : "";
     const descriptionStr = `${optionalTextStr}${descriptionText}`;
-    const errorClass = clientError ||
-      (error && error.status >= 400 && !this.state.value && required) ?
-      "field-error" : "";
+    const errorClass =
+      clientError ||
+      (error && error.status >= 400 && !this.state.value && required)
+        ? "field-error"
+        : "";
     return (
       <div className={`form-group ${errorClass} ${this.props.className}`}>
-        { label &&
+        {label && (
           <label className="control-label">
-            { type !== "checkbox" && type !== "radio" && label }
-            { required && <span className="required-field">Required</span>}
-            { this.renderElement() }
-            { type === "checkbox" && label }
-            { type === "radio" && <span>{label}</span> }
+            {type !== "checkbox" && type !== "radio" && label}
+            {required && <span className="required-field">Required</span>}
+            {this.renderElement()}
+            {type === "checkbox" && label}
+            {type === "radio" && <span>{label}</span>}
           </label>
-        }
-        { (extraContent || !label) &&
+        )}
+        {(extraContent || !label) && (
           <div className={extraContent ? "with-add-on" : ""}>
             {extraContent}
             {!label && this.renderElement()}
           </div>
-        }
+        )}
         {descriptionStr.trim() && this.renderDescription(descriptionStr)}
       </div>
     );
@@ -81,37 +97,61 @@ export default class EditableInput extends React.Component<EditableInputProps, E
 
   renderElement() {
     const {
-      type, elementType, placeholder, accept, list, min, max, children,
-      disabled, readOnly, name, validation, style, minLength, maxLength
-    } = this.props;
-    return React.createElement(elementType || "input", {
-      className: ((type !== "checkbox" && type !== "radio") ? "form-control" : ""),
-      ref: this.elementRef,
-      value: this.state.value,
-      checked: this.state.checked,
-      onKeyPress: validation && validation === "number" && this.validateNumber,
-      onChange: this.handleChange,
       type,
-      disabled,
-      readOnly,
-      name,
-      style,
+      elementType,
       placeholder,
       accept,
       list,
       min,
       max,
+      children,
+      disabled,
+      readOnly,
+      name,
+      validation,
+      style,
       minLength,
       maxLength,
-      ["aria-label"]: this.props["aria-label"]
-    }, children);
+    } = this.props;
+    return React.createElement(
+      elementType || "input",
+      {
+        className:
+          type !== "checkbox" && type !== "radio" ? "form-control" : "",
+        ref: this.elementRef,
+        value: this.state.value,
+        checked: this.state.checked,
+        onKeyPress:
+          validation && validation === "number" && this.validateNumber,
+        onChange: this.handleChange,
+        type,
+        disabled,
+        readOnly,
+        name,
+        style,
+        placeholder,
+        accept,
+        list,
+        min,
+        max,
+        minLength,
+        maxLength,
+        ["aria-label"]: this.props["aria-label"],
+      },
+      children
+    );
   }
 
   renderDescription(description: string) {
-    return <p className="description" dangerouslySetInnerHTML={{__html: description}} />;
+    return (
+      <p
+        className="description"
+        dangerouslySetInnerHTML={{ __html: description }}
+      />
+    );
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     let value = this.state.value;
     let checked = this.state.checked;
     let changed = false;
@@ -129,7 +169,10 @@ export default class EditableInput extends React.Component<EditableInputProps, E
   }
 
   handleChange() {
-    if (!this.props.readOnly && (!this.props.onChange || this.props.onChange(this.getValue()) !== false)) {
+    if (
+      !this.props.readOnly &&
+      (!this.props.onChange || this.props.onChange(this.getValue()) !== false)
+    ) {
       let value = this.state.value;
       let checked = this.state.checked;
       if (this.props.type === "checkbox" || this.props.type === "radio") {
@@ -142,7 +185,20 @@ export default class EditableInput extends React.Component<EditableInputProps, E
   }
 
   validateNumber(e) {
-    const validChars = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", ".", "Enter"];
+    const validChars = [
+      "0",
+      "1",
+      "2",
+      "3",
+      "4",
+      "5",
+      "6",
+      "7",
+      "8",
+      "9",
+      ".",
+      "Enter",
+    ];
     if (validChars.indexOf(e.key) < 0) {
       e.preventDefault();
     }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -115,7 +115,7 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
       { label: "Dashboard", href: "dashboard/", auth: isSiteWide },
       {
         label: "System Configuration",
-        href: "config/"
+        href: "config/",
       },
       {
         label: "Troubleshooting",
@@ -200,7 +200,7 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
     );
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     if (this.props.fetchLibraries) {
       this.props.fetchLibraries();
     }

--- a/src/components/IndividualAdminEditForm.tsx
+++ b/src/components/IndividualAdminEditForm.tsx
@@ -29,12 +29,15 @@ export interface IndividualAdminEditFormContext {
 }
 
 /** Form for editing an individual admin from the individual admin configuration page. */
-export default class IndividualAdminEditForm extends React.Component<IndividualAdminEditFormProps, IndividualAdminEditFormState> {
+export default class IndividualAdminEditForm extends React.Component<
+  IndividualAdminEditFormProps,
+  IndividualAdminEditFormState
+> {
   context: IndividualAdminEditFormContext;
 
   static contextTypes: React.ValidationMap<IndividualAdminEditFormContext> = {
     settingUp: PropTypes.bool.isRequired,
-    admin: PropTypes.object.isRequired as React.Validator<Admin>
+    admin: PropTypes.object.isRequired as React.Validator<Admin>,
   };
   private emailRef = React.createRef<EditableInput>();
   private passwordRef = React.createRef<EditableInput>();
@@ -47,7 +50,7 @@ export default class IndividualAdminEditForm extends React.Component<IndividualA
   constructor(props) {
     super(props);
     this.state = {
-      admin: new Admin(this.props.item && this.props.item.roles || [])
+      admin: new Admin((this.props.item && this.props.item.roles) || []),
     };
     this.isSelected = this.isSelected.bind(this);
     this.handleRoleChange = this.handleRoleChange.bind(this);
@@ -57,7 +60,7 @@ export default class IndividualAdminEditForm extends React.Component<IndividualA
     this.renderRoleForm = this.renderRoleForm.bind(this);
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.item && nextProps.item !== this.props.item) {
       this.setState({ admin: new Admin(nextProps.item.roles || []) });
     }
@@ -69,8 +72,8 @@ export default class IndividualAdminEditForm extends React.Component<IndividualA
         this.managerAllRef,
         this.librarianAllRef,
         this.libraryManagerRef,
-        this.librarianRef
-      ].forEach(ref => clearForm(ref));
+        this.librarianRef,
+      ].forEach((ref) => clearForm(ref));
     }
   }
 
@@ -80,7 +83,7 @@ export default class IndividualAdminEditForm extends React.Component<IndividualA
         onSubmit={this.submit}
         className="edit-form"
         disableButton={this.props.disabled}
-        content = {[
+        content={[
           <Panel
             headerText="Admin Information"
             id="admin-info"
@@ -90,15 +93,16 @@ export default class IndividualAdminEditForm extends React.Component<IndividualA
             collapsible={!this.context.settingUp}
             onEnter={this.submit}
           />,
-          !this.context.settingUp &&
-          <Panel
-            id="admin-roles"
-            headerText="Admin Roles"
-            key="roles"
-            content={this.renderRoleForm()}
-            openByDefault={true}
-            onEnter={this.submit}
-          />
+          !this.context.settingUp && (
+            <Panel
+              id="admin-roles"
+              headerText="Admin Roles"
+              key="roles"
+              content={this.renderRoleForm()}
+              openByDefault={true}
+              onEnter={this.submit}
+            />
+          ),
         ]}
       />
     );
@@ -120,18 +124,18 @@ export default class IndividualAdminEditForm extends React.Component<IndividualA
           value={this.props.item && this.props.item.email}
           error={this.props.error}
         />
-        { this.canChangePassword() &&
-            <EditableInput
-              elementType="input"
-              type="text"
-              disabled={this.props.disabled}
-              name="password"
-              label="Password"
-              ref={this.passwordRef}
-              required={this.context.settingUp}
-              error={this.props.error}
-            />
-          }
+        {this.canChangePassword() && (
+          <EditableInput
+            elementType="input"
+            type="text"
+            disabled={this.props.disabled}
+            name="password"
+            label="Password"
+            ref={this.passwordRef}
+            required={this.context.settingUp}
+            error={this.props.error}
+          />
+        )}
       </fieldset>
     );
   }
@@ -156,14 +160,14 @@ export default class IndividualAdminEditForm extends React.Component<IndividualA
               <th></th>
               <th>
                 <EditableInput
-                   elementType="input"
-                   type="checkbox"
-                   disabled={this.isDisabled("manager-all")}
-                   name="manager-all"
-                   ref={this.managerAllRef}
-                   label="Library Manager"
-                   checked={this.isSelected("manager-all")}
-                   onChange={() => this.handleRoleChange("manager-all")}
+                  elementType="input"
+                  type="checkbox"
+                  disabled={this.isDisabled("manager-all")}
+                  name="manager-all"
+                  ref={this.managerAllRef}
+                  label="Library Manager"
+                  checked={this.isSelected("manager-all")}
+                  onChange={() => this.handleRoleChange("manager-all")}
                 />
               </th>
               <th>
@@ -181,39 +185,46 @@ export default class IndividualAdminEditForm extends React.Component<IndividualA
             </tr>
           </thead>
           <tbody>
-            { this.props.data && this.props.data.allLibraries && this.props.data.allLibraries.map(library =>
-              <tr key={library.short_name}>
-                <td>
-                  {library.name}
-                </td>
-                <td>
-                  <EditableInput
-                    elementType="input"
-                    type="checkbox"
-                    disabled={this.isDisabled("manager", library.short_name)}
-                    name={"manager-" + library.short_name}
-                    ref={this.libraryManagerRef}
-                    label=""
-                    aria-label={`Library Manager for ${library.short_name}`}
-                    checked={this.isSelected("manager", library.short_name)}
-                    onChange={() => this.handleRoleChange("manager", library.short_name)}
-                  />
-                </td>
-                <td>
-                  <EditableInput
-                    elementType="input"
-                    type="checkbox"
-                    disabled={this.isDisabled("librarian", library.short_name)}
-                    name={"librarian-" + library.short_name}
-                    ref={this.librarianRef}
-                    label=""
-                    aria-label={`Librarian for ${library.short_name}`}
-                    checked={this.isSelected("librarian", library.short_name)}
-                    onChange={() => this.handleRoleChange("librarian", library.short_name)}
-                  />
-                </td>
-              </tr>
-            ) }
+            {this.props.data &&
+              this.props.data.allLibraries &&
+              this.props.data.allLibraries.map((library) => (
+                <tr key={library.short_name}>
+                  <td>{library.name}</td>
+                  <td>
+                    <EditableInput
+                      elementType="input"
+                      type="checkbox"
+                      disabled={this.isDisabled("manager", library.short_name)}
+                      name={"manager-" + library.short_name}
+                      ref={this.libraryManagerRef}
+                      label=""
+                      aria-label={`Library Manager for ${library.short_name}`}
+                      checked={this.isSelected("manager", library.short_name)}
+                      onChange={() =>
+                        this.handleRoleChange("manager", library.short_name)
+                      }
+                    />
+                  </td>
+                  <td>
+                    <EditableInput
+                      elementType="input"
+                      type="checkbox"
+                      disabled={this.isDisabled(
+                        "librarian",
+                        library.short_name
+                      )}
+                      name={"librarian-" + library.short_name}
+                      ref={this.librarianRef}
+                      label=""
+                      aria-label={`Librarian for ${library.short_name}`}
+                      checked={this.isSelected("librarian", library.short_name)}
+                      onChange={() =>
+                        this.handleRoleChange("librarian", library.short_name)
+                      }
+                    />
+                  </td>
+                </tr>
+              ))}
           </tbody>
         </table>
       </fieldset>
@@ -227,7 +238,7 @@ export default class IndividualAdminEditForm extends React.Component<IndividualA
     if (this.props.item.roles.length === 0) {
       return this.context.admin.isLibraryManagerOfSomeLibrary();
     }
-    let targetAdmin = new Admin(this.props.item.roles || []);
+    const targetAdmin = new Admin(this.props.item.roles || []);
     if (targetAdmin.isSystemAdmin()) {
       return this.context.admin.isSystemAdmin();
     } else if (targetAdmin.isSitewideLibraryManager()) {
@@ -275,24 +286,42 @@ export default class IndividualAdminEditForm extends React.Component<IndividualA
       if (this.isSelected(role)) {
         this.setState(Object.assign({}, this.state, { admin: new Admin([]) }));
       } else {
-        this.setState(Object.assign({}, this.state, { admin: new Admin([{ role }]) }));
+        this.setState(
+          Object.assign({}, this.state, { admin: new Admin([{ role }]) })
+        );
       }
     } else if (role === "manager-all") {
       if (this.isSelected(role)) {
-        this.setState(Object.assign({}, this.state, { admin: new Admin([{ role: "librarian-all" }]) }));
+        this.setState(
+          Object.assign({}, this.state, {
+            admin: new Admin([{ role: "librarian-all" }]),
+          })
+        );
       } else {
-        this.setState(Object.assign({}, this.state, { admin: new Admin([{ role: "manager-all" }]) }));
+        this.setState(
+          Object.assign({}, this.state, {
+            admin: new Admin([{ role: "manager-all" }]),
+          })
+        );
       }
     } else if (role === "librarian-all") {
       if (this.isSelected(role)) {
         // Remove librarian-all role, but leave manager roles.
-        const roles = this.state.admin.roles.filter(stateRole => stateRole.role === "manager");
-        this.setState(Object.assign({}, this.state, { admin: new Admin(roles) }));
+        const roles = this.state.admin.roles.filter(
+          (stateRole) => stateRole.role === "manager"
+        );
+        this.setState(
+          Object.assign({}, this.state, { admin: new Admin(roles) })
+        );
       } else {
         // Remove old librarian roles, but leave manager roles.
-        const roles = this.state.admin.roles.filter(stateRole => stateRole.role === "manager");
+        const roles = this.state.admin.roles.filter(
+          (stateRole) => stateRole.role === "manager"
+        );
         roles.push({ role: "librarian-all" });
-        this.setState(Object.assign({}, this.state, { admin: new Admin(roles) }));
+        this.setState(
+          Object.assign({}, this.state, { admin: new Admin(roles) })
+        );
       }
     } else if (role === "manager") {
       if (this.isSelected(role, library)) {
@@ -307,22 +336,32 @@ export default class IndividualAdminEditForm extends React.Component<IndividualA
             }
           }
           roles.push({ role: "librarian-all" });
-          this.setState(Object.assign({}, this.state, { admin: new Admin(roles) }));
+          this.setState(
+            Object.assign({}, this.state, { admin: new Admin(roles) })
+          );
         } else {
           // Remove the manager role for this library and add the librarian role,
           // unless librarian-all is already selected.
-          const roles = this.state.admin.roles.filter(stateRole => stateRole.library !== library);
+          const roles = this.state.admin.roles.filter(
+            (stateRole) => stateRole.library !== library
+          );
           if (!this.isSelected("librarian-all")) {
             roles.push({ role: "librarian", library: library });
           }
-          this.setState(Object.assign({}, this.state, { admin: new Admin(roles) }));
+          this.setState(
+            Object.assign({}, this.state, { admin: new Admin(roles) })
+          );
         }
       } else {
         // Add the manager role for the library, and remove the librarian role if it was
         // there.
-        const roles = this.state.admin.roles.filter(stateRole => stateRole.library !== library);
+        const roles = this.state.admin.roles.filter(
+          (stateRole) => stateRole.library !== library
+        );
         roles.push({ role: "manager", library: library });
-        this.setState(Object.assign({}, this.state, { admin: new Admin(roles) }));
+        this.setState(
+          Object.assign({}, this.state, { admin: new Admin(roles) })
+        );
       }
     } else if (role === "librarian") {
       if (this.isSelected(role, library)) {
@@ -330,31 +369,44 @@ export default class IndividualAdminEditForm extends React.Component<IndividualA
         // selected. If any 'all' roles were selected, remove them and add roles for
         // individual libraries.
         if (this.isSelected("librarian-all")) {
-           if (this.isSelected("manager-all")) {
-             const roles = [];
-             for (const l of this.props.data.allLibraries || []) {
-               if (l.short_name !== library) {
-                 roles.push({ role: "manager", library: l.short_name });
-               }
-             }
-             this.setState(Object.assign({}, this.state, { admin: new Admin(roles) }));
-           } else if (this.isSelected("librarian-all")) {
-             const roles = this.state.admin.roles.filter(stateRole => (stateRole.role === "manager" && stateRole.library !== library));
-             for (const l of this.props.data.allLibraries || []) {
-               if (l.short_name !== library) {
-                 roles.push({ role: "librarian", library: l.short_name });
-               }
-             }
-             this.setState(Object.assign({}, this.state, { admin: new Admin(roles) }));
-           }
+          if (this.isSelected("manager-all")) {
+            const roles = [];
+            for (const l of this.props.data.allLibraries || []) {
+              if (l.short_name !== library) {
+                roles.push({ role: "manager", library: l.short_name });
+              }
+            }
+            this.setState(
+              Object.assign({}, this.state, { admin: new Admin(roles) })
+            );
+          } else if (this.isSelected("librarian-all")) {
+            const roles = this.state.admin.roles.filter(
+              (stateRole) =>
+                stateRole.role === "manager" && stateRole.library !== library
+            );
+            for (const l of this.props.data.allLibraries || []) {
+              if (l.short_name !== library) {
+                roles.push({ role: "librarian", library: l.short_name });
+              }
+            }
+            this.setState(
+              Object.assign({}, this.state, { admin: new Admin(roles) })
+            );
+          }
         } else {
-          const roles = this.state.admin.roles.filter(stateRole => stateRole.library !== library);
-          this.setState(Object.assign({}, this.state, { admin: new Admin(roles) }));
+          const roles = this.state.admin.roles.filter(
+            (stateRole) => stateRole.library !== library
+          );
+          this.setState(
+            Object.assign({}, this.state, { admin: new Admin(roles) })
+          );
         }
       } else {
-          const roles = this.state.admin.roles;
-          roles.push({ role, library });
-          this.setState(Object.assign({}, this.state, { admin: new Admin(roles) }));
+        const roles = this.state.admin.roles;
+        roles.push({ role, library });
+        this.setState(
+          Object.assign({}, this.state, { admin: new Admin(roles) })
+        );
       }
     }
   }
@@ -370,8 +422,7 @@ export default class IndividualAdminEditForm extends React.Component<IndividualA
   }
 
   async submit(data: FormData) {
-    let modifiedData = this.handleData(data);
+    const modifiedData = this.handleData(data);
     await this.props.save(modifiedData);
   }
-
 }

--- a/src/components/IndividualAdmins.tsx
+++ b/src/components/IndividualAdmins.tsx
@@ -44,11 +44,10 @@ export class IndividualAdmins extends EditableConfigList<
     return { h2, h3 };
   }
 
-  getSetUpClassName() {
+  getClassName() {
     const className = this.props.settingUp ? "set-up" : "";
     return className;
   }
-
   save(data: FormData) {
     this.editItem(data).then(() => {
       // If we're setting up an admin for the first time, refresh the page

--- a/src/components/IndividualAdmins.tsx
+++ b/src/components/IndividualAdmins.tsx
@@ -1,6 +1,10 @@
 import * as React from "react";
 import * as PropTypes from "prop-types";
-import EditableConfigList, { EditableConfigListStateProps, EditableConfigListDispatchProps, EditableConfigListOwnProps } from "./EditableConfigList";
+import EditableConfigList, {
+  EditableConfigListStateProps,
+  EditableConfigListDispatchProps,
+  EditableConfigListOwnProps,
+} from "./EditableConfigList";
 import { connect } from "react-redux";
 import ActionCreator from "../actions";
 import { IndividualAdminsData, IndividualAdminData } from "../interfaces";
@@ -10,7 +14,10 @@ import IndividualAdminEditForm from "./IndividualAdminEditForm";
 /** Right panel for individual admin configuration on the system configuration page.
     Shows a list of current individual admins and allows create a new admin or
     editing or deleting an existing admin. */
-export class IndividualAdmins extends EditableConfigList<IndividualAdminsData, IndividualAdminData> {
+export class IndividualAdmins extends EditableConfigList<
+  IndividualAdminsData,
+  IndividualAdminData
+> {
   EditForm = IndividualAdminEditForm;
   listDataKey = "individualAdmins";
   itemTypeName = "individual admin";
@@ -20,7 +27,7 @@ export class IndividualAdmins extends EditableConfigList<IndividualAdminsData, I
 
   context: { admin: Admin };
   static contextTypes = {
-    admin: PropTypes.object.isRequired
+    admin: PropTypes.object.isRequired,
   };
 
   canDelete() {
@@ -28,13 +35,17 @@ export class IndividualAdmins extends EditableConfigList<IndividualAdminsData, I
   }
 
   getHeaders() {
-    let h2 = this.props.settingUp ? "Welcome!" : "Individual admin configuration";
-    let h3 = this.props.settingUp ? "Set up your system admin account" : "Create a new individual admin";
+    const h2 = this.props.settingUp
+      ? "Welcome!"
+      : "Individual admin configuration";
+    const h3 = this.props.settingUp
+      ? "Set up your system admin account"
+      : "Create a new individual admin";
     return { h2, h3 };
   }
 
-  getClassName() {
-    let className = this.props.settingUp ? "set-up" : "";
+  getSetUpClassName() {
+    const className = this.props.settingUp ? "set-up" : "";
     return className;
   }
 
@@ -43,15 +54,18 @@ export class IndividualAdmins extends EditableConfigList<IndividualAdminsData, I
       // If we're setting up an admin for the first time, refresh the page
       // to go to login.
       if (this.props.settingUp) {
-       window.location.reload();
-       return;
-     }
+        window.location.reload();
+        return;
+      }
     });
   }
 }
 
 function mapStateToProps(state, ownProps) {
-  const data = Object.assign({}, state.editor.individualAdmins && state.editor.individualAdmins.data || {});
+  const data = Object.assign(
+    {},
+    (state.editor.individualAdmins && state.editor.individualAdmins.data) || {}
+  );
   if (state.editor.libraries && state.editor.libraries.data) {
     data.allLibraries = state.editor.libraries.data.libraries;
   }
@@ -59,23 +73,32 @@ function mapStateToProps(state, ownProps) {
   // create/edit form.
   return {
     data: data,
-    responseBody: state.editor.individualAdmins && state.editor.individualAdmins.successMessage,
+    responseBody:
+      state.editor.individualAdmins &&
+      state.editor.individualAdmins.successMessage,
     fetchError: state.editor.individualAdmins.fetchError,
     formError: state.editor.individualAdmins.formError,
-    isFetching: state.editor.individualAdmins.isFetching || state.editor.individualAdmins.isEditing
+    isFetching:
+      state.editor.individualAdmins.isFetching ||
+      state.editor.individualAdmins.isEditing,
   };
 }
 
 function mapDispatchToProps(dispatch, ownProps) {
-  let actions = new ActionCreator(null, ownProps.csrfToken);
+  const actions = new ActionCreator(null, ownProps.csrfToken);
   return {
     fetchData: () => dispatch(actions.fetchIndividualAdmins()),
     editItem: (data: FormData) => dispatch(actions.editIndividualAdmin(data)),
-    deleteItem: (identifier: string | number) => dispatch(actions.deleteIndividualAdmin(identifier)),
+    deleteItem: (identifier: string | number) =>
+      dispatch(actions.deleteIndividualAdmin(identifier)),
   };
 }
 
-const ConnectedIndividualAdmins = connect<EditableConfigListStateProps<IndividualAdminsData>, EditableConfigListDispatchProps<IndividualAdminsData>, EditableConfigListOwnProps>(
+const ConnectedIndividualAdmins = connect<
+  EditableConfigListStateProps<IndividualAdminsData>,
+  EditableConfigListDispatchProps<IndividualAdminsData>,
+  EditableConfigListOwnProps
+>(
   mapStateToProps,
   mapDispatchToProps
 )(IndividualAdmins);

--- a/src/components/IndividualAdmins.tsx
+++ b/src/components/IndividualAdmins.tsx
@@ -44,10 +44,11 @@ export class IndividualAdmins extends EditableConfigList<
     return { h2, h3 };
   }
 
-  getClassName() {
+  getClassName(): string {
     const className = this.props.settingUp ? "set-up" : "";
     return className;
   }
+
   save(data: FormData) {
     this.editItem(data).then(() => {
       // If we're setting up an admin for the first time, refresh the page

--- a/src/components/InputList.tsx
+++ b/src/components/InputList.tsx
@@ -57,7 +57,7 @@ export default class InputList extends React.Component<
     this.capitalize = this.capitalize.bind(this);
   }
 
-  componentWillReceiveProps(newProps: InputListProps) {
+  UNSAFE_componentWillReceiveProps(newProps: InputListProps) {
     // Update the list of existing items with value from new props
     if (
       this.state.listItems &&

--- a/src/components/Lane.tsx
+++ b/src/components/Lane.tsx
@@ -15,7 +15,10 @@ export interface LaneProps {
   snapshot?: any;
   provided?: any;
   orderChanged: boolean;
-  toggleLaneVisibility: (lane: LaneData, shouldBeVisible: boolean) => Promise<void>;
+  toggleLaneVisibility: (
+    lane: LaneData,
+    shouldBeVisible: boolean
+  ) => Promise<void>;
   parent?: LaneData;
   library: string;
   renderLanes: (lanes: LaneData[], parent: LaneData | null) => JSX.Element;
@@ -31,7 +34,10 @@ export default class Lane extends React.Component<LaneProps, LaneState> {
   constructor(props: LaneProps) {
     super(props);
     // Top-level lanes start out expanded.
-    this.state = { expanded: !this.props.parent, visible: this.props.lane.visible };
+    this.state = {
+      expanded: !this.props.parent,
+      visible: this.props.lane.visible,
+    };
     this.toggleExpanded = this.toggleExpanded.bind(this);
     this.toggleVisible = this.toggleVisible.bind(this);
     this.renderVisibilityToggle = this.renderVisibilityToggle.bind(this);
@@ -39,9 +45,10 @@ export default class Lane extends React.Component<LaneProps, LaneState> {
   }
 
   render(): JSX.Element {
-    let { lane, active, snapshot, provided, renderLanes } = this.props;
-    let hasSublanes = lane.sublanes && !!lane.sublanes.length;
-    let hasCustomLists = lane.custom_list_ids && !!lane.custom_list_ids.length;
+    const { lane, active, snapshot, provided, renderLanes } = this.props;
+    const hasSublanes = lane.sublanes && !!lane.sublanes.length;
+    const hasCustomLists =
+      lane.custom_list_ids && !!lane.custom_list_ids.length;
     return (
       <li key={lane.id}>
         <div
@@ -56,37 +63,44 @@ export default class Lane extends React.Component<LaneProps, LaneState> {
         >
           <div className={"lane-info" + (provided ? " draggable" : "")}>
             <span>
-              { snapshot && <GrabIcon /> }
+              {snapshot && <GrabIcon />}
               <Button
-                className={`transparent ${this.state.expanded ? "collapse-button" :  "expand-button"}`}
+                className={`transparent ${
+                  this.state.expanded ? "collapse-button" : "expand-button"
+                }`}
                 type="button"
                 callback={this.toggleExpanded}
                 aria-label={`Button to expand or collapse a lane`}
                 content={<PyramidIcon />}
               />
-              { lane.display_name + " (" + lane.count + ")" }
+              {lane.display_name + " (" + lane.count + ")"}
             </span>
-            { this.renderVisibilityToggle() }
+            {this.renderVisibilityToggle()}
           </div>
-          { this.state.expanded &&
+          {this.state.expanded && (
             <div className="lane-buttons">
-            { hasCustomLists && this.renderButton("edit") }
-            { this.renderButton("create") }
+              {hasCustomLists && this.renderButton("edit")}
+              {this.renderButton("create")}
             </div>
-          }
-          { this.state.expanded && hasSublanes && renderLanes(lane.sublanes, lane) }
+          )}
+          {this.state.expanded &&
+            hasSublanes &&
+            renderLanes(lane.sublanes, lane)}
         </div>
-        { provided && provided.placeholder }
+        {provided && provided.placeholder}
       </li>
     );
   }
 
-  componentWillReceiveProps(newProps) {
-    this.setState({ expanded: this.state.expanded, visible: newProps.lane.visible });
+  UNSAFE_componentWillReceiveProps(newProps) {
+    this.setState({
+      expanded: this.state.expanded,
+      visible: newProps.lane.visible,
+    });
   }
 
   toggleVisible(): void {
-    const change: boolean = !this.state.visible;
+    const change = !this.state.visible;
     this.props.toggleLaneVisibility(this.props.lane, change);
     this.setState({ expanded: this.state.expanded, visible: change });
   }
@@ -96,31 +110,62 @@ export default class Lane extends React.Component<LaneProps, LaneState> {
     const parentHidden = this.props.parent && !this.props.parent.visible;
     const canToggle = !this.props.orderChanged && !parentHidden;
     const className = this.state.visible ? "hide-lane" : "show-lane";
-    const buttonContent = this.state.visible ? <span>Visible<VisibleIcon/></span> : <span>Hidden<HiddenIcon/></span>;
-    return <Button
-      className={"small transparent top-align bottom-align " + className}
-      disabled={!canToggle}
-      callback={this.toggleVisible}
-      content={buttonContent}
-    />;
+    const buttonContent = this.state.visible ? (
+      <span>
+        Visible
+        <VisibleIcon />
+      </span>
+    ) : (
+      <span>
+        Hidden
+        <HiddenIcon />
+      </span>
+    );
+    return (
+      <Button
+        className={"small transparent top-align bottom-align " + className}
+        disabled={!canToggle}
+        callback={this.toggleVisible}
+        content={buttonContent}
+      />
+    );
   }
 
   renderButton(editOrCreate: string): JSX.Element {
-    const link = this.props.orderChanged ?
-      null : `/admin/web/lanes/${this.props.library}/${editOrCreate}/${this.props.lane.id}`;
-    const content = editOrCreate === "create" ?
-      <span>Create Sublane<AddIcon /></span> : <span>Edit Lane<PencilIcon /></span>;
+    const link = this.props.orderChanged
+      ? null
+      : `/admin/web/lanes/${this.props.library}/${editOrCreate}/${this.props.lane.id}`;
+    const content =
+      editOrCreate === "create" ? (
+        <span>
+          Create Sublane
+          <AddIcon />
+        </span>
+      ) : (
+        <span>
+          Edit Lane
+          <PencilIcon />
+        </span>
+      );
 
-    let button = (
+    const button = (
       <Link
-        className={`btn small right-align ${editOrCreate}-lane ` + (this.props.orderChanged ? "disabled" : "")}
+        className={
+          `btn small right-align ${editOrCreate}-lane ` +
+          (this.props.orderChanged ? "disabled" : "")
+        }
         to={link}
-      >{content}</Link>
+      >
+        {content}
+      </Link>
     );
     return button;
   }
 
   toggleExpanded(): void {
-    this.setState({ expanded: !this.state.expanded, visible: this.state.visible });
+    this.setState({
+      expanded: !this.state.expanded,
+      visible: this.state.visible,
+    });
   }
 }

--- a/src/components/LaneEditor.tsx
+++ b/src/components/LaneEditor.tsx
@@ -16,7 +16,10 @@ export interface LaneEditorProps extends React.Props<LaneEditor> {
   responseBody?: string;
   editLane: (data: FormData) => Promise<void>;
   deleteLane?: (lane: LaneData) => Promise<void>;
-  toggleLaneVisibility: (lane: LaneData, shouldBeVisible: boolean) => Promise<void>;
+  toggleLaneVisibility: (
+    lane: LaneData,
+    shouldBeVisible: boolean
+  ) => Promise<void>;
   findParentOfLane: (lane: LaneData) => LaneData | null;
 }
 
@@ -27,19 +30,25 @@ export interface LaneEditorState {
 }
 
 /** Right panel of the lanes page for editing a single lane. */
-export default class LaneEditor extends React.Component<LaneEditorProps, LaneEditorState> {
+export default class LaneEditor extends React.Component<
+  LaneEditorProps,
+  LaneEditorState
+> {
   private laneNameRef = React.createRef<TextWithEditMode>();
   private laneCustomListsRef = React.createRef<LaneCustomListsEditor>();
   constructor(props) {
     super(props);
     this.state = {
       name: this.props.lane && this.props.lane.display_name,
-      customListIds: this.props.lane && this.props.lane.custom_list_ids || [],
-      inheritParentRestrictions: this.props.lane && this.props.lane.inherit_parent_restrictions
+      customListIds: (this.props.lane && this.props.lane.custom_list_ids) || [],
+      inheritParentRestrictions:
+        this.props.lane && this.props.lane.inherit_parent_restrictions,
     };
     this.changeName = this.changeName.bind(this);
     this.changeCustomLists = this.changeCustomLists.bind(this);
-    this.changeInheritParentRestrictions = this.changeInheritParentRestrictions.bind(this);
+    this.changeInheritParentRestrictions = this.changeInheritParentRestrictions.bind(
+      this
+    );
     this.delete = this.delete.bind(this);
     this.save = this.save.bind(this);
     this.reset = this.reset.bind(this);
@@ -48,7 +57,7 @@ export default class LaneEditor extends React.Component<LaneEditorProps, LaneEdi
   }
 
   render(): JSX.Element {
-    let parent = this.props.findParentOfLane(this.props.lane);
+    const parent = this.props.findParentOfLane(this.props.lane);
     return (
       <div className="lane-editor">
         <div className="lane-editor-header">
@@ -61,44 +70,46 @@ export default class LaneEditor extends React.Component<LaneEditorProps, LaneEdi
                 ref={this.laneNameRef}
                 aria-label="Enter a name for this lane"
               />
-              { this.props.lane &&
-                <h4>ID-{this.props.lane.id}</h4>
-              }
+              {this.props.lane && <h4>ID-{this.props.lane.id}</h4>}
             </div>
             <span className="lane-buttons">
-              { this.props.lane && this.props.deleteLane &&
+              {this.props.lane && this.props.deleteLane && (
                 <Button
                   className="danger delete-lane"
                   callback={this.delete}
-                  content={<span>Delete lane <TrashIcon /></span>}
+                  content={
+                    <span>
+                      Delete lane <TrashIcon />
+                    </span>
+                  }
                 />
-              }
-              { this.visibilityToggle() }
+              )}
+              {this.visibilityToggle()}
               <Button
                 className="save-lane"
                 callback={this.save}
                 content="Save lane"
               />
-              { this.hasChanges() &&
+              {this.hasChanges() && (
                 <Button
                   className="cancel-changes inverted"
                   callback={this.reset}
                   content="Cancel changes"
                 />
-              }
+              )}
             </span>
           </div>
           <div className="lane-details">
             {this.renderInfo(parent)}
-            { parent &&
+            {parent && (
               <EditableInput
                 type="checkbox"
                 name="inherit_parent_restrictions"
                 checked={this.state.inheritParentRestrictions}
                 label="Inherit restrictions from parent lane"
                 onChange={this.changeInheritParentRestrictions}
-                />
-            }
+              />
+            )}
           </div>
         </div>
         <div className="lane-editor-body">
@@ -107,47 +118,67 @@ export default class LaneEditor extends React.Component<LaneEditorProps, LaneEdi
             customListIds={this.state.customListIds}
             onUpdate={this.changeCustomLists}
             ref={this.laneCustomListsRef}
-            />
+          />
         </div>
       </div>
     );
   }
 
   renderInfo(parent?: LaneData): JSX.Element {
-    let isVisible = (lane: LaneData) => lane.visible;
+    const isVisible = (lane: LaneData) => lane.visible;
 
     if (this.props.lane) {
       let visibility;
       if (isVisible(this.props.lane)) {
-        visibility = <div>This lane is currently visible. <VisibleIcon /></div>;
+        visibility = (
+          <div>
+            This lane is currently visible. <VisibleIcon />
+          </div>
+        );
       } else if (parent && !isVisible(parent)) {
-        visibility = <div>This lane's parent is currently hidden. <HiddenIcon /></div>;
+        visibility = (
+          <div>
+            This lane's parent is currently hidden. <HiddenIcon />
+          </div>
+        );
       } else {
-        visibility = <div>This lane is currently hidden. <HiddenIcon /></div>;
+        visibility = (
+          <div>
+            This lane is currently hidden. <HiddenIcon />
+          </div>
+        );
       }
       return visibility;
     } else {
-      let laneLevel = parent ? `sublane of ${parent.display_name}` : "top-level lane";
+      const laneLevel = parent
+        ? `sublane of ${parent.display_name}`
+        : "top-level lane";
       return <div>New {laneLevel}</div>;
     }
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     this.setState({
       name: nextProps.lane && nextProps.lane.display_name,
-      customListIds: nextProps.lane && nextProps.lane.custom_list_ids || [],
-      inheritParentRestrictions: nextProps.lane && nextProps.lane.inherit_parent_restrictions
+      customListIds: (nextProps.lane && nextProps.lane.custom_list_ids) || [],
+      inheritParentRestrictions:
+        nextProps.lane && nextProps.lane.inherit_parent_restrictions,
     });
   }
 
   hasChanges(): boolean {
-    const nameChanged = (this.props.lane && this.props.lane.display_name !== this.state.name);
+    const nameChanged =
+      this.props.lane && this.props.lane.display_name !== this.state.name;
     let listsChanged = false;
-    if (this.props.lane && this.props.lane.custom_list_ids.length !== this.state.customListIds.length) {
+    if (
+      this.props.lane &&
+      this.props.lane.custom_list_ids.length !== this.state.customListIds.length
+    ) {
       listsChanged = true;
     } else {
-      let propsListIds = this.props.lane && this.props.lane.custom_list_ids.sort() || [];
-      let stateListIds = this.state.customListIds.sort();
+      const propsListIds =
+        (this.props.lane && this.props.lane.custom_list_ids.sort()) || [];
+      const stateListIds = this.state.customListIds.sort();
       for (let i = 0; i < propsListIds.length; i++) {
         if (propsListIds[i] !== stateListIds[i]) {
           listsChanged = true;
@@ -156,7 +187,11 @@ export default class LaneEditor extends React.Component<LaneEditorProps, LaneEdi
       }
     }
     let inheritParentRestrictionsChanged = false;
-    if (this.props.lane && this.props.lane.inherit_parent_restrictions !== this.state.inheritParentRestrictions) {
+    if (
+      this.props.lane &&
+      this.props.lane.inherit_parent_restrictions !==
+        this.state.inheritParentRestrictions
+    ) {
       inheritParentRestrictionsChanged = true;
     }
     return nameChanged || listsChanged || inheritParentRestrictionsChanged;
@@ -171,7 +206,7 @@ export default class LaneEditor extends React.Component<LaneEditorProps, LaneEdi
   }
 
   changeInheritParentRestrictions() {
-    let inheritParentRestrictions = !this.state.inheritParentRestrictions;
+    const inheritParentRestrictions = !this.state.inheritParentRestrictions;
     this.setState(Object.assign({}, this.state, { inheritParentRestrictions }));
   }
 
@@ -185,19 +220,27 @@ export default class LaneEditor extends React.Component<LaneEditorProps, LaneEdi
     // The lane's visibility cannot be changed if it has a hidden parent.  In all other cases--i.e.
     // if 1) the lane does not have a parent or 2) the lane has a parent which is visible--we render
     // the hide/show button.
-    let parent = this.props.findParentOfLane(this.props.lane);
-    let canToggle = this.props.lane && (!parent || (parent && parent.visible));
+    const parent = this.props.findParentOfLane(this.props.lane);
+    const canToggle =
+      this.props.lane && (!parent || (parent && parent.visible));
     if (canToggle) {
-      return (<Button
-                className={this.props.lane.visible ? "hide-lane" : "show-lane"}
-                content={`${this.props.lane.visible ? "Hide" : "Show"} lane`}
-                callback={() => this.props.toggleLaneVisibility(this.props.lane, !this.props.lane.visible)}
-             />);
+      return (
+        <Button
+          className={this.props.lane.visible ? "hide-lane" : "show-lane"}
+          content={`${this.props.lane.visible ? "Hide" : "Show"} lane`}
+          callback={() =>
+            this.props.toggleLaneVisibility(
+              this.props.lane,
+              !this.props.lane.visible
+            )
+          }
+        />
+      );
     }
   }
 
   save() {
-    let parent = this.props.findParentOfLane(this.props.lane);
+    const parent = this.props.findParentOfLane(this.props.lane);
     const data = new (window as any).FormData();
     if (this.props.lane) {
       data.append("id", this.props.lane.id);
@@ -205,15 +248,22 @@ export default class LaneEditor extends React.Component<LaneEditorProps, LaneEdi
     if (parent) {
       data.append("parent_id", parent.id);
     }
-    let name = this.laneNameRef.current.getText();
+    const name = this.laneNameRef.current.getText();
     data.append("display_name", name);
-    let listIds = this.laneCustomListsRef.current.getCustomListIds();
+    const listIds = this.laneCustomListsRef.current.getCustomListIds();
     data.append("custom_list_ids", JSON.stringify(listIds));
-    data.append("inherit_parent_restrictions", this.state.inheritParentRestrictions);
+    data.append(
+      "inherit_parent_restrictions",
+      this.state.inheritParentRestrictions
+    );
     this.props.editLane(data).then(() => {
       // If a new lane was created, go to its edit page.
       if (!this.props.lane && this.props.responseBody) {
-        window.location.href = "/admin/web/lanes/" + this.props.library + "/edit/" + this.props.responseBody;
+        window.location.href =
+          "/admin/web/lanes/" +
+          this.props.library +
+          "/edit/" +
+          this.props.responseBody;
       }
     });
   }
@@ -221,7 +271,8 @@ export default class LaneEditor extends React.Component<LaneEditorProps, LaneEdi
   reset() {
     this.laneNameRef.current.reset();
     this.laneCustomListsRef.current.reset(this.props.lane.custom_list_ids);
-    let inheritParentRestrictions = this.props.lane && this.props.lane.inherit_parent_restrictions;
+    const inheritParentRestrictions =
+      this.props.lane && this.props.lane.inherit_parent_restrictions;
     this.setState(Object.assign({}, this.state, { inheritParentRestrictions }));
   }
 }

--- a/src/components/Lanes.tsx
+++ b/src/components/Lanes.tsx
@@ -240,7 +240,7 @@ export class Lanes extends React.Component<LanesProps, LanesState> {
     );
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.lanes && !this.props.lanes) {
       const lanes = this.copyLanes(nextProps.lanes);
       this.setState({
@@ -252,7 +252,7 @@ export class Lanes extends React.Component<LanesProps, LanesState> {
     }
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     if (this.props.fetchLanes) {
       this.props.fetchLanes();
     }

--- a/src/components/Libraries.tsx
+++ b/src/components/Libraries.tsx
@@ -1,5 +1,10 @@
 import * as React from "react";
-import { GenericEditableConfigList, EditableConfigListStateProps, EditableConfigListDispatchProps, EditableConfigListOwnProps } from "./EditableConfigList";
+import {
+  GenericEditableConfigList,
+  EditableConfigListStateProps,
+  EditableConfigListDispatchProps,
+  EditableConfigListOwnProps,
+} from "./EditableConfigList";
 import { connect } from "react-redux";
 import * as PropTypes from "prop-types";
 import ActionCreator from "../actions";
@@ -11,17 +16,26 @@ import LibraryEditForm from "./LibraryEditForm";
     Shows a list of current libraries and allows creating a new library or
     editing or deleting an existing library. */
 
-export interface LibrariesStateProps extends EditableConfigListStateProps<LibrariesData> {
+export interface LibrariesStateProps
+  extends EditableConfigListStateProps<LibrariesData> {
   additionalData?: LanguagesData;
 }
 
-export interface LibrariesDispatchProps extends EditableConfigListDispatchProps<LibrariesData> {
+export interface LibrariesDispatchProps
+  extends EditableConfigListDispatchProps<LibrariesData> {
   fetchLanguages: () => void;
 }
 
-export interface LibrariesProps extends LibrariesStateProps, LibrariesDispatchProps, EditableConfigListOwnProps {}
+export interface LibrariesProps
+  extends LibrariesStateProps,
+    LibrariesDispatchProps,
+    EditableConfigListOwnProps {}
 
-export class Libraries extends GenericEditableConfigList<LibrariesData, LibraryData, LibrariesProps> {
+export class Libraries extends GenericEditableConfigList<
+  LibrariesData,
+  LibraryData,
+  LibrariesProps
+> {
   EditForm = LibraryEditForm;
   listDataKey = "libraries";
   itemTypeName = "library";
@@ -31,11 +45,11 @@ export class Libraries extends GenericEditableConfigList<LibrariesData, LibraryD
 
   context: { admin: Admin };
   static contextTypes = {
-    admin: PropTypes.object.isRequired
+    admin: PropTypes.object.isRequired,
   };
 
-  componentWillMount() {
-    super.componentWillMount();
+  UNSAFE_componentWillMount() {
+    super.UNSAFE_componentWillMount();
     this.props.fetchLanguages();
   }
 
@@ -57,25 +71,32 @@ function mapStateToProps(state, ownProps) {
   // create/edit form.
   return {
     data: state.editor.libraries && state.editor.libraries.data,
-    responseBody: state.editor.libraries && state.editor.libraries.successMessage,
+    responseBody:
+      state.editor.libraries && state.editor.libraries.successMessage,
     fetchError: state.editor.libraries.fetchError,
     formError: state.editor.libraries.formError,
-    isFetching: state.editor.libraries.isFetching || state.editor.libraries.isEditing,
-    additionalData: state.editor.languages && state.editor.languages.data
+    isFetching:
+      state.editor.libraries.isFetching || state.editor.libraries.isEditing,
+    additionalData: state.editor.languages && state.editor.languages.data,
   };
 }
 
 function mapDispatchToProps(dispatch, ownProps) {
-  let actions = new ActionCreator(null, ownProps.csrfToken);
+  const actions = new ActionCreator(null, ownProps.csrfToken);
   return {
     fetchData: () => dispatch(actions.fetchLibraries()),
     editItem: (data: FormData) => dispatch(actions.editLibrary(data)),
-    deleteItem: (identifier: string | number) => dispatch(actions.deleteLibrary(identifier)),
-    fetchLanguages: () => dispatch(actions.fetchLanguages())
+    deleteItem: (identifier: string | number) =>
+      dispatch(actions.deleteLibrary(identifier)),
+    fetchLanguages: () => dispatch(actions.fetchLanguages()),
   };
 }
 
-const ConnectedLibraries = connect<EditableConfigListStateProps<LibrariesData>, EditableConfigListDispatchProps<LibrariesData>, EditableConfigListOwnProps>(
+const ConnectedLibraries = connect<
+  EditableConfigListStateProps<LibrariesData>,
+  EditableConfigListDispatchProps<LibrariesData>,
+  EditableConfigListOwnProps
+>(
   mapStateToProps,
   mapDispatchToProps
 )(Libraries);

--- a/src/components/LibraryEditForm.tsx
+++ b/src/components/LibraryEditForm.tsx
@@ -2,7 +2,13 @@ import * as React from "react";
 import EditableInput from "./EditableInput";
 import ProtocolFormField from "./ProtocolFormField";
 import { findDefault, clearForm } from "../utils/sharedFunctions";
-import { LibrariesData, LibraryData, LibrarySettingField, SettingData, AnnouncementData } from "../interfaces";
+import {
+  LibrariesData,
+  LibraryData,
+  LibrarySettingField,
+  SettingData,
+  AnnouncementData,
+} from "../interfaces";
 import { Panel, Form } from "library-simplified-reusable-components";
 import { FetchErrorData } from "opds-web-client/lib/interfaces";
 import PairedMenus from "./PairedMenus";
@@ -23,7 +29,10 @@ export interface LibraryEditFormProps {
 
 /** Form for editing a library's configuration, on the libraries tab of the
     system configuration page. */
-export default class LibraryEditForm extends React.Component<LibraryEditFormProps, {}> {
+export default class LibraryEditForm extends React.Component<
+  LibraryEditFormProps,
+  {}
+> {
   private nameRef = React.createRef<EditableInput>();
   private shortNameRef = React.createRef<EditableInput>();
   private settingRef = React.createRef<ProtocolFormField>();
@@ -33,13 +42,13 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
     this.submit = this.submit.bind(this);
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.responseBody && !nextProps.fetchError) {
       clearForm([
         this.nameRef.current,
         this.shortNameRef.current,
         this.settingRef.current,
-        this.announcementsRef.current
+        this.announcementsRef.current,
       ]);
     }
   }
@@ -48,7 +57,7 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
     // The server has assigned each setting a level from 1 to 3, indicating what level of permissions
     // the admin needs to have in order to be able to modify the item.  If the server has left the level blank,
     // the setting will be treated as if it is level 1 (editable by all admins).
-    return (setting.level && (setting.level > this.props.adminLevel));
+    return setting.level && setting.level > this.props.adminLevel;
   }
 
   render(): JSX.Element {
@@ -56,13 +65,18 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
     let otherFields = [];
 
     if (this.props.data && this.props.data.settings) {
-      basicInfo = this.props.data.settings.filter(setting => (setting.required || setting.category === "Basic Information"));
-      otherFields = this.props.data.settings.filter(setting => !(new Set(basicInfo).has(setting)));
+      basicInfo = this.props.data.settings.filter(
+        (setting) =>
+          setting.required || setting.category === "Basic Information"
+      );
+      otherFields = this.props.data.settings.filter(
+        (setting) => !new Set(basicInfo).has(setting)
+      );
     }
 
-    let categories = this.separateCategories(otherFields);
+    const categories = this.separateCategories(otherFields);
     const requiresSystemAdmin = 3;
-    let ref = (setting) => {
+    const ref = (setting) => {
       if (setting.key === "name") {
         return this.nameRef;
       } else if (setting.key === "short name") {
@@ -71,7 +85,7 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
         return this.settingRef;
       }
     };
-    let basicInfoPanel = (
+    const basicInfoPanel = (
       <Panel
         id="library-basic-info"
         headerText="Basic Information"
@@ -79,23 +93,27 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
         openByDefault={true}
         content={
           <fieldset>
-          <legend className="visuallyHidden">Basic Information</legend>
-          { basicInfo.map(setting =>
-            <ProtocolFormField
-              key={setting.key}
-              ref={ref(setting) as any}
-              setting={setting}
-              disabled={this.props.disabled}
-              value={this.props.item && this.props.item[setting.key] || this.props.item?.settings && this.props.item.settings[setting.key]}
-              default={findDefault(setting)}
-              error={this.props.error}
-              readOnly={this.adminNotAuthorized(setting)}
-            />
-          )
+            <legend className="visuallyHidden">Basic Information</legend>
+            {basicInfo.map((setting) => (
+              <ProtocolFormField
+                key={setting.key}
+                ref={ref(setting) as any}
+                setting={setting}
+                disabled={this.props.disabled}
+                value={
+                  (this.props.item && this.props.item[setting.key]) ||
+                  (this.props.item?.settings &&
+                    this.props.item.settings[setting.key])
+                }
+                default={findDefault(setting)}
+                error={this.props.error}
+                readOnly={this.adminNotAuthorized(setting)}
+              />
+            ))}
+          </fieldset>
         }
-        </fieldset>
-      }
-    />);
+      />
+    );
 
     return (
       <Form
@@ -105,29 +123,33 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
         disableButton={this.props.disabled}
         onSubmit={this.submit}
         content={[basicInfoPanel, this.renderForms(categories)]}
-      />);
+      />
+    );
   }
 
   separateCategories(nonRequiredFields: LibrarySettingField[]) {
-    let categories = {};
+    const categories = {};
     nonRequiredFields.forEach((setting) => {
-      categories[setting.category] = categories[setting.category] ? categories[setting.category].concat(setting) : [setting];
+      categories[setting.category] = categories[setting.category]
+        ? categories[setting.category].concat(setting)
+        : [setting];
     });
     return categories;
   }
 
-  renderForms(categories: {[key: string]: LibrarySettingField[]}) {
-    let forms = [];
-    let categoryNames = Object.keys(categories);
+  renderForms(categories: { [key: string]: LibrarySettingField[] }) {
+    const forms = [];
+    const categoryNames = Object.keys(categories);
     categoryNames.forEach((name) => {
-      let form =
+      const form = (
         <Panel
           id={`library-form-${name.replace(/\s/g, "-")}`}
           headerText={`${name} (Optional)`}
           onEnter={this.submit}
           key={name}
           content={this.renderFieldset(categories[name])}
-        />;
+        />
+      );
       forms.push(form);
     });
     return forms;
@@ -136,15 +158,15 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
   renderAnnouncements(setting: SettingData, value) {
     return (
       <AnnouncementsSection
-            setting={{...setting, ...{format: "date-range"}}}
-            value={value && JSON.parse(value)}
-            ref={this.announcementsRef}
+        setting={{ ...setting, ...{ format: "date-range" } }}
+        value={value && JSON.parse(value)}
+        ref={this.announcementsRef}
       />
     );
   }
 
   renderPairedMenus(setting: SettingData, fields: LibrarySettingField[]) {
-    let dropdownSetting = fields.find(x => x.key === setting.paired);
+    const dropdownSetting = fields.find((x) => x.key === setting.paired);
     // These dropdown settings have the :skip: attribute, so they'll get rendered only here;
     // when the iterator in renderFieldset gets to them, they'll get skipped over, not rendered a second time.
     return (
@@ -160,21 +182,21 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
   }
 
   renderFieldset(fields: SettingData[]) {
-    let formatSetting = (setting: SettingData) => {
+    const formatSetting = (setting: SettingData) => {
       if (setting.format === "narrow") {
         // We need to tell the ProtocolFormField to make an InputList with a menu that gets narrowed down.
-        return {...setting, ...{type: "menu"}};
+        return { ...setting, ...{ type: "menu" } };
       }
       return setting;
     };
-    let settingValue = (setting: SettingData) => {
+    const settingValue = (setting: SettingData) => {
       // Does the library already have a saved value for this setting?
       if (this.props.item?.settings) {
         return this.props.item.settings[setting.key];
       }
       return setting.default;
     };
-    let render = (setting) => {
+    const render = (setting) => {
       if (setting.paired) {
         return this.renderPairedMenus(setting, fields);
       } else if (setting.type === "announcements") {
@@ -190,7 +212,9 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
             value={settingValue(setting)}
             default={findDefault(setting)}
             error={this.props.error}
-            disableButton={this.adminNotAuthorized(setting) || this.props.disabled}
+            disableButton={
+              this.adminNotAuthorized(setting) || this.props.disabled
+            }
             readOnly={this.adminNotAuthorized(setting) || setting.readOnly}
           />
         );
@@ -199,17 +223,16 @@ export default class LibraryEditForm extends React.Component<LibraryEditFormProp
     return (
       <fieldset>
         <legend className="visuallyHidden">Additional Fields</legend>
-        { fields.map(setting => render(setting))}
+        {fields.map((setting) => render(setting))}
       </fieldset>
     );
   }
 
   submit(data: FormData) {
-    let announcements = this.announcementsRef.current.getValue();
-    let announcementList = [];
+    const announcements = this.announcementsRef.current.getValue();
+    const announcementList = [];
     announcements.forEach((a: AnnouncementData) => announcementList.push(a));
     data?.set("announcements", JSON.stringify(announcementList));
     this.props.save(data);
   }
-
 }

--- a/src/components/LibraryRegistrationForm.tsx
+++ b/src/components/LibraryRegistrationForm.tsx
@@ -16,25 +16,27 @@ export interface LibraryRegistrationFormProps {
   registrationData?: LibraryRegistrationData;
 }
 
-export default class LibraryRegistrationForm extends React.Component<LibraryRegistrationFormProps, LibraryRegistrationFormState> {
-
+export default class LibraryRegistrationForm extends React.Component<
+  LibraryRegistrationFormProps,
+  LibraryRegistrationFormState
+> {
   constructor(props) {
     super(props);
     this.state = { checked: this.props.checked };
     this.toggleChecked = this.toggleChecked.bind(this);
   }
 
-  componentWillReceiveProps(nextProps): void {
+  UNSAFE_componentWillReceiveProps(nextProps): void {
     this.setState({ checked: nextProps.checked });
   }
 
   render(): JSX.Element {
-    const hasTerms = this.props.registrationData && (
-      this.props.registrationData.terms_of_service_html ||
-      this.props.registrationData.terms_of_service_link ||
-      this.props.registrationData.access_problem
-    );
-    let disabled = this.props.disabled || (hasTerms && !this.state.checked);
+    const hasTerms =
+      this.props.registrationData &&
+      (this.props.registrationData.terms_of_service_html ||
+        this.props.registrationData.terms_of_service_link ||
+        this.props.registrationData.access_problem);
+    const disabled = this.props.disabled || (hasTerms && !this.state.checked);
 
     return (
       <Form
@@ -43,35 +45,47 @@ export default class LibraryRegistrationForm extends React.Component<LibraryRegi
         disableButton={disabled}
         onSubmit={() => this.props.register(this.props.library)}
         buttonContent={this.props.buttonText}
-        withoutButton={this.props.registrationData && this.props.registrationData.access_problem}
+        withoutButton={
+          this.props.registrationData &&
+          this.props.registrationData.access_problem
+        }
       />
     );
   }
 
   checkbox(library: LibraryData): JSX.Element {
-    let { access_problem, terms_of_service_html, terms_of_service_link } = this.props.registrationData;
+    const {
+      access_problem,
+      terms_of_service_html,
+      terms_of_service_link,
+    } = this.props.registrationData;
     let element;
     if (access_problem) {
       element = <p className="bg-danger">{access_problem.detail}</p>;
     } else if (terms_of_service_html) {
-      element = <p dangerouslySetInnerHTML={{__html: terms_of_service_html}}></p>;
+      element = (
+        <p dangerouslySetInnerHTML={{ __html: terms_of_service_html }}></p>
+      );
     } else {
-      element = <p>You must read the <a href={terms_of_service_link}>terms of service</a> before registering your library.</p>;
+      element = (
+        <p>
+          You must read the <a href={terms_of_service_link}>terms of service</a>{" "}
+          before registering your library.
+        </p>
+      );
     }
     return (
       <section className="registration-checkbox" key={library.uuid}>
-        { element }
-        {
-          !access_problem &&
+        {element}
+        {!access_problem && (
           <EditableInput
             elementType="input"
             type="checkbox"
             onChange={this.toggleChecked}
             checked={this.state.checked}
             label="I agree to the terms of service."
-          >
-          </EditableInput>
-        }
+          ></EditableInput>
+        )}
       </section>
     );
   }
@@ -79,5 +93,4 @@ export default class LibraryRegistrationForm extends React.Component<LibraryRegi
   toggleChecked(): void {
     this.setState({ checked: !this.state.checked });
   }
-
 }

--- a/src/components/SelfTests.tsx
+++ b/src/components/SelfTests.tsx
@@ -62,7 +62,7 @@ export class SelfTests extends React.Component<SelfTestsProps, SelfTestsState> {
     this.props.getSelfTests();
   }
 
-  componentWillReceiveProps(nextProps: SelfTestsProps) {
+  UNSAFE_componentWillReceiveProps(nextProps: SelfTestsProps) {
     const newTime =
       nextProps.item &&
       nextProps.item.self_test_results &&

--- a/src/components/SelfTestsTabContainer.tsx
+++ b/src/components/SelfTestsTabContainer.tsx
@@ -58,7 +58,7 @@ export class SelfTestsTabContainer extends TabContainer<
     metadataServices: "Metadata Services",
   };
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.props.fetchItems();
   }
 

--- a/src/components/ServiceEditForm.tsx
+++ b/src/components/ServiceEditForm.tsx
@@ -4,7 +4,14 @@ import ProtocolFormField from "./ProtocolFormField";
 import { Panel, Button, Form } from "library-simplified-reusable-components";
 import WithEditButton from "./WithEditButton";
 import WithRemoveButton from "./WithRemoveButton";
-import { LibraryData, LibraryWithSettingsData, ProtocolData, ServiceData, ServicesData, SettingData } from "../interfaces";
+import {
+  LibraryData,
+  LibraryWithSettingsData,
+  ProtocolData,
+  ServiceData,
+  ServicesData,
+  SettingData,
+} from "../interfaces";
 import { clearForm } from "../utils/sharedFunctions";
 import { FetchErrorData } from "opds-web-client/lib/interfaces";
 
@@ -33,7 +40,9 @@ export interface ServiceEditFormState {
 
 /** Form for editing service configuration based on protocol information from the server.
     Used on most tabs on the system configuration page. */
-export default class ServiceEditForm<T extends ServicesData> extends React.Component<ServiceEditFormProps<T>, ServiceEditFormState> {
+export default class ServiceEditForm<
+  T extends ServicesData
+> extends React.Component<ServiceEditFormProps<T>, ServiceEditFormState> {
   private extraForm = React.createRef();
   constructor(props) {
     super(props);
@@ -42,12 +51,17 @@ export default class ServiceEditForm<T extends ServicesData> extends React.Compo
       defaultProtocol = this.availableProtocols()[0].name;
     }
     this.state = {
-      protocol: (this.props.item && this.props.item.protocol) || defaultProtocol,
-      parentId: (this.props.item && this.props.item.parent_id && String(this.props.item.parent_id)) || null,
+      protocol:
+        (this.props.item && this.props.item.protocol) || defaultProtocol,
+      parentId:
+        (this.props.item &&
+          this.props.item.parent_id &&
+          String(this.props.item.parent_id)) ||
+        null,
       libraries: (this.props.item && this.props.item.libraries) || [],
       expandedLibraries: [],
       selectedLibrary: null,
-      analyticsOption: null
+      analyticsOption: null,
     };
     this.handleProtocolChange = this.handleProtocolChange.bind(this);
     this.handleParentChange = this.handleParentChange.bind(this);
@@ -63,52 +77,77 @@ export default class ServiceEditForm<T extends ServicesData> extends React.Compo
     this.renderLibrariesForm = this.renderLibrariesForm.bind(this);
   }
 
-  componentWillReceiveProps(newProps) {
+  UNSAFE_componentWillReceiveProps(newProps) {
     let protocol = this.state.protocol;
     let parentId = this.state.parentId;
     let libraries = this.state.libraries;
     if (newProps.item && newProps.item.protocol) {
-      if (!this.props.item || !this.props.item.protocol || (this.props.item.protocol !== newProps.item.protocol)) {
+      if (
+        !this.props.item ||
+        !this.props.item.protocol ||
+        this.props.item.protocol !== newProps.item.protocol
+      ) {
         protocol = newProps.item.protocol;
       }
     }
     if (!protocol && this.availableProtocols(newProps).length > 0) {
-        protocol = this.availableProtocols(newProps)[0].name;
+      protocol = this.availableProtocols(newProps)[0].name;
     }
 
     if (newProps.item && newProps.item.parent_id) {
-      if (!this.props.item || !this.props.item.parent_id || (this.props.item.parent_id !== newProps.item.parent_id)) {
+      if (
+        !this.props.item ||
+        !this.props.item.parent_id ||
+        this.props.item.parent_id !== newProps.item.parent_id
+      ) {
         parentId = newProps.item.parent_id;
       }
     }
 
     if (newProps.item && newProps.item.libraries) {
-      if (!this.props.item || !this.props.item.libraries || (this.props.item.libraries !== newProps.item.libraries)) {
+      if (
+        !this.props.item ||
+        !this.props.item.libraries ||
+        this.props.item.libraries !== newProps.item.libraries
+      ) {
         libraries = newProps.item.libraries;
       }
     }
-    const newState = Object.assign({}, this.state, { protocol, parentId, libraries });
+    const newState = Object.assign({}, this.state, {
+      protocol,
+      parentId,
+      libraries,
+    });
     this.setState(newState);
 
     if (newProps.responseBody && !newProps.fetchError) {
       clearForm(this.refs);
     }
-
   }
 
   shouldDisable(): boolean {
-    return this.props.disabled || (this.props.item?.level && this.props.item.level > this.props.adminLevel);
+    return (
+      this.props.disabled ||
+      (this.props.item?.level && this.props.item.level > this.props.adminLevel)
+    );
   }
 
   render(): JSX.Element {
-    let protocol = this.findProtocol();
+    const protocol = this.findProtocol();
     const listDataKey = this.props.listDataKey;
-    const { requiredFields, nonRequiredFields, extraFields } = this.protocolSettings(protocol);
-    const showLibrariesForm = (!this.sitewide(protocol) || this.protocolLibrarySettings(protocol).length > 0);
+    const {
+      requiredFields,
+      nonRequiredFields,
+      extraFields,
+    } = this.protocolSettings(protocol);
+    const showLibrariesForm =
+      !this.sitewide(protocol) ||
+      this.protocolLibrarySettings(protocol).length > 0;
     const hasNonRequiredFields = nonRequiredFields.length > 0;
-    const hasInstructions = this.props.data && this.protocolInstructions(protocol);
+    const hasInstructions =
+      this.props.data && this.protocolInstructions(protocol);
     const disabled: boolean = this.shouldDisable();
-    let instructions = hasInstructions && (
+    const instructions = hasInstructions && (
       <div className="form-group" key="instructions">
         <label className="control-label">Instructions</label>
         <Panel
@@ -121,7 +160,7 @@ export default class ServiceEditForm<T extends ServicesData> extends React.Compo
       </div>
     );
 
-    let requiredFieldsPanel = (
+    const requiredFieldsPanel = (
       <Panel
         key="required"
         id={`form-${listDataKey}-required`}
@@ -132,7 +171,7 @@ export default class ServiceEditForm<T extends ServicesData> extends React.Compo
       />
     );
 
-    let optionalFieldsPanel = hasNonRequiredFields && (
+    const optionalFieldsPanel = hasNonRequiredFields && (
       <Panel
         id={`form-${listDataKey}-optional`}
         key="optional"
@@ -140,17 +179,21 @@ export default class ServiceEditForm<T extends ServicesData> extends React.Compo
         content={this.renderOptionalFields(nonRequiredFields, disabled)}
       />
     );
-    let extraPanel = this.props.extraFormSection && extraFields.length > 0 && (
-        React.createElement(this.props.extraFormSection, {
-          key: this.props.extraFormKey,
-          setting: extraFields[0],
-          ref: this.extraForm,
-          currentValue: this.props.item && this.props.item.settings && this.props.item.settings[this.props.extraFormKey],
-          disabled: disabled
-        })
-    );
+    const extraPanel =
+      this.props.extraFormSection &&
+      extraFields.length > 0 &&
+      React.createElement(this.props.extraFormSection, {
+        key: this.props.extraFormKey,
+        setting: extraFields[0],
+        ref: this.extraForm,
+        currentValue:
+          this.props.item &&
+          this.props.item.settings &&
+          this.props.item.settings[this.props.extraFormKey],
+        disabled: disabled,
+      });
 
-    let librariesForm = showLibrariesForm && (
+    const librariesForm = showLibrariesForm && (
       <Panel
         key="libraries"
         id={`form-${listDataKey}-libraries`}
@@ -164,17 +207,31 @@ export default class ServiceEditForm<T extends ServicesData> extends React.Compo
         onSubmit={this.submit}
         className="no-border edit-form"
         hiddenName={this.props.item && this.props.item.id && "id"}
-        hiddenValue={this.props.item && this.props.item.id && String(this.props.item.id)}
+        hiddenValue={
+          this.props.item && this.props.item.id && String(this.props.item.id)
+        }
         disableButton={disabled}
-        content={[instructions, requiredFieldsPanel, optionalFieldsPanel, extraPanel, librariesForm]}
+        content={[
+          instructions,
+          requiredFieldsPanel,
+          optionalFieldsPanel,
+          extraPanel,
+          librariesForm,
+        ]}
       />
     );
   }
 
-  renderRequiredFields(requiredFields, protocol: ProtocolData, disabled: boolean) {
+  renderRequiredFields(
+    requiredFields,
+    protocol: ProtocolData,
+    disabled: boolean
+  ) {
     return (
       <fieldset>
-        <legend className="visuallyHidden"><h4>Required Fields</h4></legend>
+        <legend className="visuallyHidden">
+          <h4>Required Fields</h4>
+        </legend>
         <EditableInput
           elementType="input"
           type="text"
@@ -186,7 +243,7 @@ export default class ServiceEditForm<T extends ServicesData> extends React.Compo
           label="Name"
           value={this.props.item && this.props.item.name}
           error={this.props.error}
-          />
+        />
         <EditableInput
           elementType="select"
           disabled={disabled}
@@ -196,47 +253,63 @@ export default class ServiceEditForm<T extends ServicesData> extends React.Compo
           value={this.state.protocol}
           ref="protocol"
           onChange={this.handleProtocolChange}
-          description={!this.protocolInstructions(protocol) && this.protocolDescription(protocol)}
-          >
-          { this.availableProtocols().map(protocol =>
-              <option key={protocol.name} value={protocol.name} aria-selected={this.state.protocol === protocol.name}>
-                {protocol.label || protocol.name}
-              </option>
-            )
+          description={
+            !this.protocolInstructions(protocol) &&
+            this.protocolDescription(protocol)
           }
+        >
+          {this.availableProtocols().map((protocol) => (
+            <option
+              key={protocol.name}
+              value={protocol.name}
+              aria-selected={this.state.protocol === protocol.name}
+            >
+              {protocol.label || protocol.name}
+            </option>
+          ))}
         </EditableInput>
-        { this.props.data && this.allowsParent(protocol) && (this.availableParents().length > 0) &&
-          <EditableInput
-            elementType="select"
-            readOnly={disabled}
-            disabled={disabled}
-            name="parent_id"
-            label="Parent"
-            value={this.state.parentId}
-            ref="parent"
-            onChange={this.handleParentChange}
-          >
-            <option value="" aria-selected={this.state.parentId === ""}>None</option>
-            { this.availableParents().map(parent =>
-                <option key={parent.id} value={parent.id} aria-selected={this.state.parentId === parent.id}>
-                  {parent.name || parent.id}
-                </option>
-              )
-            }
-          </EditableInput>
-        }
-        { requiredFields.map(setting =>
-            <ProtocolFormField
-              key={setting.key}
-              ref={setting.key}
-              setting={setting}
+        {this.props.data &&
+          this.allowsParent(protocol) &&
+          this.availableParents().length > 0 && (
+            <EditableInput
+              elementType="select"
               readOnly={disabled}
               disabled={disabled}
-              value={this.props.item && this.props.item.settings && this.props.item.settings[setting.key]}
-              error={this.props.error}
-              />
-          )
-        }
+              name="parent_id"
+              label="Parent"
+              value={this.state.parentId}
+              ref="parent"
+              onChange={this.handleParentChange}
+            >
+              <option value="" aria-selected={this.state.parentId === ""}>
+                None
+              </option>
+              {this.availableParents().map((parent) => (
+                <option
+                  key={parent.id}
+                  value={parent.id}
+                  aria-selected={this.state.parentId === parent.id}
+                >
+                  {parent.name || parent.id}
+                </option>
+              ))}
+            </EditableInput>
+          )}
+        {requiredFields.map((setting) => (
+          <ProtocolFormField
+            key={setting.key}
+            ref={setting.key}
+            setting={setting}
+            readOnly={disabled}
+            disabled={disabled}
+            value={
+              this.props.item &&
+              this.props.item.settings &&
+              this.props.item.settings[setting.key]
+            }
+            error={this.props.error}
+          />
+        ))}
       </fieldset>
     );
   }
@@ -245,18 +318,21 @@ export default class ServiceEditForm<T extends ServicesData> extends React.Compo
     return (
       <fieldset>
         <legend className="visuallyHidden">Additional Fields</legend>
-        { optionalFields.map(setting =>
-            <ProtocolFormField
-              key={setting.key}
-              ref={setting.key}
-              setting={setting}
-              readOnly={disabled}
-              disabled={disabled}
-              value={this.props.item && this.props.item.settings && this.props.item.settings[setting.key]}
-              error={this.props.error}
-              />
-          )
-        }
+        {optionalFields.map((setting) => (
+          <ProtocolFormField
+            key={setting.key}
+            ref={setting.key}
+            setting={setting}
+            readOnly={disabled}
+            disabled={disabled}
+            value={
+              this.props.item &&
+              this.props.item.settings &&
+              this.props.item.settings[setting.key]
+            }
+            error={this.props.error}
+          />
+        ))}
       </fieldset>
     );
   }
@@ -266,104 +342,122 @@ export default class ServiceEditForm<T extends ServicesData> extends React.Compo
       <fieldset className="update-libraries">
         <legend className="visuallyHidden">Libraries</legend>
         <div className="form-group">
-          { this.state.libraries.map(library =>
-              <div key={library.short_name}>
-                <WithRemoveButton
-                  disabled={disabled}
-                  onRemove={() => this.removeLibrary(library)}
-                  ref={library.short_name}
-                  >
-                  { this.props.data && this.props.data.protocols && this.protocolLibrarySettings(protocol) && this.protocolLibrarySettings(protocol).length > 0 &&
+          {this.state.libraries.map((library) => (
+            <div key={library.short_name}>
+              <WithRemoveButton
+                disabled={disabled}
+                onRemove={() => this.removeLibrary(library)}
+                ref={library.short_name}
+              >
+                {this.props.data &&
+                  this.props.data.protocols &&
+                  this.protocolLibrarySettings(protocol) &&
+                  this.protocolLibrarySettings(protocol).length > 0 && (
                     <WithEditButton
                       disabled={disabled}
                       onEdit={() => this.expandLibrary(library)}
-                      >
-                      {this.getLibrary(library.short_name) && this.getLibrary(library.short_name).name}
+                    >
+                      {this.getLibrary(library.short_name) &&
+                        this.getLibrary(library.short_name).name}
                     </WithEditButton>
-                  }
-                  { !(this.props.data && this.props.data.protocols && this.protocolLibrarySettings(protocol) && this.protocolLibrarySettings(protocol).length > 0) &&
-                    this.getLibrary(library.short_name) && this.getLibrary(library.short_name).name
-                  }
-                </WithRemoveButton>
-                { this.isExpanded(library) &&
-                  <div className="edit-library-settings">
-                    { this.props.data && this.props.data.protocols && this.protocolLibrarySettings(protocol) && this.protocolLibrarySettings(protocol).map(setting =>
+                  )}
+                {!(
+                  this.props.data &&
+                  this.props.data.protocols &&
+                  this.protocolLibrarySettings(protocol) &&
+                  this.protocolLibrarySettings(protocol).length > 0
+                ) &&
+                  this.getLibrary(library.short_name) &&
+                  this.getLibrary(library.short_name).name}
+              </WithRemoveButton>
+              {this.isExpanded(library) && (
+                <div className="edit-library-settings">
+                  {this.props.data &&
+                    this.props.data.protocols &&
+                    this.protocolLibrarySettings(protocol) &&
+                    this.protocolLibrarySettings(protocol).map((setting) => (
                       <ProtocolFormField
                         key={setting.key}
                         setting={setting}
                         disabled={disabled}
                         value={library[setting.key]}
                         ref={library.short_name + "_" + setting.key}
-                        />
-                      )
-                    }
-                    <Button
-                      type="button"
-                      className="edit-library"
-                      disabled={disabled}
-                      callback={() => this.editLibrary(library, protocol)}
-                      content="Save"
-                    />
-                  </div>
-                }
-              </div>
-            )
-          }
-        </div>
-        { (this.availableLibraries().length > 0) &&
-            <div className="form-group">
-              <EditableInput
-                elementType="select"
-                disabled={disabled}
-                readOnly={disabled}
-                name="add-library"
-                label="Add Library"
-                ref="addLibrary"
-                value={this.state.selectedLibrary}
-                onChange={this.selectLibrary}
-                >
-                <option value="none" aria-selected={this.state.selectedLibrary === "none"}>Select a library</option>
-                { this.availableLibraries().map(library =>
-                    <option
-                      key={library.short_name}
-                      value={library.short_name}
-                      aria-selected={this.state.selectedLibrary === "library.short_name"}
-                    >
-                      {library.name}
-                    </option>
-                  )
-                }
-              </EditableInput>
-              { this.state.selectedLibrary &&
-                <div>
-                  { this.props.data && this.props.data.protocols && this.protocolLibrarySettings(protocol) && this.protocolLibrarySettings(protocol).map(setting =>
-                      <ProtocolFormField
-                        key={setting.key}
-                        setting={setting}
-                        disabled={disabled}
-                        readOnly={disabled}
-                        ref={setting.key}
-                        />
-                    )
-                  }
+                      />
+                    ))}
                   <Button
                     type="button"
+                    className="edit-library"
                     disabled={disabled}
-                    callback={() => this.addLibrary(protocol)}
-                    content="Add Library"
-                    className="left-align"
+                    callback={() => this.editLibrary(library, protocol)}
+                    content="Save"
                   />
                 </div>
-              }
+              )}
             </div>
-        }
+          ))}
+        </div>
+        {this.availableLibraries().length > 0 && (
+          <div className="form-group">
+            <EditableInput
+              elementType="select"
+              disabled={disabled}
+              readOnly={disabled}
+              name="add-library"
+              label="Add Library"
+              ref="addLibrary"
+              value={this.state.selectedLibrary}
+              onChange={this.selectLibrary}
+            >
+              <option
+                value="none"
+                aria-selected={this.state.selectedLibrary === "none"}
+              >
+                Select a library
+              </option>
+              {this.availableLibraries().map((library) => (
+                <option
+                  key={library.short_name}
+                  value={library.short_name}
+                  aria-selected={
+                    this.state.selectedLibrary === "library.short_name"
+                  }
+                >
+                  {library.name}
+                </option>
+              ))}
+            </EditableInput>
+            {this.state.selectedLibrary && (
+              <div>
+                {this.props.data &&
+                  this.props.data.protocols &&
+                  this.protocolLibrarySettings(protocol) &&
+                  this.protocolLibrarySettings(protocol).map((setting) => (
+                    <ProtocolFormField
+                      key={setting.key}
+                      setting={setting}
+                      disabled={disabled}
+                      readOnly={disabled}
+                      ref={setting.key}
+                    />
+                  ))}
+                <Button
+                  type="button"
+                  disabled={disabled}
+                  callback={() => this.addLibrary(protocol)}
+                  content="Add Library"
+                  className="left-align"
+                />
+              </div>
+            )}
+          </div>
+        )}
       </fieldset>
     );
   }
 
   availableProtocols(props?): ProtocolData[] {
     props = props || this.props;
-    const allProtocols = props.data && props.data.protocols || [];
+    const allProtocols = (props.data && props.data.protocols) || [];
 
     // If we're editing an existing service, the protocol can't be changed,
     // so there's only one available protocol.
@@ -389,10 +483,14 @@ export default class ServiceEditForm<T extends ServicesData> extends React.Compo
   }
 
   availableParents() {
-    const allServices = this.props.data && this.props.data[this.props.listDataKey] || [];
+    const allServices =
+      (this.props.data && this.props.data[this.props.listDataKey]) || [];
     const availableParents = [];
     for (const service of allServices) {
-      if (service.protocol === this.state.protocol && service.id !== (this.props.item && this.props.item.id)) {
+      if (
+        service.protocol === this.state.protocol &&
+        service.id !== (this.props.item && this.props.item.id)
+      ) {
         availableParents.push(service);
       }
     }
@@ -413,21 +511,30 @@ export default class ServiceEditForm<T extends ServicesData> extends React.Compo
   }
 
   findProtocol(): ProtocolData {
-    return this.protocols() && this.protocols().find(p => p.name === this.state.protocol);
+    return (
+      this.protocols() &&
+      this.protocols().find((p) => p.name === this.state.protocol)
+    );
   }
 
   protocolSettings(protocol: ProtocolData) {
-    let requiredFields = [];
-    let nonRequiredFields = [];
-    let extraFields = [];
-    let extraSettings = [this.props.extraFormKey];
+    const requiredFields = [];
+    const nonRequiredFields = [];
+    const extraFields = [];
+    const extraSettings = [this.props.extraFormKey];
     let settings;
     if (protocol) {
-      settings = this.state.parentId ? protocol.child_settings : protocol.settings;
-      settings && settings.forEach((s) => {
-        extraSettings.includes(s.key) ? extraFields.push(s) :
-        (s.required ? requiredFields.push(s) : nonRequiredFields.push(s));
-      });
+      settings = this.state.parentId
+        ? protocol.child_settings
+        : protocol.settings;
+      settings &&
+        settings.forEach((s) => {
+          extraSettings.includes(s.key)
+            ? extraFields.push(s)
+            : s.required
+            ? requiredFields.push(s)
+            : nonRequiredFields.push(s);
+        });
     }
     return { requiredFields, nonRequiredFields, extraFields };
   }
@@ -449,7 +556,7 @@ export default class ServiceEditForm<T extends ServicesData> extends React.Compo
   }
 
   getLibrary(shortName: string): LibraryData {
-    const libraries = this.props.data && this.props.data.allLibraries || [];
+    const libraries = (this.props.data && this.props.data.allLibraries) || [];
     for (const library of libraries) {
       if (library.short_name === shortName) {
         return library;
@@ -459,8 +566,8 @@ export default class ServiceEditForm<T extends ServicesData> extends React.Compo
   }
 
   availableLibraries(): LibraryData[] {
-    const libraries = this.props.data && this.props.data.allLibraries || [];
-    return libraries.filter(library => {
+    const libraries = (this.props.data && this.props.data.allLibraries) || [];
+    return libraries.filter((library) => {
       for (const stateLibrary of this.state.libraries) {
         if (stateLibrary.short_name === library.short_name) {
           return false;
@@ -484,9 +591,16 @@ export default class ServiceEditForm<T extends ServicesData> extends React.Compo
   }
 
   removeLibrary(library) {
-    const libraries = this.state.libraries.filter(stateLibrary => stateLibrary.short_name !== library.short_name);
-    const expandedLibraries = this.state.expandedLibraries.filter(shortName => shortName !== library.short_name);
-    const newState = Object.assign({}, this.state, { libraries, expandedLibraries });
+    const libraries = this.state.libraries.filter(
+      (stateLibrary) => stateLibrary.short_name !== library.short_name
+    );
+    const expandedLibraries = this.state.expandedLibraries.filter(
+      (shortName) => shortName !== library.short_name
+    );
+    const newState = Object.assign({}, this.state, {
+      libraries,
+      expandedLibraries,
+    });
     this.setState(newState);
   }
 
@@ -497,24 +611,35 @@ export default class ServiceEditForm<T extends ServicesData> extends React.Compo
       const newState = Object.assign({}, this.state, { expandedLibraries });
       this.setState(newState);
     } else {
-      const expandedLibraries = this.state.expandedLibraries.filter(shortName => shortName !== library.short_name);
+      const expandedLibraries = this.state.expandedLibraries.filter(
+        (shortName) => shortName !== library.short_name
+      );
       const newState = Object.assign({}, this.state, { expandedLibraries });
       this.setState(newState);
     }
   }
 
   editLibrary(library, protocol: ProtocolData) {
-    const libraries = this.state.libraries.filter(stateLibrary => stateLibrary.short_name !== library.short_name);
-    const expandedLibraries = this.state.expandedLibraries.filter(shortName => shortName !== library.short_name);
+    const libraries = this.state.libraries.filter(
+      (stateLibrary) => stateLibrary.short_name !== library.short_name
+    );
+    const expandedLibraries = this.state.expandedLibraries.filter(
+      (shortName) => shortName !== library.short_name
+    );
     const newLibrary = { short_name: library.short_name };
     for (const setting of this.protocolLibrarySettings(protocol)) {
-      const value = (this.refs[library.short_name + "_" + setting.key] as any).getValue();
+      const value = (this.refs[
+        library.short_name + "_" + setting.key
+      ] as any).getValue();
       if (value) {
         newLibrary[setting.key] = value;
       }
     }
     libraries.push(newLibrary);
-    const newState = Object.assign({}, this.state, { libraries, expandedLibraries });
+    const newState = Object.assign({}, this.state, {
+      libraries,
+      expandedLibraries,
+    });
     this.setState(newState);
   }
 
@@ -529,19 +654,23 @@ export default class ServiceEditForm<T extends ServicesData> extends React.Compo
       (this.refs[setting.key] as any).clear();
     }
     const libraries = this.state.libraries.concat(newLibrary);
-    const newState = Object.assign({}, this.state, { libraries, selectedLibrary: null });
+    const newState = Object.assign({}, this.state, {
+      libraries,
+      selectedLibrary: null,
+    });
     this.setState(newState);
   }
 
   handleData(data: FormData) {
     const extraFormRef = this.extraForm.current;
-    extraFormRef && data.append(this.props.extraFormKey, (extraFormRef as any).getValue());
+    extraFormRef &&
+      data.append(this.props.extraFormKey, (extraFormRef as any).getValue());
     data && data.append("libraries", JSON.stringify(this.state.libraries));
     return data;
   }
 
   async submit(data: FormData) {
-    let modifiedData = this.handleData(data);
+    const modifiedData = this.handleData(data);
     await this.props.save(modifiedData);
   }
 }

--- a/src/components/SitewideSettingEditForm.tsx
+++ b/src/components/SitewideSettingEditForm.tsx
@@ -18,13 +18,18 @@ export interface SitewideSettingEditFormState {
 }
 
 /** Form for editing a single sitewide setting. */
-export default class SitewideSettingEditForm extends React.Component<SitewideSettingEditFormProps, SitewideSettingEditFormState> {
+export default class SitewideSettingEditForm extends React.Component<
+  SitewideSettingEditFormProps,
+  SitewideSettingEditFormState
+> {
   constructor(props) {
     super(props);
     this.onChange = this.onChange.bind(this);
     this.submit = this.submit.bind(this);
     this.state = {
-      inputKey: this.availableSettings().length ? this.availableSettings()[0].key : "",
+      inputKey: this.availableSettings().length
+        ? this.availableSettings()[0].key
+        : "",
     };
   }
 
@@ -32,22 +37,28 @@ export default class SitewideSettingEditForm extends React.Component<SitewideSet
     const inputKey = this.state.inputKey;
     const availableSettings = this.availableSettings();
     let settingToRender;
-    availableSettings.forEach(setting => {
+    availableSettings.forEach((setting) => {
       if (setting.key === inputKey) {
         settingToRender = setting;
       }
     });
-    const selectType = !!(settingToRender && settingToRender.options && settingToRender.options.length);
+    const selectType = !!(
+      settingToRender &&
+      settingToRender.options &&
+      settingToRender.options.length
+    );
     return (
       <div>
-        { availableSettings.length > 0 &&
+        {availableSettings.length > 0 && (
           <Form
             onSubmit={this.submit}
             className="no-border edit-form"
             disableButton={this.props.disabled}
             content={
               <fieldset key="sitewide-setting">
-                <legend className="visuallyHidden">Enter or edit a value for the selected sitewide setting key</legend>
+                <legend className="visuallyHidden">
+                  Enter or edit a value for the selected sitewide setting key
+                </legend>
                 <EditableInput
                   elementType="select"
                   disabled={this.props.disabled}
@@ -58,58 +69,71 @@ export default class SitewideSettingEditForm extends React.Component<SitewideSet
                   value={this.props.item && this.props.item.key}
                   onChange={this.onChange}
                 >
-                  {
-                    availableSettings.map(setting =>
-                      <option key={setting.key} value={setting.key} aria-selected={false}>{setting.label}</option>
-                    )
-                  }
-                </EditableInput>
-                {
-                  selectType ? (
-                    <EditableInput
-                      elementType="select"
-                      name="value"
-                      ref="value"
-                      label="Value"
-                      value={this.props.item && this.props.item.value}
+                  {availableSettings.map((setting) => (
+                    <option
+                      key={setting.key}
+                      value={setting.key}
+                      aria-selected={false}
                     >
-                      {
-                        availableSettings.map(setting => {
-                          if (setting.key === inputKey) {
-                            return setting.options.map(s => {
-                              return <option key={s.key} value={s.key} aria-selected={false}>{s.label}</option>;
-                            });
-                          }
-                        })
+                      {setting.label}
+                    </option>
+                  ))}
+                </EditableInput>
+                {selectType ? (
+                  <EditableInput
+                    elementType="select"
+                    name="value"
+                    ref="value"
+                    label="Value"
+                    value={this.props.item && this.props.item.value}
+                  >
+                    {availableSettings.map((setting) => {
+                      if (setting.key === inputKey) {
+                        return setting.options.map((s) => {
+                          return (
+                            <option
+                              key={s.key}
+                              value={s.key}
+                              aria-selected={false}
+                            >
+                              {s.label}
+                            </option>
+                          );
+                        });
                       }
-                    </EditableInput>
-                  ) : (
-                    <EditableInput
-                      elementType="input"
-                      type="text"
-                      disabled={this.props.disabled}
-                      required={settingToRender && settingToRender.required}
-                      name="value"
-                      ref="value"
-                      label="Value"
-                      value={this.props.item && this.props.item.value}
-                    />
-                  )
-                }
-                {
-                  availableSettings.map(setting => {
-                    if (setting.key === inputKey && setting.description) {
-                      return <p className="description" dangerouslySetInnerHTML={{__html: setting.description}} />;
-                    }
-                  })
-                }
+                    })}
+                  </EditableInput>
+                ) : (
+                  <EditableInput
+                    elementType="input"
+                    type="text"
+                    disabled={this.props.disabled}
+                    required={settingToRender && settingToRender.required}
+                    name="value"
+                    ref="value"
+                    label="Value"
+                    value={this.props.item && this.props.item.value}
+                  />
+                )}
+                {availableSettings.map((setting) => {
+                  if (setting.key === inputKey && setting.description) {
+                    return (
+                      <p
+                        className="description"
+                        dangerouslySetInnerHTML={{
+                          __html: setting.description,
+                        }}
+                      />
+                    );
+                  }
+                })}
               </fieldset>
             }
           />
-        }
-        { this.availableSettings().length === 0 &&
+        )}
+        {this.availableSettings().length === 0 && (
           <p>All sitewide settings have already been created.</p>
-        }
+        )}
       </div>
     );
   }
@@ -119,7 +143,7 @@ export default class SitewideSettingEditForm extends React.Component<SitewideSet
   }
 
   availableSettings() {
-    const allSettings = this.props.data && this.props.data.all_settings || [];
+    const allSettings = (this.props.data && this.props.data.all_settings) || [];
     if (this.props.item) {
       for (const setting of allSettings) {
         if (setting.key === this.props.item.key) {
@@ -130,7 +154,9 @@ export default class SitewideSettingEditForm extends React.Component<SitewideSet
       const availableSettings = [];
       for (const possibleSetting of allSettings) {
         let hasSetting = false;
-        for (const actualSetting of (this.props.data && this.props.data.settings) || []) {
+        for (const actualSetting of (this.props.data &&
+          this.props.data.settings) ||
+          []) {
           if (actualSetting.key === possibleSetting.key) {
             hasSetting = true;
           }
@@ -148,10 +174,9 @@ export default class SitewideSettingEditForm extends React.Component<SitewideSet
     await this.props.save(data);
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.responseBody && !nextProps.fetchError) {
       clearForm(this.refs);
     }
   }
-
 }

--- a/src/components/Stats.tsx
+++ b/src/components/Stats.tsx
@@ -26,45 +26,57 @@ export interface StatsOwnProps {
   library?: string;
 }
 
-export interface StatsProps extends StatsStateProps, StatsDispatchProps, StatsOwnProps {}
+export interface StatsProps
+  extends StatsStateProps,
+    StatsDispatchProps,
+    StatsOwnProps {}
 
 /** Displays statistics about patrons, licenses, and vendors from the server. */
 export class Stats extends React.Component<StatsProps, {}> {
   render(): JSX.Element {
     let libraryData: LibraryData | null = null;
     for (const library of this.props.libraries || []) {
-      if (this.props.library && (library.short_name === this.props.library)) {
+      if (this.props.library && library.short_name === this.props.library) {
         libraryData = library;
       }
     }
 
-    if (!libraryData && this.props.libraries && this.props.libraries.length === 1) {
+    if (
+      !libraryData &&
+      this.props.libraries &&
+      this.props.libraries.length === 1
+    ) {
       libraryData = this.props.libraries[0];
     }
 
-    let libraryStats = this.props.isLoaded && this.props.stats && libraryData && this.props.stats[libraryData.short_name];
-    const totalStats = this.props.isLoaded && this.props.libraries && this.props.libraries.length > 1 && this.props.stats && this.props.stats["total"];
+    const libraryStats =
+      this.props.isLoaded &&
+      this.props.stats &&
+      libraryData &&
+      this.props.stats[libraryData.short_name];
+    const totalStats =
+      this.props.isLoaded &&
+      this.props.libraries &&
+      this.props.libraries.length > 1 &&
+      this.props.stats &&
+      this.props.stats["total"];
 
     return (
       <>
-        { libraryStats &&
+        {libraryStats && (
           <LibraryStats library={libraryData} stats={libraryStats} />
-        }
-        { totalStats &&
-          <LibraryStats stats={totalStats} />
-        }
-        { this.props.fetchError &&
+        )}
+        {totalStats && <LibraryStats stats={totalStats} />}
+        {this.props.fetchError && (
           <ErrorMessage error={this.props.fetchError} />
-        }
+        )}
 
-        { !this.props.isLoaded &&
-          <LoadingIndicator />
-        }
+        {!this.props.isLoaded && <LoadingIndicator />}
       </>
     );
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     if (this.props.fetchStats) {
       this.props.fetchStats();
     }
@@ -77,21 +89,28 @@ export class Stats extends React.Component<StatsProps, {}> {
 function mapStateToProps(state, ownProps) {
   return {
     stats: state.editor.stats.data,
-    libraries: state.editor.libraries && state.editor.libraries.data && state.editor.libraries.data.libraries,
+    libraries:
+      state.editor.libraries &&
+      state.editor.libraries.data &&
+      state.editor.libraries.data.libraries,
     fetchError: state.editor.stats.fetchError,
-    isLoaded: state.editor.stats.isLoaded
+    isLoaded: state.editor.stats.isLoaded,
   };
 }
 
 function mapDispatchToProps(dispatch) {
-  let actions = new ActionCreator();
+  const actions = new ActionCreator();
   return {
     fetchStats: () => dispatch(actions.fetchStats()),
-    fetchLibraries: () => dispatch(actions.fetchLibraries())
+    fetchLibraries: () => dispatch(actions.fetchLibraries()),
   };
 }
 
-const ConnectedStats = connect<StatsStateProps, StatsDispatchProps, StatsOwnProps>(
+const ConnectedStats = connect<
+  StatsStateProps,
+  StatsDispatchProps,
+  StatsOwnProps
+>(
   mapStateToProps,
   mapDispatchToProps
 )(Stats);

--- a/src/components/TextWithEditMode.tsx
+++ b/src/components/TextWithEditMode.tsx
@@ -18,13 +18,16 @@ export interface TextWithEditModeState {
 
 /** Renders text with a link to switch to edit mode and show an editable input instead.
     If the text isn't defined yet, it starts in edit mode. */
-export default class TextWithEditMode extends React.Component<TextWithEditModeProps, TextWithEditModeState> {
+export default class TextWithEditMode extends React.Component<
+  TextWithEditModeProps,
+  TextWithEditModeState
+> {
   private textRef = React.createRef<EditableInput>();
   constructor(props) {
     super(props);
     this.state = {
       text: this.props.text || "",
-      editMode: !this.props.text
+      editMode: !this.props.text,
     };
 
     this.updateText = this.updateText.bind(this);
@@ -35,7 +38,7 @@ export default class TextWithEditMode extends React.Component<TextWithEditModePr
   render(): JSX.Element {
     return (
       <div>
-        { this.state.editMode &&
+        {this.state.editMode && (
           <h3>
             <EditableInput
               type="text"
@@ -53,22 +56,26 @@ export default class TextWithEditMode extends React.Component<TextWithEditModePr
               disabled={this.props.disableIfBlank && !this.state.text.length}
             />
           </h3>
-        }
-        { !this.state.editMode &&
+        )}
+        {!this.state.editMode && (
           <h3>
-            { this.state.text }
+            {this.state.text}
             <Button
               callback={this.startEditMode}
               className="inverted inline"
-              content={<span>Edit {this.props.placeholder} <PencilIcon /></span>}
+              content={
+                <span>
+                  Edit {this.props.placeholder} <PencilIcon />
+                </span>
+              }
             />
           </h3>
-        }
+        )}
       </div>
     );
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.text !== this.props.text) {
       this.setState({ text: nextProps.text, editMode: !nextProps.text });
     }
@@ -92,7 +99,7 @@ export default class TextWithEditMode extends React.Component<TextWithEditModePr
 
   getText() {
     if (this.state.editMode) {
-      let value = this.textRef.current.getValue();
+      const value = this.textRef.current.getValue();
       this.updateText();
       return value;
     } else {

--- a/src/components/TroubleshootingPage.tsx
+++ b/src/components/TroubleshootingPage.tsx
@@ -6,7 +6,6 @@ import Footer from "./Footer";
 import { State } from "../reducers/index";
 import TroubleshootingTabContainer from "./TroubleshootingTabContainer";
 
-
 export interface TroubleshootingPageContext {
   editorStore: Store<State>;
   csrfToken: string;
@@ -17,24 +16,33 @@ export interface TroubleshootingPageState {
   subtab: string;
 }
 
-export interface TroubleshootingPageProps extends React.Props<TroubleshootingPageProps> {
+export interface TroubleshootingPageProps
+  extends React.Props<TroubleshootingPageProps> {
   params: {
     tab?: string;
     subtab?: string;
   };
 }
 
-export default class TroubleshootingPage extends React.Component<TroubleshootingPageProps, TroubleshootingPageState> {
+export default class TroubleshootingPage extends React.Component<
+  TroubleshootingPageProps,
+  TroubleshootingPageState
+> {
   context: TroubleshootingPageContext;
 
   static contextTypes: React.ValidationMap<TroubleshootingPageContext> = {
     editorStore: PropTypes.object.isRequired as React.Validator<Store>,
-    csrfToken: PropTypes.string.isRequired
+    csrfToken: PropTypes.string.isRequired,
   };
 
   CATEGORIES = {
-    "diagnostics": ["coverage_provider", "script", "monitor", "other"],
-    "self-tests": ["collections", "patronAuthServices", "searchServices", "metadataServices"]
+    diagnostics: ["coverage_provider", "script", "monitor", "other"],
+    "self-tests": [
+      "collections",
+      "patronAuthServices",
+      "searchServices",
+      "metadataServices",
+    ],
   };
 
   constructor(props) {
@@ -43,15 +51,18 @@ export default class TroubleshootingPage extends React.Component<Troubleshooting
     this.goToTab = this.goToTab.bind(this);
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     document.title = "Circulation Manager - Troubleshooting";
   }
 
   render(): JSX.Element {
-    let tab = this.props.params.tab || this.state.tab;
+    const tab = this.props.params.tab || this.state.tab;
     let subtab = this.props.params.subtab || this.state.subtab;
-    subtab = this.CATEGORIES[tab].indexOf(subtab) >= 0 ? subtab : this.CATEGORIES[tab][0];
-    return(
+    subtab =
+      this.CATEGORIES[tab].indexOf(subtab) >= 0
+        ? subtab
+        : this.CATEGORIES[tab][0];
+    return (
       <div className="troubleshooting-page">
         <Header />
         <div className="body">
@@ -72,5 +83,4 @@ export default class TroubleshootingPage extends React.Component<Troubleshooting
   goToTab(tab: string) {
     this.setState({ tab, subtab: this.props.params.subtab });
   }
-
 }

--- a/src/components/TroubleshootingTabContainer.tsx
+++ b/src/components/TroubleshootingTabContainer.tsx
@@ -2,7 +2,11 @@ import * as React from "react";
 import { Store } from "redux";
 import * as PropTypes from "prop-types";
 import { State } from "../reducers/index";
-import { TabContainer, TabContainerProps, TabContainerContext } from "./TabContainer";
+import {
+  TabContainer,
+  TabContainerProps,
+  TabContainerContext,
+} from "./TabContainer";
 import TroubleshootingCategoryPage from "./TroubleshootingCategoryPage";
 
 export interface TroubleshootingTabContainerProps extends TabContainerProps {
@@ -10,35 +14,55 @@ export interface TroubleshootingTabContainerProps extends TabContainerProps {
   subtab?: string;
 }
 
-export default class TroubleshootingTabContainer extends TabContainer<TroubleshootingTabContainerProps> {
+export default class TroubleshootingTabContainer extends TabContainer<
+  TroubleshootingTabContainerProps
+> {
   context: TabContainerContext;
   static contextTypes: React.ValidationMap<TabContainerContext> = {
     router: PropTypes.object.isRequired,
-    pathFor: PropTypes.func.isRequired
+    pathFor: PropTypes.func.isRequired,
   };
 
   tabs() {
     return {
-      "diagnostics": <TroubleshootingCategoryPage subtab={this.props.tab === "diagnostics" ? this.props.subtab : "coverage_provider"} type="diagnostics" />,
-      "self-tests": <TroubleshootingCategoryPage subtab={this.props.tab === "self-tests" ? this.props.subtab : "collections"} type="self-tests" />
+      diagnostics: (
+        <TroubleshootingCategoryPage
+          subtab={
+            this.props.tab === "diagnostics"
+              ? this.props.subtab
+              : "coverage_provider"
+          }
+          type="diagnostics"
+        />
+      ),
+      "self-tests": (
+        <TroubleshootingCategoryPage
+          subtab={
+            this.props.tab === "self-tests" ? this.props.subtab : "collections"
+          }
+          type="self-tests"
+        />
+      ),
     };
   }
 
-  componentWillReceiveProps(newProps: TroubleshootingTabContainerProps) {
-    (newProps.tab !== this.props.tab) && this.route(newProps.tab, newProps.subtab);
+  UNSAFE_componentWillReceiveProps(newProps: TroubleshootingTabContainerProps) {
+    newProps.tab !== this.props.tab &&
+      this.route(newProps.tab, newProps.subtab);
   }
 
   handleSelect(event) {
-    let tab = event.currentTarget.dataset.tabkey;
-    let subtab = this.props.subtab;
+    const tab = event.currentTarget.dataset.tabkey;
+    const subtab = this.props.subtab;
     this.props.goToTab(tab);
     this.route(tab, subtab);
-
   }
 
   route(tab: string, subtab: string) {
     if (this.context.router) {
-      this.context.router.push("/admin/web/troubleshooting/" + tab + "/" + subtab);
+      this.context.router.push(
+        "/admin/web/troubleshooting/" + tab + "/" + subtab
+      );
     }
   }
 }

--- a/src/components/__tests__/CirculationEvents-test.tsx
+++ b/src/components/__tests__/CirculationEvents-test.tsx
@@ -13,7 +13,7 @@ import { Button } from "library-simplified-reusable-components";
 import { CirculationEventData } from "../../interfaces";
 
 describe("CirculationEvents", () => {
-  let eventsData: CirculationEventData[] = [
+  const eventsData: CirculationEventData[] = [
     {
       id: 1,
       type: "check_in",
@@ -21,8 +21,8 @@ describe("CirculationEvents", () => {
       time: "Wed, 01 Jun 2016 16:49:17 GMT",
       book: {
         title: "book 1 title",
-        url: "book 1 url"
-      }
+        url: "book 1 url",
+      },
     },
     {
       id: 2,
@@ -31,16 +31,16 @@ describe("CirculationEvents", () => {
       time: "Wed, 01 Jun 2016 12:00:00 GMT",
       book: {
         title: "book 2 title",
-        url: "book 2 url"
-      }
+        url: "book 2 url",
+      },
     },
   ];
 
   describe("rendering", () => {
     let wrapper;
-    let fetchError = { status: 401, response: "test", url: "test url" };
+    const fetchError = { status: 401, response: "test", url: "test url" };
     let fetchCirculationEvents;
-    let context = { showCircEventsDownload: true };
+    const context = { showCircEventsDownload: true };
 
     beforeEach(() => {
       fetchCirculationEvents = stub().returns(
@@ -62,12 +62,12 @@ describe("CirculationEvents", () => {
     });
 
     it("shows header", () => {
-      let header = wrapper.find("h2");
+      const header = wrapper.find("h2");
       expect(header.text()).to.equal("Circulation Events");
     });
 
     it("shows CirculationEventsDownloadForm", () => {
-      let form = wrapper.find(CirculationEventsDownloadForm);
+      const form = wrapper.find(CirculationEventsDownloadForm);
       expect(form.length).to.equal(1);
       expect(form.prop("show")).to.equal(false);
       expect(form.prop("hide")).to.equal(wrapper.instance().hideDownloadForm);
@@ -82,18 +82,18 @@ describe("CirculationEvents", () => {
     });
 
     it("shows table data since there is no library", () => {
-      let instance = wrapper.instance();
-      let table = wrapper.find("table").find("tbody");
-      let rows = table.find("tr");
+      const instance = wrapper.instance();
+      const table = wrapper.find("table").find("tbody");
+      const rows = table.find("tr");
 
       rows.forEach((row, i) => {
-        let data = eventsData[i];
-        let link = row.find(CatalogLink);
+        const data = eventsData[i];
+        const link = row.find(CatalogLink);
         expect(link.prop("bookUrl")).to.equal(data.book.url);
         expect(link.children().text()).to.equal(data.book.title);
-        let type = row.find("td").at(1);
+        const type = row.find("td").at(1);
         expect(type.text()).to.equal(instance.formatType(data.type));
-        let time = row.find("td").at(2);
+        const time = row.find("td").at(2);
         expect(time.text()).to.equal(instance.formatTime(data.time));
       });
     });
@@ -124,7 +124,7 @@ describe("CirculationEvents", () => {
         { context }
       );
 
-      let table = wrapper.find("table");
+      const table = wrapper.find("table");
       expect(table.length).to.equal(0);
 
       wrapper.instance().componentWillUnmount();
@@ -134,7 +134,7 @@ describe("CirculationEvents", () => {
   describe("behavior", () => {
     let wrapper;
     let fetchCirculationEvents;
-    let context = { showCircEventsDownload: true };
+    const context = { showCircEventsDownload: true };
 
     beforeEach(() => {
       fetchCirculationEvents = stub().returns(
@@ -146,7 +146,7 @@ describe("CirculationEvents", () => {
           events={eventsData}
           fetchCirculationEvents={fetchCirculationEvents}
           wait={1}
-          />,
+        />,
         { context }
       );
     });
@@ -156,8 +156,8 @@ describe("CirculationEvents", () => {
     });
 
     it("fetches and queues on mount", () => {
-      let fetchAndQueue = stub(wrapper.instance(), "fetchAndQueue");
-      wrapper.instance().componentWillMount();
+      const fetchAndQueue = stub(wrapper.instance(), "fetchAndQueue");
+      wrapper.instance().UNSAFE_componentWillMount();
       expect(fetchAndQueue.callCount).to.equal(1);
       fetchAndQueue.restore();
     });
@@ -175,14 +175,14 @@ describe("CirculationEvents", () => {
           fetchCirculationEvents={fetchCirculationEvents}
           wait={1}
           library="NYPL"
-          />,
+        />,
         { context }
       );
 
-      let fetchAndQueue = stub(wrapper.instance(), "fetchAndQueue");
+      const fetchAndQueue = stub(wrapper.instance(), "fetchAndQueue");
       expect(fetchAndQueue.callCount).to.equal(0);
       fetchAndQueue.restore();
-      wrapper.instance().componentWillMount();
+      wrapper.instance().UNSAFE_componentWillMount();
     });
 
     describe("fetchAndQueue", () => {
@@ -214,22 +214,22 @@ describe("CirculationEvents", () => {
         />,
         { context }
       );
-      let fakeTimer = useFakeTimers();
+      const fakeTimer = useFakeTimers();
       await wrapper.instance().fetchAndQueue();
-      let button = wrapper.find(Button);
+      const button = wrapper.find(Button);
       expect(button.length).to.equal(1);
       expect(button.prop("content")).to.equal("Download CSV");
       expect(wrapper.state("showDownloadForm")).to.equal(false);
       button.simulate("click");
       expect(wrapper.state("showDownloadForm")).to.equal(true);
-      let form = wrapper.find(CirculationEventsDownloadForm);
+      const form = wrapper.find(CirculationEventsDownloadForm);
       expect(form.prop("show")).to.equal(true);
       fakeTimer.restore();
     });
 
     it("hides download form", () => {
       wrapper.setState({ showDownloadForm: true });
-      let form = wrapper.find(CirculationEventsDownloadForm);
+      const form = wrapper.find(CirculationEventsDownloadForm);
       form.prop("hide")();
       expect(wrapper.state("showDownloadForm")).to.equal(false);
     });


### PR DESCRIPTION
## Description
- Prepended all deprecated React lifecycle methods (componentWillMount and componentWillReceiveProps) with UNSAFE_.
- Added rules to ignore to .eslintrc file to be able to make commits (will address these rules, and update the code properly in another ticket/PR).

## Motivation and Context
- Using deprecated components causes the console to be crowded with warnings.
- Easily being able to see which methods we are using are deprecated may make debugging faster.

## How Has This Been Tested?
- All tests still pass.

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
