### PR TITLE
Simply 2102/pull through book cover url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,11 @@
 ## Changelog
 
-### 08/10/2021
+### v0.5.3
 
-#### Updated (to be included in next version)
+#### Updated
 
-- Addressed linter errors throughout repo and used prettier to format code conistently.
-
-### 08/06/2021
-
-#### Updated (to be included in next version)
-
+- Added a value attribute to the book cover URL's `EditableInput` in `BookCoverEditor` so that the existing URL pulls through for the user to start.
+- Addressed linter errors throughout repo and used prettier to format code consistently.
 - Prepended all deprecated React lifecycle methods (componentWillMount and componentWillReceiveProps) with UNSAFE\_.
 
 ### v0.5.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/components/BookCoverEditor.tsx
+++ b/src/components/BookCoverEditor.tsx
@@ -148,6 +148,7 @@ export class BookCoverEditor extends React.Component<BookCoverEditorProps, {}> {
                 label="URL for cover image"
                 ref={this.coverUrlRef}
                 optionalText={false}
+                value={this.props.book.coverUrl}
               />
               <EditableInput
                 elementType="input"


### PR DESCRIPTION
## Description

- Added a value to the book cover URL EditableInput in the BookCoverEditor component.

## Motivation and Context

- Prior to this update, the book cover URL field started out blank for the user, so they weren't able to see the current URL.

## How Has This Been Tested?

- Modeled this change after another EditableInput that already had a value attribute.
- Checked that the field was being displayed in local host.
- Ensured all tests are still passing.

## Checklist:

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
