### PR TITLE
Simply 3945/update react beautiful dnd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changelog
 
+### 1/12/22
+
+#### Updated
+
+- Updated the react-beautiful-dnd library from v2.3.1 to v11.0.2, and made necessary changes to the code and tests.
+
 ### v0.5.11
 
 #### Bugfix

--- a/package-lock.json
+++ b/package-lock.json
@@ -1115,6 +1115,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "dev": true,
       "requires": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
@@ -1123,12 +1124,14 @@
         "core-js": {
           "version": "2.6.12",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
+          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
+          "dev": true
         },
         "regenerator-runtime": {
           "version": "0.11.1",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+          "dev": true
         }
       }
     },
@@ -2303,6 +2306,14 @@
         "public-encrypt": "^4.0.0",
         "randombytes": "^2.0.0",
         "randomfill": "^1.0.3"
+      }
+    },
+    "css-box-model": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/css-box-model/-/css-box-model-1.2.1.tgz",
+      "integrity": "sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==",
+      "requires": {
+        "tiny-invariant": "^1.0.6"
       }
     },
     "css-loader": {
@@ -6606,9 +6617,9 @@
       }
     },
     "memoize-one": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-3.1.1.tgz",
-      "integrity": "sha512-YqVh744GsMlZu6xkhGslPSqSurOv6P+kLN2J3ysBZfagLcL5FdRK/0UpgLoL8hwjjEvvAVkjJZyFP+1T6p1vgA=="
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
     },
     "memory-fs": {
       "version": "0.5.0",
@@ -8647,9 +8658,9 @@
       }
     },
     "raf-schd": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-2.1.2.tgz",
-      "integrity": "sha512-Orl0IEvMtUCgPddgSxtxreK77UiQz4nPYJy9RggVzu4mKsZkQWiAaG1y9HlYWdvm9xtN348xRaT37qkvL/+A+g=="
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
+      "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ=="
     },
     "railroad-diagrams": {
       "version": "1.0.0",
@@ -8727,47 +8738,18 @@
       }
     },
     "react-beautiful-dnd": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/react-beautiful-dnd/-/react-beautiful-dnd-2.6.4.tgz",
-      "integrity": "sha512-P+iXbRNpO23PwjsnK1zaoCK2HMdnTMznOfbtf+oU/hZo2F2OuYAVcR1JkbZNk6+P4Aqcu3HfAUT6NlsWzOwGWg==",
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/react-beautiful-dnd/-/react-beautiful-dnd-11.0.2.tgz",
+      "integrity": "sha512-8Z6fTli+w04suhFWUcvmQZLaouqsgWWvsZnKenyTiLs7AzaNREt4OshKCBhb2ml78n5GYMge6WB6nIINRVjK5w==",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "invariant": "^2.2.2",
-        "memoize-one": "^3.0.1",
-        "prop-types": "^15.6.0",
-        "raf-schd": "^2.0.2",
-        "react-motion": "^0.5.2",
-        "react-redux": "^5.0.6",
-        "redux": "^3.7.2",
-        "redux-thunk": "^2.2.0",
-        "reselect": "^3.0.1"
-      },
-      "dependencies": {
-        "react-redux": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.1.2.tgz",
-          "integrity": "sha512-Ns1G0XXc8hDyH/OcBHOxNgQx9ayH3SPxBnFCOidGKSle8pKihysQw2rG/PmciUQRoclhVBO8HMhiRmGXnDja9Q==",
-          "requires": {
-            "@babel/runtime": "^7.1.2",
-            "hoist-non-react-statics": "^3.3.0",
-            "invariant": "^2.2.4",
-            "loose-envify": "^1.1.0",
-            "prop-types": "^15.6.1",
-            "react-is": "^16.6.0",
-            "react-lifecycles-compat": "^3.0.0"
-          }
-        },
-        "redux": {
-          "version": "3.7.2",
-          "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
-          "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
-          "requires": {
-            "lodash": "^4.2.1",
-            "lodash-es": "^4.2.1",
-            "loose-envify": "^1.1.0",
-            "symbol-observable": "^1.0.3"
-          }
-        }
+        "@babel/runtime-corejs2": "^7.4.3",
+        "css-box-model": "^1.1.1",
+        "memoize-one": "^5.0.4",
+        "raf-schd": "^4.0.0",
+        "react-redux": "^7.0.2",
+        "redux": "^4.0.1",
+        "tiny-invariant": "^1.0.4",
+        "use-memo-one": "^1.1.0"
       }
     },
     "react-bootstrap": {
@@ -8823,23 +8805,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
-    },
-    "react-motion": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/react-motion/-/react-motion-0.5.2.tgz",
-      "integrity": "sha512-9q3YAvHoUiWlP3cK0v+w1N5Z23HXMj4IF4YuvjvWegWqNPfLXsOBE/V7UvQGpXxHFKRQQcNcVQE31g9SB/6qgQ==",
-      "requires": {
-        "performance-now": "^0.2.0",
-        "prop-types": "^15.5.8",
-        "raf": "^3.1.0"
-      },
-      "dependencies": {
-        "performance-now": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-          "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
-        }
-      }
     },
     "react-overlays": {
       "version": "0.8.3",
@@ -9387,11 +9352,6 @@
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.3.6.tgz",
       "integrity": "sha512-ipEzlWQe6RK3jkzikgCupiTbTvm4S0/CAU5GlgptkN5SO6F3u0UD0K18wy6ErDqiCyP4J4YYe1HuAShvsxePLg=="
-    },
-    "reselect": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-3.0.1.tgz",
-      "integrity": "sha1-79qpjqdFEyTQkrKyFjpqHXqaIUc="
     },
     "resize-observer-polyfill": {
       "version": "1.5.1",
@@ -11037,6 +10997,11 @@
         "setimmediate": "^1.0.4"
       }
     },
+    "tiny-invariant": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.2.0.tgz",
+      "integrity": "sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg=="
+    },
     "tinycolor2": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.2.tgz",
@@ -11650,6 +11615,11 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
+    },
+    "use-memo-one": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.2.tgz",
+      "integrity": "sha512-u2qFKtxLsia/r8qG0ZKkbytbztzRb317XCkT7yP8wxL0tZ/CzK2G+WWie5vWvpyeP7+YoPIwbJoIHJ4Ba4k0oQ=="
     },
     "user-home": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "prop-types": "^15.7.2",
     "qs": "^6.2.0",
     "react": "^16.8.6",
-    "react-beautiful-dnd": "^2.3.1",
+    "react-beautiful-dnd": "^11.0.2",
     "react-bootstrap": "^0.32.4",
     "react-color": "^2.14.1",
     "react-dom": "^16.8.6",

--- a/src/components/CustomListBookCard.tsx
+++ b/src/components/CustomListBookCard.tsx
@@ -13,6 +13,7 @@ export interface Entry extends BookData {
 }
 
 export interface CustomListBookCardProps {
+  index: number;
   typeOfCard: "searchResult" | "entry";
   opdsFeedUrl?: string;
   book: Entry;
@@ -21,6 +22,7 @@ export interface CustomListBookCardProps {
 }
 
 export default function CustomListBookCard({
+  index,
   typeOfCard,
   opdsFeedUrl,
   book,
@@ -30,62 +32,63 @@ export default function CustomListBookCard({
   const isSearchResult = typeOfCard === "searchResult";
 
   return (
-    <Draggable key={book.id} draggableId={book.id}>
-      {(provided, snapshot) => (
-        <li>
-          <div
-            className={`${
-              isSearchResult ? "search-result" : "custom-list-entry"
-            } ${snapshot.isDragging && " dragging"}`}
-            ref={provided.innerRef}
-            style={provided.draggableStyle}
-            {...provided.dragHandleProps}
-          >
-            <GrabIcon />
-            <div>
-              <div className="title">{book.title}</div>
-              <div className="authors">{book.authors.join(", ")}</div>
+    <Draggable key={book.id} draggableId={String(book.id)} index={index}>
+      {(provided, snapshot) => {
+        return (
+          <li>
+            <div
+              className={`${
+                isSearchResult ? "search-result" : "custom-list-entry"
+              } ${snapshot.isDragging && " dragging"}`}
+              ref={provided.innerRef}
+              {...provided.draggableProps}
+              {...provided.dragHandleProps}
+            >
+              <GrabIcon />
+              <div>
+                <div className="title">{book.title}</div>
+                <div className="authors">{book.authors.join(", ")}</div>
+              </div>
+              {getMediumSVG(getMedium(book))}
+              <div className="links">
+                {book.url && (
+                  <CatalogLink
+                    bookUrl={book.url}
+                    title={book.title}
+                    target="_blank"
+                    className="btn inverted left-align small top-align"
+                  >
+                    View details
+                  </CatalogLink>
+                )}
+                {isSearchResult ? (
+                  <Button
+                    callback={() => handleAddEntry(book.id)}
+                    className="right-align"
+                    content={
+                      <span>
+                        Add to list
+                        <AddIcon />
+                      </span>
+                    }
+                  />
+                ) : (
+                  <Button
+                    className="small right-align"
+                    callback={() => handleDeleteEntry(book.id)}
+                    content={
+                      <span>
+                        Remove from list
+                        <TrashIcon />
+                      </span>
+                    }
+                  />
+                )}
+              </div>
             </div>
-            {getMediumSVG(getMedium(book))}
-            <div className="links">
-              {book.url && (
-                <CatalogLink
-                  bookUrl={book.url}
-                  title={book.title}
-                  target="_blank"
-                  className="btn inverted left-align small top-align"
-                >
-                  View details
-                </CatalogLink>
-              )}
-              {isSearchResult ? (
-                <Button
-                  callback={() => handleAddEntry(book.id)}
-                  className="right-align"
-                  content={
-                    <span>
-                      Add to list
-                      <AddIcon />
-                    </span>
-                  }
-                />
-              ) : (
-                <Button
-                  className="small right-align"
-                  callback={() => handleDeleteEntry(book.id)}
-                  content={
-                    <span>
-                      Remove from list
-                      <TrashIcon />
-                    </span>
-                  }
-                />
-              )}
-            </div>
-          </div>
-          {provided.placeholder}
-        </li>
-      )}
+          </li>
+        );
+      }}
     </Draggable>
   );
 }

--- a/src/components/CustomListBuilder.tsx
+++ b/src/components/CustomListBuilder.tsx
@@ -44,17 +44,12 @@ export default function CustomListBuilder({
   loadMoreSearchResults,
   setLoadedMoreEntries,
 }: CustomListBuilderProps): JSX.Element {
-  const [draggingFrom, setDraggingFrom] = React.useState(null);
-
-  const onDragStart = (initial) => {
+  const onDragStart = () => {
     document.body.classList.add("dragging");
-    const { source } = initial;
-    setDraggingFrom(source.droppableId);
   };
 
   const onDragEnd = (result) => {
     const { draggableId, source, destination } = result;
-
     if (
       source.droppableId === "search-results" &&
       destination &&
@@ -67,8 +62,6 @@ export default function CustomListBuilder({
       destination.droppableId === "search-results"
     ) {
       deleteEntry(draggableId);
-    } else {
-      setDraggingFrom(null);
     }
     document.body.classList.remove("dragging");
   };
@@ -79,12 +72,10 @@ export default function CustomListBuilder({
         <CustomListSearchResults
           entries={entries}
           searchResults={searchResults}
-          draggingFrom={draggingFrom}
           opdsFeedUrl={opdsFeedUrl}
           isFetchingMoreSearchResults={isFetchingMoreSearchResults}
           addEntry={addEntry}
           addAll={addAll}
-          setDraggingFrom={setDraggingFrom}
           loadMoreSearchResults={loadMoreSearchResults}
         />
         <CustomListEntries
@@ -93,10 +84,9 @@ export default function CustomListBuilder({
           deleteEntry={deleteEntry}
           deleteAll={deleteAll}
           deletedListEntries={deletedListEntries}
-          draggingFrom={draggingFrom}
           addedListEntries={addedListEntries}
           opdsFeedUrl={opdsFeedUrl}
-          setDraggingFrom={setDraggingFrom}
+          searchResults={searchResults}
           isFetchingMoreCustomListEntries={isFetchingMoreCustomListEntries}
           nextPageUrl={nextPageUrl}
           loadMoreEntries={loadMoreEntries}

--- a/src/components/CustomListEntries.tsx
+++ b/src/components/CustomListEntries.tsx
@@ -13,32 +13,32 @@ export interface Entry extends BookData {
 export interface CustomListEntriesProps {
   addedListEntries: Entry[];
   deletedListEntries: Entry[];
-  draggingFrom: string | null;
   entries?: Entry[];
   entryCount?: string;
   isFetchingMoreCustomListEntries: boolean;
   nextPageUrl?: string;
   opdsFeedUrl?: string;
+  searchResults?: CollectionData;
   deleteAll: () => void;
   deleteEntry?: (id: string) => void;
   loadMoreEntries: (url: string) => Promise<CollectionData>;
-  setDraggingFrom: (dragging: string | null) => void;
   setLoadedMoreEntries: (clicked: boolean) => void;
+  // Including for test purposes
+  children?: any;
 }
 
 export default function CustomListEntries({
   addedListEntries,
   deletedListEntries,
-  draggingFrom,
   entries,
   entryCount,
   isFetchingMoreCustomListEntries,
   nextPageUrl,
   opdsFeedUrl,
+  searchResults,
   deleteAll,
   deleteEntry,
   loadMoreEntries,
-  setDraggingFrom,
   setLoadedMoreEntries,
 }: CustomListEntriesProps) {
   const [totalVisibleEntries, setTotalVisibleEntries] = React.useState(0);
@@ -49,12 +49,10 @@ export default function CustomListEntries({
 
   const handleDeleteEntry = (id: string) => {
     deleteEntry(id);
-    setDraggingFrom(null);
   };
 
   const handleDeleteAll = () => {
     deleteAll();
-    setDraggingFrom(null);
   };
 
   let entryListDisplay = "No books in this list";
@@ -131,11 +129,10 @@ export default function CustomListEntries({
           </div>
         )}
       </div>
-      <p>Drag search results here to add them to the list.</p>
-      <Droppable
-        droppableId="custom-list-entries"
-        isDropDisabled={draggingFrom !== "search-results"}
-      >
+      {searchResults && (
+        <p>Drag search results here to add them to the list.</p>
+      )}
+      <Droppable droppableId="custom-list-entries">
         {(provided, snapshot) => (
           <ul
             ref={provided.innerRef}
@@ -145,8 +142,9 @@ export default function CustomListEntries({
             }
           >
             {entries &&
-              entries.map((book) => (
+              entries.map((book, index) => (
                 <CustomListBookCard
+                  index={index}
                   key={book.id}
                   typeOfCard="entry"
                   book={book}

--- a/src/components/CustomListSearchResults.tsx
+++ b/src/components/CustomListSearchResults.tsx
@@ -10,7 +10,6 @@ export interface Entry extends BookData {
   medium?: string;
 }
 export interface CustomListSearchResultsProps {
-  draggingFrom: string | null;
   entries?: Entry[];
   isFetchingMoreSearchResults: boolean;
   opdsFeedUrl?: string;
@@ -18,11 +17,11 @@ export interface CustomListSearchResultsProps {
   addAll: (resultsToAdd: Entry[]) => void;
   addEntry?: (id: string) => void;
   loadMoreSearchResults: (url: string) => Promise<CollectionData>;
-  setDraggingFrom: (className: string | null) => void;
+  // Including for test purposes
+  children?: any;
 }
 
 export default function CustomListSearchResults({
-  draggingFrom,
   entries,
   isFetchingMoreSearchResults,
   opdsFeedUrl,
@@ -30,7 +29,6 @@ export default function CustomListSearchResults({
   addAll,
   addEntry,
   loadMoreSearchResults,
-  setDraggingFrom,
 }: CustomListSearchResultsProps) {
   const searchResultsNotInEntries = () => {
     const entryIds =
@@ -51,13 +49,11 @@ export default function CustomListSearchResults({
 
   const handleAddEntry = (id: string) => {
     addEntry(id);
-    setDraggingFrom(null);
   };
 
   const handleAddAll = () => {
     const resultsToAdd = searchResultsNotInEntries();
     addAll(resultsToAdd);
-    setDraggingFrom(null);
   };
 
   const resultsToDisplay = searchResults && searchResultsNotInEntries();
@@ -73,23 +69,24 @@ export default function CustomListSearchResults({
       <div className="droppable-header">
         <h4>Search Results</h4>
         {searchResults && resultsToDisplay.length > 0 && (
-          <Button
-            key="addAll"
-            className="add-all-button"
-            callback={handleAddAll}
-            content={
-              <span>
-                Add all to list
-                <ApplyIcon />
-              </span>
-            }
-          />
+          <div>
+            <span>Add all currently visible items from list:</span>
+            <Button
+              key="addAll"
+              className="add-all-button"
+              callback={handleAddAll}
+              content={
+                <span>
+                  Add all to list
+                  <ApplyIcon />
+                </span>
+              }
+            />
+          </div>
         )}
       </div>
-      <Droppable
-        droppableId="search-results"
-        isDropDisabled={draggingFrom !== "custom-list-entries"}
-      >
+      {entries && <p>Drag books here to remove them from the list.</p>}
+      <Droppable droppableId="search-results">
         {(provided, snapshot) => (
           <ul
             ref={provided.innerRef}
@@ -97,14 +94,11 @@ export default function CustomListSearchResults({
               snapshot.isDraggingOver ? "droppable dragging-over" : "droppable"
             }
           >
-            {draggingFrom === "custom-list-entries" && (
-              <p>Drag books here to remove them from the list.</p>
-            )}
-            {draggingFrom !== "custom-list-entries" &&
-              searchResults &&
-              resultsToDisplay.map((book) => (
+            {searchResults &&
+              resultsToDisplay.map((book, index) => (
                 <CustomListBookCard
                   key={book.id}
+                  index={index}
                   typeOfCard="searchResult"
                   book={book}
                   opdsFeedUrl={opdsFeedUrl}

--- a/src/components/Lane.tsx
+++ b/src/components/Lane.tsx
@@ -58,7 +58,7 @@ export default class Lane extends React.Component<LaneProps, LaneState> {
             (active ? "active" : "")
           }
           ref={provided && provided.innerRef}
-          style={provided && provided.draggableStyle}
+          {...(provided ? provided.draggableProps : {})}
           {...(provided ? provided.dragHandleProps : {})}
         >
           <div className={"lane-info" + (provided ? " draggable" : "")}>
@@ -87,7 +87,6 @@ export default class Lane extends React.Component<LaneProps, LaneState> {
             hasSublanes &&
             renderLanes(lane.sublanes, lane)}
         </div>
-        {provided && provided.placeholder}
       </li>
     );
   }

--- a/src/components/Lane.tsx
+++ b/src/components/Lane.tsx
@@ -58,8 +58,9 @@ export default class Lane extends React.Component<LaneProps, LaneState> {
             (active ? "active" : "")
           }
           ref={provided && provided.innerRef}
-          {...(provided ? provided.draggableProps : {})}
-          {...(provided ? provided.dragHandleProps : {})}
+          {...(provided
+            ? { ...provided.draggableProps, ...provided.dragHandleProps }
+            : {})}
         >
           <div className={"lane-info" + (provided ? " draggable" : "")}>
             <span>

--- a/src/components/LaneCustomListsEditor.tsx
+++ b/src/components/LaneCustomListsEditor.tsx
@@ -6,28 +6,18 @@ import TrashIcon from "./icons/TrashIcon";
 import GrabIcon from "./icons/GrabIcon";
 import { Button } from "library-simplified-reusable-components";
 
-export interface LaneCustomListsEditorProps
-  extends React.Props<LaneCustomListsEditor> {
+export interface LaneCustomListsEditorProps {
   allCustomLists: CustomListData[];
   customListIds: number[];
   onUpdate?: (customListIds: number[]) => void;
 }
 
-export interface LaneCustomListsEditorState {
-  draggingFrom: string | null;
-}
-
 /** Drag and drop interface for adding custom lists to a lane. */
 export default class LaneCustomListsEditor extends React.Component<
-  LaneCustomListsEditorProps,
-  LaneCustomListsEditorState
+  LaneCustomListsEditorProps
 > {
   constructor(props) {
     super(props);
-    this.state = {
-      draggingFrom: null,
-    };
-
     this.onDragStart = this.onDragStart.bind(this);
     this.onDragEnd = this.onDragEnd.bind(this);
   }
@@ -43,10 +33,7 @@ export default class LaneCustomListsEditor extends React.Component<
             <div className="droppable-header">
               <h4>Available Lists ({this.listsNotInLane().length})</h4>
             </div>
-            <Droppable
-              droppableId="available-lists"
-              isDropDisabled={this.state.draggingFrom !== "current-lists"}
-            >
+            <Droppable droppableId="available-lists">
               {(provided, snapshot) => (
                 <div
                   ref={provided.innerRef}
@@ -56,50 +43,50 @@ export default class LaneCustomListsEditor extends React.Component<
                       : "droppable"
                   }
                 >
-                  {this.state.draggingFrom === "current-lists" && (
+                  {snapshot.isDraggingOver && (
                     <p>Drag lists here to remove them from the lane.</p>
                   )}
-                  {this.state.draggingFrom !== "current-lists" &&
-                    this.listsNotInLane().map((list) => (
-                      <Draggable key={list.id} draggableId={list.id}>
-                        {(provided, snapshot) => (
-                          <div>
-                            <div
-                              className={
-                                "available-list" +
-                                (snapshot.isDragging ? " dragging" : "")
-                              }
-                              ref={provided.innerRef}
-                              style={provided.draggableStyle}
-                              {...provided.dragHandleProps}
-                            >
-                              <GrabIcon />
-                              <div className="list-info">
-                                <div className="list-name">{list.name}</div>
-                                <div className="list-count">
-                                  Items in list: {list.entry_count}
-                                </div>
-                                <div className="list-id">ID-{list.id}</div>
-                              </div>
-                              <div className="links">
-                                <Button
-                                  className="inverted"
-                                  callback={() => {
-                                    this.add(list.id);
-                                  }}
-                                  content={
-                                    <span>
-                                      Add to lane <AddIcon />
-                                    </span>
-                                  }
-                                />
-                              </div>
+                  {this.listsNotInLane().map((list, index) => (
+                    <Draggable
+                      key={list.id}
+                      draggableId={list.id}
+                      index={index}
+                    >
+                      {(provided, snapshot) => (
+                        <div
+                          className={
+                            "available-list" +
+                            (snapshot.isDragging ? " dragging" : "")
+                          }
+                          ref={provided.innerRef}
+                          {...provided.draggableProps}
+                          {...provided.dragHandleProps}
+                        >
+                          <GrabIcon />
+                          <div className="list-info">
+                            <div className="list-name">{list.name}</div>
+                            <div className="list-count">
+                              Items in list: {list.entry_count}
                             </div>
-                            {provided.placeholder}
+                            <div className="list-id">ID-{list.id}</div>
                           </div>
-                        )}
-                      </Draggable>
-                    ))}
+                          <div className="links">
+                            <Button
+                              className="inverted"
+                              callback={() => {
+                                this.add(list.id);
+                              }}
+                              content={
+                                <span>
+                                  Add to lane <AddIcon />
+                                </span>
+                              }
+                            />
+                          </div>
+                        </div>
+                      )}
+                    </Draggable>
+                  ))}
                   {provided.placeholder}
                 </div>
               )}
@@ -110,56 +97,56 @@ export default class LaneCustomListsEditor extends React.Component<
             <div className="droppable-header">
               <h4>Lists in this Lane ({this.listsInLane().length})</h4>
             </div>
-            <Droppable
-              droppableId="current-lists"
-              isDropDisabled={this.state.draggingFrom !== "available-lists"}
-            >
+            <Droppable droppableId="current-lists">
               {(provided, snapshot) => (
                 <div
                   ref={provided.innerRef}
                   className={
                     snapshot.isDraggingOver
-                      ? " droppable dragging-over"
+                      ? "droppable dragging-over"
                       : "droppable"
                   }
                 >
-                  <p>Drag lists here to add them to the lane.</p>
-                  {this.listsInLane().map((list) => (
-                    <Draggable key={list.id} draggableId={list.id}>
+                  {snapshot.isDraggingOver && (
+                    <p>Drag lists here to add them to the lane.</p>
+                  )}
+                  {this.listsInLane().map((list, index) => (
+                    <Draggable
+                      key={list.id}
+                      draggableId={list.id}
+                      index={index}
+                    >
                       {(provided, snapshot) => (
-                        <div>
-                          <div
-                            className={
-                              "current-list" +
-                              (snapshot.isDragging ? " dragging" : "")
-                            }
-                            ref={provided.innerRef}
-                            style={provided.draggableStyle}
-                            {...provided.dragHandleProps}
-                          >
-                            <GrabIcon />
-                            <div className="list-info">
-                              <div className="list-name">{list.name}</div>
-                              <div className="list-count">
-                                Items in list: {list.entry_count}
-                              </div>
-                              <div className="list-id">ID-{list.id}</div>
+                        <div
+                          className={
+                            "current-list" +
+                            (snapshot.isDragging ? " dragging" : "")
+                          }
+                          ref={provided.innerRef}
+                          {...provided.draggableProps}
+                          {...provided.dragHandleProps}
+                        >
+                          <GrabIcon />
+                          <div className="list-info">
+                            <div className="list-name">{list.name}</div>
+                            <div className="list-count">
+                              Items in list: {list.entry_count}
                             </div>
-                            <div className="links">
-                              <Button
-                                className="danger"
-                                callback={() => {
-                                  this.remove(list.id);
-                                }}
-                                content={
-                                  <span>
-                                    Remove from lane <TrashIcon />
-                                  </span>
-                                }
-                              />
-                            </div>
+                            <div className="list-id">ID-{list.id}</div>
                           </div>
-                          {provided.placeholder}
+                          <div className="links">
+                            <Button
+                              className="danger"
+                              callback={() => {
+                                this.remove(list.id);
+                              }}
+                              content={
+                                <span>
+                                  Remove from lane <TrashIcon />
+                                </span>
+                              }
+                            />
+                          </div>
                         </div>
                       )}
                     </Draggable>
@@ -205,8 +192,7 @@ export default class LaneCustomListsEditor extends React.Component<
 
   add(listId) {
     const customListIds = this.getCustomListIds();
-    customListIds.push(parseInt(String(listId), 10));
-    this.setState({ draggingFrom: null });
+    customListIds.push(parseInt(listId, 10));
     if (this.props.onUpdate) {
       this.props.onUpdate(customListIds);
     }
@@ -215,16 +201,12 @@ export default class LaneCustomListsEditor extends React.Component<
   remove(listId) {
     let customListIds = this.getCustomListIds();
     customListIds = customListIds.filter((id) => id !== listId);
-    this.setState({ draggingFrom: null });
     if (this.props.onUpdate) {
       this.props.onUpdate(customListIds);
     }
   }
 
   reset(ids: number[]) {
-    this.setState({
-      draggingFrom: null,
-    });
     if (this.props.onUpdate) {
       this.props.onUpdate(ids);
     }
@@ -234,10 +216,8 @@ export default class LaneCustomListsEditor extends React.Component<
     return this.props.customListIds || [];
   }
 
-  onDragStart(initial) {
+  onDragStart() {
     document.body.classList.add("dragging");
-    const source = initial.source;
-    this.setState({ draggingFrom: source.droppableId });
   }
 
   onDragEnd(result) {
@@ -257,8 +237,6 @@ export default class LaneCustomListsEditor extends React.Component<
       destination.droppableId === "available-lists"
     ) {
       this.remove(draggableId);
-    } else {
-      this.setState({ draggingFrom: null });
     }
 
     document.body.classList.remove("dragging");

--- a/src/components/LanesSidebar.tsx
+++ b/src/components/LanesSidebar.tsx
@@ -105,13 +105,19 @@ export default class LanesSidebar extends React.Component<
                   : "droppable"
               }
             >
-              {lanes.map((lane) => (
-                <Draggable draggableId={String(lane.id)} key={lane.id}>
-                  {(provided, snapshot) =>
-                    this.renderLane(lane, parent, provided, snapshot)
-                  }
-                </Draggable>
-              ))}
+              {lanes.map((lane, index) => {
+                return (
+                  <Draggable
+                    draggableId={String(lane.id)}
+                    key={lane.id}
+                    index={index}
+                  >
+                    {(provided, snapshot) =>
+                      this.renderLane(lane, parent, provided, snapshot)
+                    }
+                  </Draggable>
+                );
+              })}
               {provided.placeholder}
             </ul>
           )}

--- a/src/components/__tests__/CustomListBookCard-test.tsx
+++ b/src/components/__tests__/CustomListBookCard-test.tsx
@@ -5,7 +5,7 @@ import * as Enzyme from "enzyme";
 import CustomListBookCard from "../CustomListBookCard";
 import { DragDropContext, Draggable } from "react-beautiful-dnd";
 import * as PropTypes from "prop-types";
-import { BookData } from "opds-web-client/lib/interfaces";
+import { CollectionData, BookData } from "opds-web-client/lib/interfaces";
 import { Button } from "library-simplified-reusable-components";
 import CustomListEntries from "../CustomListEntries";
 import CustomListSearchResults from "../CustomListSearchResults";
@@ -17,7 +17,7 @@ export interface Entry extends BookData {
 describe("CustomListBookCard", () => {
   let wrapper;
 
-  const listData = {
+  const listData: CollectionData = {
     id: "1",
     url: "some url",
     title: "original list title",
@@ -40,7 +40,7 @@ describe("CustomListBookCard", () => {
     navigationLinks: [],
   };
 
-  const searchResultsData = {
+  const searchResultsData: CollectionData = {
     id: "id",
     url: "url",
     title: "title - search",

--- a/src/components/__tests__/CustomListEntries-test.tsx
+++ b/src/components/__tests__/CustomListEntries-test.tsx
@@ -49,9 +49,9 @@ describe("CustomListEntries", () => {
 
   const deleteAll = stub();
   const loadMoreEntries = stub();
-  const setDraggingFrom = stub();
   const deleteEntry = stub();
   const setLoadedMoreEntries = stub();
+  const onDragEnd = stub();
 
   const childContextTypes = {
     pathFor: PropTypes.func.isRequired,
@@ -73,11 +73,10 @@ describe("CustomListEntries", () => {
 
   beforeEach(() => {
     wrapper = Enzyme.mount(
-      <DragDropContext>
+      <DragDropContext onDragEnd={onDragEnd}>
         <CustomListEntries
           addedListEntries={[]}
           deletedListEntries={[]}
-          draggingFrom={null}
           entries={listData.books}
           entryCount="2"
           isFetchingMoreCustomListEntries={false}
@@ -86,7 +85,6 @@ describe("CustomListEntries", () => {
           deleteAll={deleteAll}
           deleteEntry={deleteEntry}
           loadMoreEntries={loadMoreEntries}
-          setDraggingFrom={setDraggingFrom}
           setLoadedMoreEntries={setLoadedMoreEntries}
         />
       </DragDropContext>,
@@ -154,7 +152,6 @@ describe("CustomListEntries", () => {
         <CustomListEntries
           addedListEntries={[]}
           deletedListEntries={[]}
-          draggingFrom={null}
           entries={listData.books}
           entryCount="2"
           // set isFetchingMoreCustomListEntries to true
@@ -164,7 +161,6 @@ describe("CustomListEntries", () => {
           deleteAll={deleteAll}
           deleteEntry={deleteEntry}
           loadMoreEntries={loadMoreEntries}
-          setDraggingFrom={setDraggingFrom}
           setLoadedMoreEntries={setLoadedMoreEntries}
         />
       ),
@@ -181,7 +177,6 @@ describe("CustomListEntries", () => {
         <CustomListEntries
           addedListEntries={[]}
           deletedListEntries={[]}
-          draggingFrom={null}
           entries={[]}
           entryCount="0"
           isFetchingMoreCustomListEntries={false}
@@ -190,7 +185,6 @@ describe("CustomListEntries", () => {
           deleteAll={deleteAll}
           deleteEntry={deleteEntry}
           loadMoreEntries={loadMoreEntries}
-          setDraggingFrom={setDraggingFrom}
           setLoadedMoreEntries={setLoadedMoreEntries}
         />
       ),
@@ -212,7 +206,6 @@ describe("CustomListEntries", () => {
         <CustomListEntries
           addedListEntries={[]}
           deletedListEntries={[]}
-          draggingFrom={null}
           entries={[]}
           entryCount="0"
           isFetchingMoreCustomListEntries={false}
@@ -220,7 +213,6 @@ describe("CustomListEntries", () => {
           deleteAll={deleteAll}
           deleteEntry={deleteEntry}
           loadMoreEntries={loadMoreEntries}
-          setDraggingFrom={setDraggingFrom}
           setLoadedMoreEntries={setLoadedMoreEntries}
         />
       ),
@@ -235,7 +227,6 @@ describe("CustomListEntries", () => {
         <CustomListEntries
           addedListEntries={[]}
           deletedListEntries={[]}
-          draggingFrom={null}
           entries={listData.books}
           entryCount="2"
           isFetchingMoreCustomListEntries={false}
@@ -243,7 +234,6 @@ describe("CustomListEntries", () => {
           deleteAll={deleteAll}
           deleteEntry={deleteEntry}
           loadMoreEntries={loadMoreEntries}
-          setDraggingFrom={setDraggingFrom}
           setLoadedMoreEntries={setLoadedMoreEntries}
         />
       ),

--- a/src/components/__tests__/CustomListSearchResults-test.tsx
+++ b/src/components/__tests__/CustomListSearchResults-test.tsx
@@ -85,8 +85,8 @@ describe("CustomListSearchResults", () => {
 
   const addAll = stub();
   const loadMoreSearchResults = stub();
-  const setDraggingFrom = stub();
   const addEntry = stub();
+  const onDragEnd = stub();
 
   const childContextTypes = {
     pathFor: PropTypes.func.isRequired,
@@ -107,9 +107,8 @@ describe("CustomListSearchResults", () => {
   };
   beforeEach(() => {
     wrapper = Enzyme.mount(
-      <DragDropContext>
+      <DragDropContext onDragEnd={onDragEnd}>
         <CustomListSearchResults
-          draggingFrom={null}
           entries={entriesData}
           isFetchingMoreSearchResults={false}
           opdsFeedUrl="opdsFeedUrl"
@@ -117,7 +116,6 @@ describe("CustomListSearchResults", () => {
           addAll={addAll}
           addEntry={addEntry}
           loadMoreSearchResults={loadMoreSearchResults}
-          setDraggingFrom={setDraggingFrom}
         />
       </DragDropContext>,
       { context: fullContext, childContextTypes }
@@ -225,7 +223,6 @@ describe("CustomListSearchResults", () => {
     wrapper.setProps({
       children: (
         <CustomListSearchResults
-          draggingFrom={null}
           entries={entriesData}
           isFetchingMoreSearchResults={false}
           opdsFeedUrl="opdsFeedUrl"
@@ -233,7 +230,6 @@ describe("CustomListSearchResults", () => {
           addAll={addAll}
           addEntry={addEntry}
           loadMoreSearchResults={loadMoreSearchResults}
-          setDraggingFrom={setDraggingFrom}
         />
       ),
     });
@@ -266,7 +262,6 @@ describe("CustomListSearchResults", () => {
     wrapper.setProps({
       children: (
         <CustomListSearchResults
-          draggingFrom={null}
           entries={entriesData}
           isFetchingMoreSearchResults={false}
           opdsFeedUrl="opdsFeedUrl"
@@ -274,7 +269,6 @@ describe("CustomListSearchResults", () => {
           addAll={addAll}
           addEntry={addEntry}
           loadMoreSearchResults={loadMoreSearchResults}
-          setDraggingFrom={setDraggingFrom}
         />
       ),
     });
@@ -298,14 +292,12 @@ describe("CustomListSearchResults", () => {
     wrapper.setProps({
       children: (
         <CustomListSearchResults
-          draggingFrom={null}
           entries={entriesData}
           isFetchingMoreSearchResults={false}
           opdsFeedUrl="opdsFeedUrl"
           addAll={addAll}
           addEntry={addEntry}
           loadMoreSearchResults={loadMoreSearchResults}
-          setDraggingFrom={setDraggingFrom}
         />
       ),
     });
@@ -321,7 +313,6 @@ describe("CustomListSearchResults", () => {
     wrapper.setProps({
       children: (
         <CustomListSearchResults
-          draggingFrom={null}
           entries={entriesData}
           isFetchingMoreSearchResults={false}
           opdsFeedUrl="opdsFeedUrl"
@@ -330,7 +321,6 @@ describe("CustomListSearchResults", () => {
           addAll={addAll}
           addEntry={addEntry}
           loadMoreSearchResults={loadMoreSearchResults}
-          setDraggingFrom={setDraggingFrom}
         />
       ),
     });
@@ -342,7 +332,6 @@ describe("CustomListSearchResults", () => {
     wrapper.setProps({
       children: (
         <CustomListSearchResults
-          draggingFrom={null}
           entries={entriesData}
           isFetchingMoreSearchResults={false}
           opdsFeedUrl="opdsFeedUrl"
@@ -351,7 +340,6 @@ describe("CustomListSearchResults", () => {
           addAll={addAll}
           addEntry={addEntry}
           loadMoreSearchResults={loadMoreSearchResults}
-          setDraggingFrom={setDraggingFrom}
         />
       ),
     });
@@ -364,7 +352,6 @@ describe("CustomListSearchResults", () => {
     wrapper.setProps({
       children: (
         <CustomListSearchResults
-          draggingFrom={null}
           entries={entriesData}
           // set isFetchingMoreSearchResults to true
           isFetchingMoreSearchResults={true}
@@ -373,7 +360,6 @@ describe("CustomListSearchResults", () => {
           addAll={addAll}
           addEntry={addEntry}
           loadMoreSearchResults={loadMoreSearchResults}
-          setDraggingFrom={setDraggingFrom}
         />
       ),
     });
@@ -389,7 +375,6 @@ describe("CustomListSearchResults", () => {
     wrapper.setProps({
       children: (
         <CustomListSearchResults
-          draggingFrom={null}
           entries={entriesData}
           isFetchingMoreSearchResults={false}
           opdsFeedUrl="opdsFeedUrl"
@@ -398,7 +383,6 @@ describe("CustomListSearchResults", () => {
           addAll={addAll}
           addEntry={addEntry}
           loadMoreSearchResults={loadMoreSearchResults}
-          setDraggingFrom={setDraggingFrom}
         />
       ),
     });

--- a/src/components/__tests__/CustomLists-test.tsx
+++ b/src/components/__tests__/CustomLists-test.tsx
@@ -39,7 +39,7 @@ describe("CustomLists", () => {
     },
   ];
 
-  const entry = { pwid: "1", title: "title", authors: [] };
+  const entry = { id: "1", title: "title", authors: [] };
 
   const searchResults = {
     id: "id",
@@ -420,7 +420,6 @@ describe("CustomLists", () => {
     it("renders edit form", () => {
       let editor = wrapper.find(CustomListEditor);
       expect(editor.length).to.equal(0);
-
       const listDetails = Object.assign({}, listsData[1], { books: [entry] });
       wrapper.setProps({
         children: (
@@ -434,6 +433,7 @@ describe("CustomLists", () => {
           />
         ),
       });
+
       editor = wrapper.find(CustomListEditor);
       expect(editor.length).to.equal(1);
       expect(editor.props().list).to.deep.equal(listDetails);

--- a/src/components/__tests__/LanesSidebar-test.tsx
+++ b/src/components/__tests__/LanesSidebar-test.tsx
@@ -2,11 +2,9 @@ import { expect } from "chai";
 import { stub } from "sinon";
 import { LaneData } from "../../interfaces";
 import * as React from "react";
-import { shallow, mount } from "enzyme";
-import { DragDropContext, Droppable, Draggable } from "react-beautiful-dnd";
+import { mount } from "enzyme";
 
 import LanesSidebar from "../LanesSidebar";
-import Lane from "../Lane";
 import { Link } from "react-router";
 
 describe("LanesSidebar", () => {
@@ -39,6 +37,7 @@ describe("LanesSidebar", () => {
   const getTopLevelLanes = () => {
     return wrapper.find("ul.droppable").at(0).children();
   };
+
   // Returns all the children lanes (including grandchildren) from the given parent lane.
   const allChildren = (lane) => {
     return lane.find("li .lane-parent");
@@ -245,13 +244,17 @@ describe("LanesSidebar", () => {
     };
 
     let topLevelLanes = getTopLevelLanes();
-    expect(topLevelLanes.length).to.equal(2);
+    // Two are actually top level lanes, the third is a component from react-beautiful-dnd.
+    expect(topLevelLanes.length).to.equal(3);
     let topLane1 = topLevelLanes.at(0).find("div").at(0);
     const topLane2 = topLevelLanes.at(1).find("div").at(0);
+    const topLane3 = topLevelLanes.at(2);
+
     expect(topLane1.text()).to.contain("Top Lane 1");
     expect(topLane1.text()).to.contain("(5)");
     expect(topLane2.text()).to.contain("Top Lane 2");
     expect(topLane2.text()).to.contain("(1)");
+    expect(topLane3.props().shouldAnimate).to.equal(true);
 
     // both top-level lanes are expanded to start.
     expectExpanded(topLane1);

--- a/src/stylesheets/lane_editor.scss
+++ b/src/stylesheets/lane_editor.scss
@@ -42,8 +42,6 @@
       margin: 15px 0px;
     }
 
-
-
     h4 {
       color: lighten($pagetextcolor, 40%);
       svg {
@@ -79,7 +77,8 @@
     flex-grow: 1;
   }
 
-  .available-lists, .current-lists {
+  .available-lists,
+  .current-lists {
     display: flex;
     flex-direction: column;
     flex-basis: 44%;
@@ -100,14 +99,14 @@
       border: 1px solid $medium-gray;
       padding: 10px;
       flex: 1;
-      overflow-y: scroll;
       margin-bottom: 15px;
 
       &.dragging-over {
         border-color: $pagetextcolor;
       }
 
-      .available-list, .current-list {
+      .available-list,
+      .current-list {
         display: flex;
         flex-direction: row;
         justify-content: space-between;
@@ -117,7 +116,8 @@
         cursor: grab;
         cursor: -webkit-grab;
 
-        &:hover, &.dragging {
+        &:hover,
+        &.dragging {
           border: 1px solid $pagetextcolor;
           background-color: $pagecolorlight;
         }
@@ -136,17 +136,18 @@
         }
 
         button {
-          font-size: .8em;
+          font-size: 0.8em;
 
           svg {
             margin: 0 0 0 5px;
             float: unset;
             vertical-align: unset;
-            height: .8em;
+            height: 0.8em;
           }
         }
 
-        .list-name, .list-id {
+        .list-name,
+        .list-id {
           font-weight: bold;
         }
 


### PR DESCRIPTION
## Description

- Updated the react-beautiful-dnd library from v2.3.1 to v11.0.2, and made necessary changes to the code and tests.
- The drag and drop functionality is used in the List Manager and Lane Manager.

## Motivation and Context

- The react-beautiful-dnd library was very outdated, and subsequent versions included performance and UX improvements.
- The drag and drop functionality is a part of the List Manager, which is the tool I am working on improving overall with the refactor.

## How Has This Been Tested?

- I have tested this update manually, on local host.
- I have updated unit tests, and all unit tests are passing.
- I **did not update** the skipped tests in `CustomListBuilder-test`. This is because enzyme is not well-suited to test user interactions (ie, dragging and dropping), nor stateful functional components with hooks. My next piece of work will be to bring in React Testing Library for these tests.

## Checklist:

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
