### PR TITLE
Removes value from cover editor URL input and adds description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changelog
 
+### 08/30/21 (to be included in future release)
+
+#### Updated
+
+- Updated the book cover editor so that the current cover URL pulls through not as a value in the input (as described in v0.5.3), but as a description beneath the input.
+
 ### v0.5.4
 
 #### Updated

--- a/src/components/BookCoverEditor.tsx
+++ b/src/components/BookCoverEditor.tsx
@@ -146,9 +146,13 @@ export class BookCoverEditor extends React.Component<BookCoverEditorProps, {}> {
                 disabled={this.props.isFetching}
                 name="cover_url"
                 label="URL for cover image"
+                description={
+                  this.props.book.coverUrl
+                    ? `Current URL: ${this.props.book.coverUrl}`
+                    : ""
+                }
                 ref={this.coverUrlRef}
                 optionalText={false}
-                value={this.props.book.coverUrl}
               />
               <EditableInput
                 elementType="input"


### PR DESCRIPTION
## Description

- Removed current URL as default value in cover image URL input. 
- Added a description below the input that shows the current cover URL instead.

## Motivation and Context

- The current cover image URL should be available to the user, but shouldn't pre-populate the form. This is because the user is most likely intending on changing the image and may even upload a file from the computer as opposed to using this input field.

## How Has This Been Tested?

- Ran existing tests and all pass.
