### PR TITLE
Simply 3798/save this list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 #### Updated
 
-- Updated CustomListEditor so that the "Save this list" button is disabled if either title or entries are absent, and enabled if both are present.
+- Updated `CustomListEditor` so that the "Save this list" button is disabled if either title or entries are absent, and enabled if both are present.
 - Updated the book cover editor so that the current cover URL pulls through not as a value in the input (as described in v0.5.3), but as a description beneath the input.
 
 ### v0.5.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 ## Changelog
 
-### 08/30/21 (to be included in future release)
+### v0.5.5
 
 #### Updated
 
+- Updated CustomListEditor so that the "Save this list" button is disabled if either title or entries are absent, and enabled if both are present.
 - Updated the book cover editor so that the current cover URL pulls through not as a value in the input (as described in v0.5.3), but as a description beneath the input.
 
 ### v0.5.4

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/components/CustomListEditor.tsx
+++ b/src/components/CustomListEditor.tsx
@@ -183,7 +183,12 @@ export default class CustomListEditor extends React.Component<
     // into account.
     if (!nextProps.list && !this.props.list) {
       // This is no current or previous list, so this is a new list.
-      this.setState({ title: "", entries: [], collections: [] });
+      if (!this.state.title) {
+        this.setState({ title: "", entries: [], collections: [] });
+      } else {
+        // This is a new list, but the user has already entered a title.
+        this.setState({ entries: [], collections: [] });
+      }
     } else if (nextProps.list && nextProps.listId !== this.props.listId) {
       // Update the state with the next list to edit.
       this.setState({

--- a/src/components/CustomListEditor.tsx
+++ b/src/components/CustomListEditor.tsx
@@ -74,7 +74,7 @@ export default class CustomListEditor extends React.Component<
     const hasChanges = this.hasChanges();
     // The "save this list" button should be disabled if there are no changes
     // or if the list's title is empty.
-    const disableSave = this.isTitleEmpty() || !hasChanges;
+    const disableSave = this.isTitleOrEntriesEmpty() || !hasChanges;
     return (
       <div className="custom-list-editor">
         <div className="custom-list-editor-header">
@@ -228,14 +228,20 @@ export default class CustomListEditor extends React.Component<
     }
   }
 
-  isTitleEmpty(): boolean {
-    if (this.props.list?.title) {
+  isTitleOrEntriesEmpty(): boolean {
+    // Checks if the list is in a saveable state (aka, has a title and books).
+    if (
+      (this.props.list?.title || this.state.title) &&
+      this.state.title !== "list title" &&
+      this.state.entries.length
+    ) {
       return false;
     } else {
       return (
         !this.state.title ||
         this.state.title === "list title" ||
-        this.state.title === ""
+        this.state.title === "" ||
+        this.state.entries.length === 0
       );
     }
   }

--- a/src/components/CustomListEditor.tsx
+++ b/src/components/CustomListEditor.tsx
@@ -182,13 +182,7 @@ export default class CustomListEditor extends React.Component<
     // state of the component can already have updates that need to be taken
     // into account.
     if (!nextProps.list && !this.props.list) {
-      // This is no current or previous list, so this is a new list.
-      if (!this.state.title) {
-        this.setState({ title: "", entries: [], collections: [] });
-      } else {
-        // This is a new list, but the user has already entered a title.
-        this.setState({ entries: [], collections: [] });
-      }
+      this.setState({ entries: [], collections: [] });
     } else if (nextProps.list && nextProps.listId !== this.props.listId) {
       // Update the state with the next list to edit.
       this.setState({

--- a/src/components/__tests__/CustomListEditor-test.tsx
+++ b/src/components/__tests__/CustomListEditor-test.tsx
@@ -246,7 +246,7 @@ describe("CustomListEditor", () => {
     getEntriesStub.restore();
   });
 
-  it("shouldn't allow you to save unless the list has a title", () => {
+  it("shouldn't allow you to save unless the list has a title and entries", () => {
     wrapper = mount(
       <CustomListEditor
         library={library}
@@ -267,6 +267,14 @@ describe("CustomListEditor", () => {
     expect(saveButton.props().disabled).to.equal(true);
 
     wrapper.setState({ title: "new list title" });
+    saveButton = wrapper.find(".save-or-cancel-list").find(Button).at(0);
+
+    expect(saveButton.props().disabled).to.equal(true);
+
+    wrapper.setState({
+      title: "new list title",
+      entries: [{ id: "1234", title: "a", authors: [] }],
+    });
     saveButton = wrapper.find(".save-or-cancel-list").find(Button).at(0);
 
     expect(saveButton.props().disabled).to.equal(false);
@@ -304,7 +312,7 @@ describe("CustomListEditor", () => {
       "getEntries"
     ).returns(newEntries);
     const saveButton = wrapper.find(".save-or-cancel-list").find(Button).at(0);
-    wrapper.setState({ title: "new list title" });
+    wrapper.setState({ title: "new list title", entries: newEntries });
     saveButton.simulate("click");
 
     expect(editCustomList.callCount).to.equal(1);

--- a/src/components/__tests__/CustomListEditor-test.tsx
+++ b/src/components/__tests__/CustomListEditor-test.tsx
@@ -718,21 +718,25 @@ describe("CustomListEditor", () => {
       expect(hasChanges).to.equal(true);
     });
   });
-  it("should know whether the list title is blank", () => {
-    // There is a list property with a title
-    expect(wrapper.instance().isTitleEmpty()).to.be.false;
+  it("should know whether the list title is blank, or there are no entries", () => {
+    // There is a list property with a title and entries
+    expect(wrapper.instance().isTitleOrEntriesEmpty()).to.be.false;
     wrapper.setProps({ list: null });
+    wrapper.setState({ entries: [] });
     wrapper.setState({ title: null });
     // New list, no title
-    expect(wrapper.instance().isTitleEmpty()).to.be.true;
+    expect(wrapper.instance().isTitleOrEntriesEmpty()).to.be.true;
     // New list, title is still just the placeholder
     wrapper.setState({ title: "list title" });
-    expect(wrapper.instance().isTitleEmpty()).to.be.true;
+    expect(wrapper.instance().isTitleOrEntriesEmpty()).to.be.true;
     // New list, placeholder has been deleted.
     wrapper.setState({ title: "" });
-    expect(wrapper.instance().isTitleEmpty()).to.be.true;
-    // Adding a title...
+    expect(wrapper.instance().isTitleOrEntriesEmpty()).to.be.true;
+    // Adding a title, but no entries...
     wrapper.setState({ title: "testing..." });
-    expect(wrapper.instance().isTitleEmpty()).to.be.false;
+    expect(wrapper.instance().isTitleOrEntriesEmpty()).to.be.true;
+    // Adding entries...
+    wrapper.setState({ entries: [{ id: "1234", title: "a", authors: [] }] });
+    expect(wrapper.instance().isTitleOrEntriesEmpty()).to.be.false;
   });
 });


### PR DESCRIPTION
## Description

- Updated `CustomListEditor` component so that the "Save this list" button is disabled if either title or entries are absent, and enabled if both are present.

## Motivation and Context

- Previously, users were unable to save the list in a saveable state and able to save a list in what was supposed to be an unsaveable state (see ticket [SIMPLY-3798](https://jira.nypl.org/browse/SIMPLY-3798)).

## How Has This Been Tested?

- Updated tests to 1) test `save` function if title _and_ entries are present, instead of just title and 2) test `isTitleOrEntriesEmpty` function correctly.
- Now, all tests are passing.

## Checklist:

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
