### PR TITLE
Simply 3949/reusable book card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changelog
 
+### 11/23/2021
+
+#### Refactored
+
+- Created reusable component `CustomListBookCard` to reduce repetitive code in `CustomListSearchResults` and `CustomListEntries`.
+
 ### v0.5.9
 
 #### Bugfix

--- a/src/components/CustomListBookCard.tsx
+++ b/src/components/CustomListBookCard.tsx
@@ -27,17 +27,16 @@ export default function CustomListBookCard({
   handleAddEntry,
   handleDeleteEntry,
 }: CustomListBookCardProps) {
+  const isSearchResult = typeOfCard === "searchResult";
+
   return (
     <Draggable key={book.id} draggableId={book.id}>
       {(provided, snapshot) => (
         <li>
           <div
-            className={
-              (typeOfCard === "searchResult"
-                ? "search-result"
-                : "custom-list-entry") +
-              (snapshot.isDragging ? " dragging" : "")
-            }
+            className={`${
+              isSearchResult ? "search-result" : "custom-list-entry"
+            } ${snapshot.isDragging && " dragging"}`}
             ref={provided.innerRef}
             style={provided.draggableStyle}
             {...provided.dragHandleProps}
@@ -60,7 +59,7 @@ export default function CustomListBookCard({
                   View details
                 </CatalogLink>
               )}
-              {typeOfCard === "searchResult" ? (
+              {isSearchResult ? (
                 <Button
                   callback={() => handleAddEntry(book.id)}
                   className="right-align"

--- a/src/components/CustomListBookCard.tsx
+++ b/src/components/CustomListBookCard.tsx
@@ -1,0 +1,93 @@
+import * as React from "react";
+import { Draggable } from "react-beautiful-dnd";
+import { BookData } from "opds-web-client/lib/interfaces";
+import GrabIcon from "./icons/GrabIcon";
+import TrashIcon from "./icons/TrashIcon";
+import AddIcon from "./icons/AddIcon";
+import { Button } from "library-simplified-reusable-components";
+import CatalogLink from "opds-web-client/lib/components/CatalogLink";
+import { getMedium, getMediumSVG } from "opds-web-client/lib/utils/book";
+
+export interface Entry extends BookData {
+  medium?: string;
+}
+
+export interface CustomListBookCardProps {
+  typeOfCard: "searchResult" | "entry";
+  opdsFeedUrl?: string;
+  book: Entry;
+  handleAddEntry?: (id: string) => void;
+  handleDeleteEntry?: (id: string) => void;
+}
+
+export default function CustomListBookCard({
+  typeOfCard,
+  opdsFeedUrl,
+  book,
+  handleAddEntry,
+  handleDeleteEntry,
+}: CustomListBookCardProps) {
+  return (
+    <Draggable key={book.id} draggableId={book.id}>
+      {(provided, snapshot) => (
+        <li>
+          <div
+            className={
+              (typeOfCard === "searchResult"
+                ? "search-result"
+                : "custom-list-entry") +
+              (snapshot.isDragging ? " dragging" : "")
+            }
+            ref={provided.innerRef}
+            style={provided.draggableStyle}
+            {...provided.dragHandleProps}
+          >
+            <GrabIcon />
+            <div>
+              <div className="title">{book.title}</div>
+              <div className="authors">{book.authors.join(", ")}</div>
+            </div>
+            {getMediumSVG(getMedium(book))}
+            <div className="links">
+              {book.url && (
+                <CatalogLink
+                  collectionUrl={opdsFeedUrl}
+                  bookUrl={book.url}
+                  title={book.title}
+                  target="_blank"
+                  className="btn inverted left-align small top-align"
+                >
+                  View details
+                </CatalogLink>
+              )}
+              {typeOfCard === "searchResult" ? (
+                <Button
+                  callback={() => handleAddEntry(book.id)}
+                  className="right-align"
+                  content={
+                    <span>
+                      Add to list
+                      <AddIcon />
+                    </span>
+                  }
+                />
+              ) : (
+                <Button
+                  className="small right-align"
+                  callback={() => handleDeleteEntry(book.id)}
+                  content={
+                    <span>
+                      Remove from list
+                      <TrashIcon />
+                    </span>
+                  }
+                />
+              )}
+            </div>
+          </div>
+          {provided.placeholder}
+        </li>
+      )}
+    </Draggable>
+  );
+}

--- a/src/components/CustomListEntries.tsx
+++ b/src/components/CustomListEntries.tsx
@@ -1,12 +1,10 @@
 import * as React from "react";
-import { Droppable, Draggable } from "react-beautiful-dnd";
+import { Droppable } from "react-beautiful-dnd";
 import { CollectionData, BookData } from "opds-web-client/lib/interfaces";
 import LoadButton from "./LoadButton";
 import TrashIcon from "./icons/TrashIcon";
-import GrabIcon from "./icons/GrabIcon";
 import { Button } from "library-simplified-reusable-components";
-import CatalogLink from "opds-web-client/lib/components/CatalogLink";
-import { getMedium, getMediumSVG } from "opds-web-client/lib/utils/book";
+import CustomListBookCard from "./CustomListBookCard";
 
 export interface Entry extends BookData {
   medium?: string;
@@ -147,55 +145,14 @@ export default function CustomListEntries({
             }
           >
             {entries &&
-              entries.map((book, i) => (
-                <Draggable key={i} draggableId={book.id}>
-                  {(provided, snapshot) => (
-                    <li>
-                      <div
-                        className={
-                          "custom-list-entry" +
-                          (snapshot.isDragging ? " dragging" : "")
-                        }
-                        ref={provided.innerRef}
-                        style={provided.draggableStyle}
-                        {...provided.dragHandleProps}
-                      >
-                        <GrabIcon />
-                        <div>
-                          <div className="title">{book.title}</div>
-                          <div className="authors">
-                            {book.authors.join(", ")}
-                          </div>
-                        </div>
-                        {getMediumSVG(getMedium(book))}
-                        <div className="links">
-                          {book.url && (
-                            <CatalogLink
-                              collectionUrl={opdsFeedUrl}
-                              bookUrl={book.url}
-                              title={book.title}
-                              target="_blank"
-                              className="btn inverted left-align small top-align"
-                            >
-                              View details
-                            </CatalogLink>
-                          )}
-                          <Button
-                            className="small right-align"
-                            callback={() => handleDeleteEntry(book.id)}
-                            content={
-                              <span>
-                                Remove from list
-                                <TrashIcon />
-                              </span>
-                            }
-                          />
-                        </div>
-                      </div>
-                      {provided.placeholder}
-                    </li>
-                  )}
-                </Draggable>
+              entries.map((book) => (
+                <CustomListBookCard
+                  key={book.id}
+                  typeOfCard="entry"
+                  book={book}
+                  opdsFeedUrl={opdsFeedUrl}
+                  handleDeleteEntry={handleDeleteEntry}
+                />
               ))}
             {provided.placeholder}
           </ul>

--- a/src/components/CustomListSearchResults.tsx
+++ b/src/components/CustomListSearchResults.tsx
@@ -1,18 +1,14 @@
 import * as React from "react";
-import { Droppable, Draggable } from "react-beautiful-dnd";
+import { Droppable } from "react-beautiful-dnd";
 import { CollectionData, BookData } from "opds-web-client/lib/interfaces";
 import LoadButton from "./LoadButton";
 import ApplyIcon from "./icons/ApplyIcon";
-import GrabIcon from "./icons/GrabIcon";
-import AddIcon from "./icons/AddIcon";
 import { Button } from "library-simplified-reusable-components";
-import CatalogLink from "opds-web-client/lib/components/CatalogLink";
-import { getMedium, getMediumSVG } from "opds-web-client/lib/utils/book";
+import CustomListBookCard from "./CustomListBookCard";
 
 export interface Entry extends BookData {
   medium?: string;
 }
-
 export interface CustomListSearchResultsProps {
   draggingFrom: string | null;
   entries?: Entry[];
@@ -53,7 +49,7 @@ export default function CustomListSearchResults({
     return resultsNotInEntries;
   };
 
-  const handleAddEntry = (id) => {
+  const handleAddEntry = (id: string) => {
     addEntry(id);
     setDraggingFrom(null);
   };
@@ -107,56 +103,13 @@ export default function CustomListSearchResults({
             {draggingFrom !== "custom-list-entries" &&
               searchResults &&
               resultsToDisplay.map((book) => (
-                <Draggable key={book.id} draggableId={book.id}>
-                  {(provided, snapshot) => (
-                    <li>
-                      <div
-                        className={
-                          "search-result" +
-                          (snapshot.isDragging ? " dragging" : "")
-                        }
-                        ref={provided.innerRef}
-                        style={provided.draggableStyle}
-                        {...provided.dragHandleProps}
-                      >
-                        <GrabIcon />
-                        <div>
-                          <div className="title">{book.title}</div>
-                          <div className="authors">
-                            {book.authors.join(", ")}
-                          </div>
-                        </div>
-                        {getMediumSVG(getMedium(book))}
-                        <div className="links">
-                          {book.url && (
-                            <CatalogLink
-                              collectionUrl={opdsFeedUrl}
-                              bookUrl={book.url}
-                              title={book.title}
-                              target="_blank"
-                              className="btn inverted left-align small top-align"
-                            >
-                              View details
-                            </CatalogLink>
-                          )}
-                          <Button
-                            callback={() => {
-                              handleAddEntry(book.id);
-                            }}
-                            className="right-align"
-                            content={
-                              <span>
-                                Add to list
-                                <AddIcon />
-                              </span>
-                            }
-                          />
-                        </div>
-                      </div>
-                      {provided.placeholder}
-                    </li>
-                  )}
-                </Draggable>
+                <CustomListBookCard
+                  key={book.id}
+                  typeOfCard="searchResult"
+                  book={book}
+                  opdsFeedUrl={opdsFeedUrl}
+                  handleAddEntry={handleAddEntry}
+                />
               ))}
             {provided.placeholder}
           </ul>

--- a/src/components/__tests__/CustomListBookCard-test.tsx
+++ b/src/components/__tests__/CustomListBookCard-test.tsx
@@ -1,0 +1,104 @@
+import { expect } from "chai";
+import { stub } from "sinon";
+import * as React from "react";
+import * as Enzyme from "enzyme";
+import CustomListBookCard from "../CustomListBookCard";
+import { DragDropContext, Draggable } from "react-beautiful-dnd";
+import * as PropTypes from "prop-types";
+import { BookData } from "opds-web-client/lib/interfaces";
+import { Button } from "library-simplified-reusable-components";
+
+export interface Entry extends BookData {
+  medium?: string;
+}
+
+describe("CustomListBookCard", () => {
+  let wrapper;
+
+  const entry: Entry = {
+    id: "A",
+    title: "entry A",
+    authors: ["author 1"],
+    raw: {
+      $: {
+        "schema:additionalType": { value: "http://schema.org/EBook" },
+      },
+    },
+  };
+
+  const searchResult: Entry = {
+    id: "1",
+    title: "result 1",
+    authors: ["author 1"],
+    url: "/some/url1",
+    language: "eng",
+    raw: {
+      $: { "schema:additionalType": { value: "http://schema.org/EBook" } },
+    },
+  };
+
+  const childContextTypes = {
+    pathFor: PropTypes.func.isRequired,
+    router: PropTypes.object.isRequired,
+  };
+  const fullContext = {
+    ...{
+      pathFor: stub().returns("url"),
+      router: {
+        createHref: stub(),
+        push: stub(),
+        isActive: stub(),
+        replace: stub(),
+        go: stub(),
+        goBack: stub(),
+        goForward: stub(),
+        setRouteLeaveHook: stub(),
+      },
+    },
+  };
+
+  const handleDeleteEntry = stub();
+  const handleAddEntry = stub();
+
+  beforeEach(() => {
+    wrapper = Enzyme.mount(
+      <DragDropContext>
+        <CustomListBookCard
+          typeOfCard="entry"
+          book={entry}
+          opdsFeedUrl="opdsFeedUrl"
+          handleDeleteEntry={handleDeleteEntry}
+        />
+      </DragDropContext>,
+      { context: fullContext, childContextTypes }
+    );
+  });
+
+  it("renders a single entry", () => {
+    const result = wrapper.find(Draggable);
+    expect(result.length).to.equal(1);
+    expect(result.at(0).text()).to.contain("entry A");
+    expect(result.at(0).text()).to.contain("author 1e");
+    const button = result.find(Button);
+    expect(button.text()).to.contain("Remove from list");
+  });
+
+  it("renders a single search result", () => {
+    wrapper.setProps({
+      children: (
+        <CustomListBookCard
+          typeOfCard="searchResult"
+          book={searchResult}
+          opdsFeedUrl="opdsFeedUrl"
+          handleDeleteEntry={handleAddEntry}
+        />
+      ),
+    });
+    const result = wrapper.find(Draggable);
+    expect(result.length).to.equal(1);
+    expect(result.at(0).text()).to.contain("result 1");
+    expect(result.at(0).text()).to.contain("author 1");
+    const button = result.find(Button);
+    expect(button.text()).to.contain("Add to list");
+  });
+});

--- a/src/components/__tests__/CustomListBookCard-test.tsx
+++ b/src/components/__tests__/CustomListBookCard-test.tsx
@@ -42,18 +42,16 @@ describe("CustomListBookCard", () => {
     router: PropTypes.object.isRequired,
   };
   const fullContext = {
-    ...{
-      pathFor: stub().returns("url"),
-      router: {
-        createHref: stub(),
-        push: stub(),
-        isActive: stub(),
-        replace: stub(),
-        go: stub(),
-        goBack: stub(),
-        goForward: stub(),
-        setRouteLeaveHook: stub(),
-      },
+    pathFor: stub().returns("url"),
+    router: {
+      createHref: stub(),
+      push: stub(),
+      isActive: stub(),
+      replace: stub(),
+      go: stub(),
+      goBack: stub(),
+      goForward: stub(),
+      setRouteLeaveHook: stub(),
     },
   };
 

--- a/src/components/__tests__/CustomListBuilder-test.tsx
+++ b/src/components/__tests__/CustomListBuilder-test.tsx
@@ -67,22 +67,19 @@ describe("CustomListBuilder", () => {
       pathFor: PropTypes.func.isRequired,
       router: PropTypes.object.isRequired,
     };
-    fullContext = Object.assign(
-      {},
-      {
-        pathFor: stub().returns("url"),
-        router: {
-          createHref: stub(),
-          push: stub(),
-          isActive: stub(),
-          replace: stub(),
-          go: stub(),
-          goBack: stub(),
-          goForward: stub(),
-          setRouteLeaveHook: stub(),
-        },
-      }
-    );
+    fullContext = {
+      pathFor: stub().returns("url"),
+      router: {
+        createHref: stub(),
+        push: stub(),
+        isActive: stub(),
+        replace: stub(),
+        go: stub(),
+        goBack: stub(),
+        goForward: stub(),
+        setRouteLeaveHook: stub(),
+      },
+    };
 
     wrapper = mount(
       <CustomListBuilder

--- a/src/components/__tests__/CustomListEditor-test.tsx
+++ b/src/components/__tests__/CustomListEditor-test.tsx
@@ -375,7 +375,7 @@ describe("CustomListEditor", () => {
     expect(window.location.href).to.contain("1");
   });
 
-  it("should properly display how many books are in the entry list", () => {
+  it("properly displays how many books are in the entry list", () => {
     let display = wrapper.find(".custom-list-entries h4");
 
     expect(display.text()).to.equal("Displaying 1 - 2 of 2 Books");
@@ -384,6 +384,8 @@ describe("CustomListEditor", () => {
     deleteLink.at(0).simulate("click");
 
     expect(display.text()).to.equal("Displaying 1 - 1 of 1 Book");
+
+    deleteLink = wrapper.find(".custom-list-entries .links").find(Button);
 
     deleteLink.at(0).simulate("click");
 
@@ -421,7 +423,7 @@ describe("CustomListEditor", () => {
     let addAllBtn = wrapper.find(".add-all-button").at(0);
     addAllBtn.simulate("click");
 
-    // // All search results were added to the entries.
+    // All search results were added to the entries.
     searchEntries = wrapper.find(".custom-list-search-results li");
     expect(searchEntries.length).to.equal(0);
     expect(display.text()).to.equal("Displaying 1 - 30 of 30 Books");

--- a/src/components/__tests__/CustomListEditor-test.tsx
+++ b/src/components/__tests__/CustomListEditor-test.tsx
@@ -137,18 +137,16 @@ describe("CustomListEditor", () => {
       router: PropTypes.object.isRequired,
     };
     fullContext = {
-      ...{
-        pathFor: stub().returns("url"),
-        router: {
-          createHref: stub(),
-          push: stub(),
-          isActive: stub(),
-          replace: stub(),
-          go: stub(),
-          goBack: stub(),
-          goForward: stub(),
-          setRouteLeaveHook: stub(),
-        },
+      pathFor: stub().returns("url"),
+      router: {
+        createHref: stub(),
+        push: stub(),
+        isActive: stub(),
+        replace: stub(),
+        go: stub(),
+        goBack: stub(),
+        goForward: stub(),
+        setRouteLeaveHook: stub(),
       },
     };
 

--- a/src/components/__tests__/CustomListEntries-test.tsx
+++ b/src/components/__tests__/CustomListEntries-test.tsx
@@ -58,18 +58,16 @@ describe("CustomListEntries", () => {
     router: PropTypes.object.isRequired,
   };
   const fullContext = {
-    ...{
-      pathFor: stub().returns("url"),
-      router: {
-        createHref: stub(),
-        push: stub(),
-        isActive: stub(),
-        replace: stub(),
-        go: stub(),
-        goBack: stub(),
-        goForward: stub(),
-        setRouteLeaveHook: stub(),
-      },
+    pathFor: stub().returns("url"),
+    router: {
+      createHref: stub(),
+      push: stub(),
+      isActive: stub(),
+      replace: stub(),
+      go: stub(),
+      goBack: stub(),
+      goForward: stub(),
+      setRouteLeaveHook: stub(),
     },
   };
 

--- a/src/components/__tests__/CustomListSearchResults-test.tsx
+++ b/src/components/__tests__/CustomListSearchResults-test.tsx
@@ -93,21 +93,18 @@ describe("CustomListSearchResults", () => {
     router: PropTypes.object.isRequired,
   };
   const fullContext = {
-    ...{
-      pathFor: stub().returns("url"),
-      router: {
-        createHref: stub(),
-        push: stub(),
-        isActive: stub(),
-        replace: stub(),
-        go: stub(),
-        goBack: stub(),
-        goForward: stub(),
-        setRouteLeaveHook: stub(),
-      },
+    pathFor: stub().returns("url"),
+    router: {
+      createHref: stub(),
+      push: stub(),
+      isActive: stub(),
+      replace: stub(),
+      go: stub(),
+      goBack: stub(),
+      goForward: stub(),
+      setRouteLeaveHook: stub(),
     },
   };
-
   beforeEach(() => {
     wrapper = Enzyme.mount(
       <DragDropContext>


### PR DESCRIPTION
## Description

- Created reusable component `CustomListBookCard` to reduce repetitive code in `CustomListSearchResults` and `CustomListEntries`.
- Added and adjusted tests where necessary.
- Simplified `fullContext` object in tests related to the List Manager.

## Motivation and Context

- Makes code neater and easier to read.

## How Has This Been Tested?

- Unit tests all pass.
- Functionality seems to work as expected in localhost.

## Checklist:

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
