### PR TITLE
Simply 3869/testing opds versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v0.5.4-test
+
+- Updated the version of opds-web-client in order to test a fix for bugs affecting the List Manager.
+
 ### v0.5.3
 
 #### Updated

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.5.3",
+  "version": "0.5.4-test",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7803,9 +7803,9 @@
       }
     },
     "opds-web-client": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/opds-web-client/-/opds-web-client-0.6.2.tgz",
-      "integrity": "sha512-0soQCzAD83Fu7Zhb3oNnc26S5YdB5ef82Ab5PDxMXVsaPdsWlh3m7/XYFd7GpOnEGgoXjyVUk5MZw3Z0grUrGA==",
+      "version": "0.6.3-test",
+      "resolved": "https://registry.npmjs.org/opds-web-client/-/opds-web-client-0.6.3-test.tgz",
+      "integrity": "sha512-H+20qmJfzlfdtMMRra7IuQZadQH0Y5DD+VD5dIVddIL2bSCvGZlX3xkuDTUbynckjnlGgLGQn8ZQ4GBRWjQLDw==",
       "requires": {
         "@nypl/dgx-svg-icons": "^0.3.4",
         "dompurify": "2.2.8",
@@ -7841,9 +7841,9 @@
           }
         },
         "jsdom": {
-          "version": "16.6.0",
-          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.6.0.tgz",
-          "integrity": "sha512-Ty1vmF4NHJkolaEmdjtxTfSfkdb8Ywarwf63f+F8/mDD1uLSSWDxDuMiZxiPhwunLrn9LOSVItWj4bLYsLN3Dg==",
+          "version": "16.7.0",
+          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.7.0.tgz",
+          "integrity": "sha512-u9Smc2G1USStM+s/x1ru5Sxrl6mPYCbByG1U/hUmqaVsm4tbNyS7CicOSRyuGQYZhTu0h84qkZZQ/I+dzizSVw==",
           "requires": {
             "abab": "^2.0.5",
             "acorn": "^8.2.4",
@@ -7870,7 +7870,7 @@
             "whatwg-encoding": "^1.0.5",
             "whatwg-mimetype": "^2.3.0",
             "whatwg-url": "^8.5.0",
-            "ws": "^7.4.5",
+            "ws": "^7.4.6",
             "xml-name-validator": "^3.0.0"
           }
         },
@@ -12667,9 +12667,9 @@
       }
     },
     "ws": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.1.tgz",
-      "integrity": "sha512-2c6faOUH/nhoQN6abwMloF7Iyl0ZS2E9HGtsiLrWn0zOOMWlhtDmdf/uihDt6jnuCxgtwGBNy6Onsoy2s2O2Ow=="
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
+      "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg=="
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.5.3",
+  "version": "0.5.4-test",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "library-simplified-reusable-components": "1.3.18",
     "numeral": "^2.0.6",
     "opds-feed-parser": "0.0.17",
-    "opds-web-client": "v0.6.3-test",
+    "opds-web-client": "0.6.3-test",
     "prop-types": "^15.7.2",
     "qs": "^6.2.0",
     "react": "^16.8.6",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "library-simplified-reusable-components": "1.3.18",
     "numeral": "^2.0.6",
     "opds-feed-parser": "0.0.17",
-    "opds-web-client": "^0.6.2",
+    "opds-web-client": "v0.6.3-test",
     "prop-types": "^15.7.2",
     "qs": "^6.2.0",
     "react": "^16.8.6",


### PR DESCRIPTION
## Description

- Updated opds-web-client dependency version from 0.6.2 to 0.6.3-test.

## Motivation and Context

- Testing a potential solution to [SIMPLY-3869](https://jira.nypl.org/browse/SIMPLY-3869).