### PR TITLE
Simply 3969/clear draft bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changelog
 
+### 12/8/2021
+
+#### Bugfix
+
+- Fixed bug wherein if a user added or deleted books from a list, then navigated to a new list without saving, the deletedListEntries and addedListEntries would not be reset to empty and therefore would cause the displayed number of books in a list to be wrong.
+
 ### v0.5.10
 
 #### Refactored

--- a/src/components/CustomListEditor.tsx
+++ b/src/components/CustomListEditor.tsx
@@ -9,7 +9,6 @@ import CustomListEditorHeader from "./CustomListEditorHeader";
 import CustomListEditorBody from "./CustomListEditorBody";
 import { Entry } from "./CustomListBuilder";
 import { getMedium } from "opds-web-client/lib/utils/book";
-import { EntryPoint } from "./CustomListSearch";
 export interface CustomListEditorProps {
   languages: LanguagesData;
   library: LibraryData;
@@ -68,6 +67,12 @@ export default function CustomListEditor({
       setDraftTitle(list.title);
       setDraftEntries(list.books);
       setDraftCollections(listCollections);
+      /**
+       * Whenever the user navigates to a new list,
+       * we want to set the deleted and added buckets back to empty.
+       */
+      setDeletedListEntries([]);
+      setAddedListEntries([]);
     } else {
       /**
        * If the list is new, set the draft state to empty.
@@ -75,6 +80,8 @@ export default function CustomListEditor({
       setDraftTitle("");
       setDraftEntries([]);
       setDraftCollections([]);
+      setDeletedListEntries([]);
+      setAddedListEntries([]);
     }
     /**
      * If the user has clicked the "Load more" button at the base of the entries list...

--- a/src/components/__tests__/CustomListEditor-test.tsx
+++ b/src/components/__tests__/CustomListEditor-test.tsx
@@ -55,6 +55,15 @@ describe("CustomListEditor", () => {
     navigationLinks: [],
   };
 
+  const listData2 = {
+    id: "2",
+    url: "some url 2",
+    title: "original list title 2",
+    lanes: [],
+    books: [],
+    navigationLinks: [],
+  };
+
   const searchResultsData = {
     id: "id",
     url: "url",
@@ -465,5 +474,36 @@ describe("CustomListEditor", () => {
     // All the search results should be back in the search result list.
     searchEntries = wrapper.find(".custom-list-search-results li");
     expect(searchEntries.length).to.equal(newSearchResultsData.length);
+  });
+
+  it("resets deletedListEntries and addedListEntries if user navigates to new list", () => {
+    let editorBody = wrapper.find(CustomListEditorBody);
+    expect(editorBody.props().deletedListEntries.length).to.equal(0);
+    expect(editorBody.props().addedListEntries.length).to.equal(0);
+
+    const deleteLink = wrapper.find(".custom-list-entries .links").find(Button);
+    deleteLink.at(0).simulate("click");
+
+    editorBody = wrapper.find(CustomListEditorBody);
+    expect(editorBody.props().deletedListEntries.length).to.equal(1);
+
+    const addLink = wrapper
+      .find(".custom-list-search-results .links")
+      .find(Button);
+    addLink.at(0).simulate("click");
+
+    editorBody = wrapper.find(CustomListEditorBody);
+    expect(editorBody.props().addedListEntries.length).to.equal(1);
+
+    wrapper.setProps({
+      list: listData2,
+      listId: "2",
+    });
+
+    wrapper.update();
+
+    editorBody = wrapper.find(CustomListEditorBody);
+    expect(editorBody.props().deletedListEntries.length).to.equal(0);
+    expect(editorBody.props().addedListEntries.length).to.equal(0);
   });
 });


### PR DESCRIPTION
## Description

- Fixed bug wherein if a user added or deleted books from a list, then navigated to a new list without saving, the deletedListEntries and addedListEntries would not be reset to empty.

## Motivation and Context

- This issue would cause the displayed number of books in a list to be wrong.

## How Has This Been Tested?

- Added a new test to CustomListEditor-test to check.
- All existing tests still pass.

## Checklist:

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
