### PR TITLE
Simply 2729/special characters in list title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 #### Bugfix
 
-- Fixed issue where the "View Details" button did not work in the List Manager.
+- Fixed issue where the "View Details" button in the List Manager caused an error.
 
 ### v0.5.10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changelog
 
+### v0.5.11
+
+#### Bugfix
+
+- Fixed issue where the "View Details" button did not work in the List Manager.
+
 ### v0.5.10
 
 #### Refactored

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-circulation-web",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/components/CustomListBookCard.tsx
+++ b/src/components/CustomListBookCard.tsx
@@ -50,7 +50,7 @@ export default function CustomListBookCard({
             <div className="links">
               {book.url && (
                 <CatalogLink
-                  collectionUrl={opdsFeedUrl}
+                  // collectionUrl={opdsFeedUrl}
                   bookUrl={book.url}
                   title={book.title}
                   target="_blank"

--- a/src/components/CustomListBookCard.tsx
+++ b/src/components/CustomListBookCard.tsx
@@ -50,7 +50,6 @@ export default function CustomListBookCard({
             <div className="links">
               {book.url && (
                 <CatalogLink
-                  // collectionUrl={opdsFeedUrl}
                   bookUrl={book.url}
                   title={book.title}
                   target="_blank"

--- a/src/components/CustomListEditorBody.tsx
+++ b/src/components/CustomListEditorBody.tsx
@@ -87,6 +87,12 @@ export default function CustomListEditorBody({
     setDraftCollections(newCollections);
   };
 
+  // const encodedTitle = draftTitle
+  //   ? encodeURIComponent(draftTitle).replace(/!/g, "%21")
+  //   : "";
+
+  // const crawlable = `lists/${encodedTitle}/crawlable`;
+
   const crawlable = `${draftTitle ? `lists/${draftTitle}/` : ""}crawlable`;
   const opdsFeedUrl = `${library?.short_name}/${crawlable}`;
 

--- a/src/components/CustomListEditorBody.tsx
+++ b/src/components/CustomListEditorBody.tsx
@@ -87,12 +87,6 @@ export default function CustomListEditorBody({
     setDraftCollections(newCollections);
   };
 
-  // const encodedTitle = draftTitle
-  //   ? encodeURIComponent(draftTitle).replace(/!/g, "%21")
-  //   : "";
-
-  // const crawlable = `lists/${encodedTitle}/crawlable`;
-
   const crawlable = `${draftTitle ? `lists/${draftTitle}/` : ""}crawlable`;
   const opdsFeedUrl = `${library?.short_name}/${crawlable}`;
 


### PR DESCRIPTION
## Description

- Fixed issue where the "View Details" button did not work in the List Manager.

## Motivation and Context

- When creating a list, if a user clicked "View Details" on any search result or entry, they would get an error. 
- Though seemingly unrelated, I believe this change fixes [SIMPLY-2729](https://jira.nypl.org/browse/SIMPLY-2729).

## How Has This Been Tested?

- I tested this locally with open access collections and non-open access collections.
- All unit tests pass.

## Checklist:

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
